### PR TITLE
Update setOrderSubtotalToPriceWithoutAdjustments to call calculateSubtot...

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderImpl.java
@@ -76,7 +76,7 @@ public class PromotableOrderImpl implements PromotableOrder {
 
     @Override
     public void setOrderSubTotalToPriceWithoutAdjustments() {
-        Money calculatedSubTotal = calculateOrderSubTotalWithoutOrderAdjustments();
+        Money calculatedSubTotal = calculateSubtotalWithoutAdjustments();
         order.setSubTotal(calculatedSubTotal);
     }
     
@@ -84,14 +84,6 @@ public class PromotableOrderImpl implements PromotableOrder {
     public void setOrderSubTotalToPriceWithAdjustments() {
         Money calculatedSubTotal = calculateSubtotalWithAdjustments();
         order.setSubTotal(calculatedSubTotal);
-    }    
-
-    private Money calculateOrderSubTotalWithoutOrderAdjustments() {
-        Money calculatedSubTotal = BroadleafCurrencyUtils.getMoney(order.getCurrency());
-        for (OrderItem orderItem : order.getOrderItems()) {
-            calculatedSubTotal = calculatedSubTotal.add(orderItem.getTotalPrice());
-        }
-        return calculatedSubTotal;
     }
 
     @Override


### PR DESCRIPTION
...alWithoutAdjustments

The old code was pulling pricing directly off the order items which is incorrect because at this point in the pricing workflow we haven't set pricing information. This means that getTotal() on order item will return stale pricing.
