### PR TITLE
Fix calculate subtotal without adjustments to use promotable item pricin...

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderImpl.java
@@ -83,10 +83,10 @@ public class PromotableOrderImpl implements PromotableOrder {
         order.setSubTotal(calculatedSubTotal);
     }    
 
-    private Money calculateOrderSubTotalWithoutOrderAdjustments() {
+    protected Money calculateOrderSubTotalWithoutOrderAdjustments() {
         Money calculatedSubTotal = BroadleafCurrencyUtils.getMoney(order.getCurrency());
-        for (OrderItem orderItem : order.getOrderItems()) {
-            calculatedSubTotal = calculatedSubTotal.add(orderItem.getTotalPrice());
+        for (PromotableOrderItem orderItem : getAllOrderItems()) {
+            calculatedSubTotal = calculatedSubTotal.add(orderItem.calculateTotalWithoutAdjustments());
         }
         return calculatedSubTotal;
     }


### PR DESCRIPTION
...g, not the pricing on the order items

We need to use the promotable order item pricing because at this point in the workflow pricing has not been set on the order (so it is stale). Also, change scope of function from private to protected to allow overriding.
