### PR TITLE
updated entity configuration to load entity configurations in the proper order

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityConfiguration.java
@@ -16,6 +16,12 @@
 
 package org.broadleafcommerce.common.persistence;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
@@ -24,11 +30,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericXmlApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
 
 @Component("blEntityConfiguration")
 public class EntityConfiguration implements ApplicationContextAware {
@@ -50,7 +51,7 @@ public class EntityConfiguration implements ApplicationContextAware {
 
     @PostConstruct
     public void configureMergedItems() {
-        Set<Resource> temp = new HashSet<Resource>();
+        Set<Resource> temp = new LinkedHashSet<Resource>();
         if (mergedEntityContexts != null && !mergedEntityContexts.isEmpty()) {
             for (String location : mergedEntityContexts) {
                 temp.add(webApplicationContext.getResource(location));


### PR DESCRIPTION
With the HashSet, the entity configurations may not load in the proper order and override files may not work.
