### PR TITLE
Unit Tests For DateUtil

### DIFF
--- a/common/src/test/java/org/broadleafcommerce/common/DateUtil_ActiveDateRangeTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/DateUtil_ActiveDateRangeTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 
 import org.broadleafcommerce.common.util.DateUtil;
 
-public class DateUtilTest_ActiveDateRange extends TestCase {
+public class DateUtil_ActiveDateRangeTest extends TestCase {
     public void testDateRangeWithNullDates_ExpectInactive(){
         Date startDate = null;
         Date endDate = null;

--- a/common/src/test/java/org/broadleafcommerce/common/DateUtil_ActiveDateTimeRangeTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/DateUtil_ActiveDateTimeRangeTest.java
@@ -9,7 +9,7 @@ import org.broadleafcommerce.common.util.DateUtil;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
-public class DateUtilTest_ActiveDateTimeRange extends TestCase {
+public class DateUtil_ActiveDateTimeRangeTest extends TestCase {
     public void testDateRangeWithCurrentTime_ExpectActive(){
         Date startDate = new Date();
         Date endDate = null;


### PR DESCRIPTION
Hi Guys,

Thanks for sharing your codes. I added some unit tests to the `org.broadleafcommerce.common.util.DateUtil` class, and notice that the `DateUtil.isActive()` method returns true even when `endDate.getTime() == now`. I would expect it to be otherwise (an offer should be inactive when the end datetime is now, right?) **UPDATE: I guess it really doesn't matter since the representation is to the milliseconds**

Feel free to merge the unit tests to the project if you think they will be helpful. I will send more pull requests if I come out with more useful unit tests.
