### PR TITLE
Fix error in MediaImpl#equals when altText and title do not match

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/media/domain/MediaImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/media/domain/MediaImpl.java
@@ -156,9 +156,9 @@ public class MediaImpl implements Media {
 		} else if (!title.equals(other.title))
 			return false;
 		if (altText == null) {
-			if (other.title != null)
+			if (other.altText != null)
 				return false;
-		} else if (!title.equals(other.title))
+		} else if (!altText.equals(other.altText))
 			return false;
         if (tags == null) {
             if (other.tags != null)


### PR DESCRIPTION
`other.title` was used in place of `other.altText` in a couple places which breaks the `MediaImpl#equals` method.
