### PR TITLE
Patch to support Hibernate's @Formula - prevent ClassCastExceptions in the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/DefaultFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/DefaultFieldMetadataProvider.java
@@ -141,10 +141,10 @@ public class DefaultFieldMetadataProvider extends BasicFieldMetadataProvider {
             Column column = null;
             for (Property property : addMetadataFromMappingDataRequest.getComponentProperties()) {
                 if (property.getName().equals(addMetadataFromMappingDataRequest.getPropertyName())) {
-                	Object columnObject = property.getColumnIterator().next();
-                	if (columnObject instanceof Column) {
+                    Object columnObject = property.getColumnIterator().next();
+                    if (columnObject instanceof Column) {
                         column = (Column) columnObject;
-                	}
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
The current implementation assumes all non-collection admin mappings use the JPA @Column annotation. I added an instance of check which allows the use of other Hibernate annotations such as @Formula for derived columns.
