### PR TITLE
Add ability to contribute field metadata in the admin after cache lookup

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
@@ -572,9 +572,11 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
 
         metadata.setName(field.getName());
         metadata.setTargetClass(targetClass.getName());
-
         metadata.setFieldName(field.getName());
 
+        if (basicFieldMetadata.getFieldType() != null) {
+            metadata.setFieldType(basicFieldMetadata.getFieldType());
+        }
         if (basicFieldMetadata.getFriendlyName() != null) {
             metadata.setFriendlyName(basicFieldMetadata.getFriendlyName());
         }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/FieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/FieldMetadataProvider.java
@@ -20,6 +20,7 @@ import org.broadleafcommerce.openadmin.dto.FieldMetadata;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromFieldTypeRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromMappingDataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataRequest;
+import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.LateStageAddMetadataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaAnnotationRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaXmlRequest;
 import org.broadleafcommerce.openadmin.server.service.type.FieldProviderResponse;
@@ -52,6 +53,20 @@ public interface FieldMetadataProvider extends Ordered {
      * @return whether or not this implementation adjusted metadata
      */
     FieldProviderResponse addMetadata(AddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata);
+    
+    /**
+     * Contribute to metadata inspection for the {@link java.lang.reflect.Field} instance in the request. Implementations should
+     * add values to the metadata parameter.
+     * 
+     * This method differs from {@link #addMetadata(AddMetadataRequest, Map)} in that it will be invoked after the cacheable
+     * properties are assembled. It is therefore useful in scenarios where you may want to contribute properties to 
+     * metadata that are dynamic and should not be cached normally.
+     *
+     * @param lateStageAddMetadataRequest contains the requested field name and support classes.
+     * @param metadata implementations should add metadata for the requested field here
+     * @return whether or not this implementation adjusted metadata
+     */
+    FieldProviderResponse lateStageAddMetadata(LateStageAddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata);
 
     /**
      * Contribute to metadata inspection for the entity in the request. Implementations should override values

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/FieldMetadataProviderAdapter.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/FieldMetadataProviderAdapter.java
@@ -20,6 +20,7 @@ import org.broadleafcommerce.openadmin.dto.FieldMetadata;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromFieldTypeRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromMappingDataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataRequest;
+import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.LateStageAddMetadataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaAnnotationRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaXmlRequest;
 import org.broadleafcommerce.openadmin.server.service.type.FieldProviderResponse;
@@ -34,6 +35,11 @@ public class FieldMetadataProviderAdapter extends AbstractFieldMetadataProvider 
 
     @Override
     public FieldProviderResponse addMetadata(AddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata) {
+        return FieldProviderResponse.NOT_HANDLED;
+    }
+
+    @Override
+    public FieldProviderResponse lateStageAddMetadata(LateStageAddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata) {
         return FieldProviderResponse.NOT_HANDLED;
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/PasswordFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/PasswordFieldMetadataProvider.java
@@ -22,6 +22,7 @@ import org.broadleafcommerce.openadmin.dto.FieldMetadata;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromFieldTypeRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataFromMappingDataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.AddMetadataRequest;
+import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.LateStageAddMetadataRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaAnnotationRequest;
 import org.broadleafcommerce.openadmin.server.dao.provider.metadata.request.OverrideViaXmlRequest;
 import org.broadleafcommerce.openadmin.server.service.type.FieldProviderResponse;
@@ -70,6 +71,11 @@ public class PasswordFieldMetadataProvider extends AbstractFieldMetadataProvider
     
     @Override
     public FieldProviderResponse addMetadata(AddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata) {
+        return FieldProviderResponse.NOT_HANDLED;
+    }
+
+    @Override
+    public FieldProviderResponse lateStageAddMetadata(LateStageAddMetadataRequest addMetadataRequest, Map<String, FieldMetadata> metadata) {
         return FieldProviderResponse.NOT_HANDLED;
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/request/LateStageAddMetadataRequest.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/request/LateStageAddMetadataRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.broadleafcommerce.openadmin.server.dao.provider.metadata.request;
+
+import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
+
+/**
+ * Contains the requested field, metadata and support classes.
+ *
+ * @author Jeff Fischer
+ */
+public class LateStageAddMetadataRequest {
+
+    private final String fieldName;
+    private final Class<?> parentClass;
+    private final Class<?> targetClass;
+    private final DynamicEntityDao dynamicEntityDao;
+    private final String prefix;
+
+    public LateStageAddMetadataRequest(String fieldName, Class<?> parentClass, Class<?> targetClass, DynamicEntityDao dynamicEntityDao, String prefix) {
+        this.fieldName = fieldName;
+        this.parentClass = parentClass;
+        this.targetClass = targetClass;
+        this.dynamicEntityDao = dynamicEntityDao;
+        this.prefix = prefix;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Class<?> getParentClass() {
+        return parentClass;
+    }
+
+    public Class<?> getTargetClass() {
+        return targetClass;
+    }
+
+    public DynamicEntityDao getDynamicEntityDao() {
+        return dynamicEntityDao;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}


### PR DESCRIPTION
There exists a scenario where one might want to contribute additional metadata outside of the cacheable properties.

For example, if a field needs to be added in dynamically, it cannot be cached in the same manner as caching reflection-based lookups, as those will never change at runtime.
