### PR TITLE
fixed null pointer exception in view resolver when BroadleafRequestContext is null

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThymeleafViewResolver.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThymeleafViewResolver.java
@@ -152,14 +152,20 @@ public class BroadleafThymeleafViewResolver extends ThymeleafViewResolver {
     }
     
     protected boolean isIFrameRequest() {
-        HttpServletRequest request = BroadleafRequestContext.getBroadleafRequestContext().getRequest();
-    	String iFrameParameter = request.getParameter("blcIFrame");
-    	return  (iFrameParameter != null && "true".equals(iFrameParameter));
+    	if (BroadleafRequestContext.getBroadleafRequestContext() != null && BroadleafRequestContext.getBroadleafRequestContext().getRequest() != null) {
+	        HttpServletRequest request = BroadleafRequestContext.getBroadleafRequestContext().getRequest();
+	    	String iFrameParameter = request.getParameter("blcIFrame");
+	    	return  (iFrameParameter != null && "true".equals(iFrameParameter));
+    	}
+    	return false;
     }
     
     protected boolean isAjaxRequest() {
-        HttpServletRequest request = BroadleafRequestContext.getBroadleafRequestContext().getRequest();
-        return BroadleafControllerUtility.isAjaxRequest(request);
+    	if (BroadleafRequestContext.getBroadleafRequestContext() != null && BroadleafRequestContext.getBroadleafRequestContext().getRequest() != null) {
+    		HttpServletRequest request = BroadleafRequestContext.getBroadleafRequestContext().getRequest();
+    		return BroadleafControllerUtility.isAjaxRequest(request);
+    	}
+    	return false;
     }
 
     /**


### PR DESCRIPTION
In cases where the BroadleafRequestContext is null. It is better to assume isAjax() == false or isIframeRequet() == false than to throw a null pointer exception in the view resolver.
