### PR TITLE
removed cascading when persisting CustomerRole

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
@@ -47,12 +47,12 @@ public class CustomerRoleImpl implements CustomerRole {
     @Column(name = "CUSTOMER_ROLE_ID")
     protected Long id;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = CustomerImpl.class, optional = false)
+    @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @Index(name="CUSTROLE_CUSTOMER_INDEX", columnNames={"CUSTOMER_ID"})
     protected Customer customer;
 
-    @ManyToOne(cascade = CascadeType.ALL, targetEntity = RoleImpl.class, optional = false)
+    @ManyToOne(targetEntity = RoleImpl.class, optional = false)
     @JoinColumn(name = "ROLE_ID")
     @Index(name="CUSTROLE_ROLE_INDEX", columnNames={"ROLE_ID"})
     protected Role role;


### PR DESCRIPTION
The case where cascading CustomerRole causes an issue is when you try to programmatically remove CustomerRoles. This causes the delete to attempt to also delete the Role associate with the CustomerRole. In most BLC implementations, this doesn't cause an issue because BLC doesn't programmatically manage CustomerRoles beyond adding the basic role. I decided to remove cascading completely, because neither Customer nor Role have a reason to be updated when a CustomerRole is added or deleted.
