### PR TITLE
Fixed GoogleUniversalAnalyticsProcessor adding order items to javascript output

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleUniversalAnalyticsProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleUniversalAnalyticsProcessor.java
@@ -251,8 +251,8 @@ public class GoogleUniversalAnalyticsProcessor extends AbstractElementProcessor 
             sb.append(",'currency': '" + order.getCurrency().getCurrencyCode() + "'");
         }
         sb.append("});");
-        
-        getItemJs(order, trackerPrefix);
+
+        sb.append(getItemJs(order, trackerPrefix));
         
         sb.append("ga('" + trackerPrefix + "ecommerce:send');");
         return sb.toString();


### PR DESCRIPTION
Order items releated javascript isn't generated. This is because the output of method 

```
org.broadleafcommerce.core.web.processor.GoogleUniversalAnalyticsProcessor#getItemJs
```

isn't added to final StringBuffer.
