### PR TITLE
added names to resource annotations in core and admin that did not have them

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -62,7 +62,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
     
     public static String PRODUCT_OPTION_FIELD_PREFIX = "productOption";
     
-    @Resource
+    @Resource(name="blCatalogService")
     protected CatalogService catalogService;
     
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/SandBoxServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/SandBoxServiceImpl.java
@@ -47,10 +47,10 @@ public class SandBoxServiceImpl implements SandBoxService {
     @Resource(name="blSandboxItemListeners")
     protected List<SandBoxItemListener> sandboxItemListeners = new ArrayList<SandBoxItemListener>();
 
-    @Resource
+    @Resource(name="blSandBoxDao")
     protected SandBoxDao sandBoxDao;
 
-    @Resource
+    @Resource(name="blSandBoxItemDao")
     protected SandBoxItemDao sandBoxItemDao;
 
     @Resource(name="blAdminSecurityService")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/dao/RatingSummaryDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/dao/RatingSummaryDaoImpl.java
@@ -39,7 +39,7 @@ public class RatingSummaryDaoImpl extends BatchRetrieveDao implements RatingSumm
     @PersistenceContext(unitName = "blPU")
     protected EntityManager em;
 
-    @Resource
+    @Resource(name="blEntityConfiguration")
     protected EntityConfiguration entityConfiguration;
 
 	public void deleteRatingSummary(final RatingSummary summary) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/dao/ReviewDetailDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/dao/ReviewDetailDaoImpl.java
@@ -35,7 +35,7 @@ public class ReviewDetailDaoImpl implements ReviewDetailDao {
     @PersistenceContext(unitName = "blPU")
     protected EntityManager em;
 
-    @Resource
+    @Resource(name="blEntityConfiguration")
     protected EntityConfiguration entityConfiguration;
 
     public ReviewDetail readReviewDetailById(Long reviewId) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
@@ -43,10 +43,10 @@ import org.springframework.stereotype.Service;
 @Service("blRatingService")
 public class RatingServiceImpl implements RatingService {
 
-    @Resource
+    @Resource(name="blRatingSummaryDao")
     private RatingSummaryDao ratingSummaryDao;
 
-    @Resource
+    @Resource(name="blReviewDetailDao")
     private ReviewDetailDao reviewDetailDao;
 
     public void deleteRatingSummary(RatingSummary ratingSummary) {


### PR DESCRIPTION
@Resource annotations without the proper bean name can cause a runtime issue when you extend BLC
