### PR TITLE
Fix incorrect comparison causing verify fulfillment groups to fail unexp...

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/strategy/FulfillmentGroupItemStrategyImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/strategy/FulfillmentGroupItemStrategyImpl.java
@@ -343,7 +343,7 @@ public class FulfillmentGroupItemStrategyImpl implements FulfillmentGroupItemStr
         }
         
         for (Entry<Long, Integer> entry : oiQuantityMap.entrySet()) {
-            if (entry.getValue() != 0) {
+            if (!entry.getValue().equals(0)) {
                 throw new IllegalStateException("Not enough fulfillment group items found for DiscreteOrderItem id: " + entry.getKey());
             }
         }


### PR DESCRIPTION
...ectedly

Comparing object to int primitive causes 0 != 0 comparison to return true, causing the verify function to throw an exception for valid order item and fulfillment group item relations.
