### PR TITLE
Fix timezone JS parsing that worked only on Chrome

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/dates.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/dates.js
@@ -57,8 +57,8 @@
                 
                 // Next, we'll parse the timezone ourselves
                 var timezone = result.toString();
-                timezone = timezone.substring(timezone.indexOf('GMT') + 3);
-                timezone = timezone.substring(0, timezone.indexOf(' '));
+                var regexTimezone = /.*([\+\-][0-9]{4}).*/;
+                timezone = timezone.replace(regexTimezone, "$1");
                 
                 // Now, let's convert it to the server format
                 var serverDate = $.datepicker.formatDate(this.blcDateFormat, result);


### PR DESCRIPTION
- Sometimes you don't have GMT but UTC
- Sometimes you don't have spaces character after timezone code

ko Firefox 20 "Wed May 01 2013 13:24:00 GMT+0200" (space missing)
ko IE10 "Wed May 1 13:24:00 UTC+0200 2013" (UTC)
ok Chrome26 "Wed May 01 2013 13:24:00 GMT+0200 (Paris, Madrid (heure d’été))" (still works)

Because of that Categories & products could not be edited and saved in IE/FF browsers

Bug:
http://forum.broadleafcommerce.org/viewtopic.php?f=13&t=1830&start=0&sid=5d8edb0cbaaeb35958be809898e4b5d7
