### PR TITLE
FixedPriceFulfillmentPricingProvider fixes

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/fulfillment/provider/FixedPriceFulfillmentPricingProvider.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/fulfillment/provider/FixedPriceFulfillmentPricingProvider.java
@@ -62,7 +62,7 @@ public class FixedPriceFulfillmentPricingProvider implements FulfillmentPricingP
 
         for (FulfillmentOption option : options) {
             if (canCalculateCostForFulfillmentGroup(fulfillmentGroup, option)) {
-                Money price = ((FixedPriceFulfillmentOption)fulfillmentGroup.getFulfillmentOption()).getPrice();
+                Money price = ((FixedPriceFulfillmentOption)option).getPrice();
                 shippingPrices.put(option, price);
             }
         }


### PR DESCRIPTION
The FixedPriceFulfillmentPricingProvider was returning prematurely, and would only evaluate the price of the chosen fulfillment option, rather than all of the options provided in the set. This is corrected by pricing all of the options in the set, and not returning until all pricing is complete.
