### PR TITLE
Delete unnecessary m2e lifecycle-mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,47 +65,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <!-- Needed for Eclipse Indigo -->
-                    <!-- This plugin does not actually exist, but is instead read by Eclipse for configuration purposes -->
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.zeroturnaround</groupId>
-                                        <artifactId>jrebel-maven-plugin</artifactId>
-                                        <versionRange>
-                                            [1.0,)
-                                        </versionRange>
-                                        <goals>
-                                            <goal>generate</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-antrun-plugin</artifactId>
-                                        <versionRange>[1.3,)</versionRange>
-                                        <goals>
-                                            <goal>run</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.0.2</version>


### PR DESCRIPTION
Broadleaf parent/aggregator pom.xml defines m2e lifecycle-mapping which
is no longer necessary. For eclipse juno there is jrebel m2e connector
("JRebel m2eclipse"), and antrun plugin is not being used in any of the
current Broadleaf pom.xml files.

This patch deletes unnecessary m2e lifecycle-mapping from parent pom.

Issue: BLCDOCS-58
