### PR TITLE
Adding NPE check in Translation Service Impl

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -137,7 +137,7 @@ public class TranslationServiceImpl implements TranslationService {
         // If we don't find one, let's try just the language (en), again utilizing the cache
         if (translation == null) {
             String nonCountryCacheKey = getCacheKey(entityType, entityId, property, localeCode);
-            if (getCache().isKeyInCache(nonCountryCacheKey) && getCache().get(countryCacheKey) != null) {
+            if (getCache().isKeyInCache(nonCountryCacheKey) && getCache().get(nonCountryCacheKey) != null) {
                 translation = (Translation) getCache().get(nonCountryCacheKey).getObjectValue();
             } else {
                 translation = getTranslation(entityType, entityId, property, localeCode);


### PR DESCRIPTION
1. Needs to Add NPE check while adding objects to cache
2. When objects are pulled from cache, causes NPE some times because of null objects present in cache
