### PR TITLE
adding coordinate type for geolocation searches

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/solr/FieldType.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/solr/FieldType.java
@@ -58,6 +58,7 @@ public class FieldType implements Serializable, BroadleafEnumerationType {
     public static final FieldType TRIELONG = new FieldType("tl", "Trie Long");
     public static final FieldType TRIEDOUBLE = new FieldType("td", "Trie Double");
     public static final FieldType TRIEDATE = new FieldType("tdt", "Trie Date");
+    public static final FieldType COORDINATE = new FieldType("c", "Coordinate");
 
     public static FieldType getInstance(final String type) {
         return TYPES.get(type);


### PR DESCRIPTION
this will allow lat/long coordinates to be used for search and facet purposes. additional pull request will be sent to DemoSite to add LatLonType to schema.xml
