### PR TITLE
Fix set sku on discrete order item so it doesn't through an exception in...

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -120,10 +120,10 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
     @Override
     public void setSku(Sku sku) {
         this.sku = sku;
-        if (sku.getRetailPrice() != null) {
+        if (sku.hasRetailPrice()) {
             this.baseRetailPrice = sku.getRetailPrice().getAmount();
         }
-        if (sku.getSalePrice() != null) {
+        if (sku.hasSalePrice()) {
             this.baseSalePrice = sku.getSalePrice().getAmount();
         }
         this.itemTaxable = sku.isTaxable();


### PR DESCRIPTION
... the case of a null retail price

In the event that you have dynamic pricing, but want to add an order item with an overridden retail price that isn't in the dynamic pricing context, the add fails because the retail retrieved is null when the order service tries to set the sku on the new item. 

I would expect some sort of exception to be thrown in the case that there was no retail price AND no price override, but in the case that there is a price override I would expect the price override to simply become the retail price.
