### PR TITLE
Remove reliance on default encoding

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/InstrumentationRuntimeFactory.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/InstrumentationRuntimeFactory.java
@@ -156,7 +156,7 @@ public class InstrumentationRuntimeFactory {
         ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(file));
         zout.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
 
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(zout));
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(zout, "UTF-8"));
 
         writer.println("Agent-Class: " + InstrumentationRuntimeFactory.class.getName());
         writer.println("Can-Redefine-Classes: true");

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/StandardConfigLocations.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/StandardConfigLocations.java
@@ -42,7 +42,7 @@ public class StandardConfigLocations {
         String[] response;
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(StandardConfigLocations.class.getResourceAsStream("StandardConfigLocations.txt")));
+            reader = new BufferedReader(new InputStreamReader(StandardConfigLocations.class.getResourceAsStream("StandardConfigLocations.txt"), "UTF-8"));
             ArrayList<String> items = new ArrayList<String>();
             boolean eof = false;
             while (!eof) {

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/ImportProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/ImportProcessor.java
@@ -107,7 +107,7 @@ public class ImportProcessor {
 
                     DOMSource source = new DOMSource(doc);
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(baos));
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(baos, "UTF-8"));
                     StreamResult result = new StreamResult(writer);
                     xmlTransformer.transform(source, result);
 

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeManager.java
@@ -351,7 +351,7 @@ public class MergeManager {
         StringBuilder item = new StringBuilder();
         boolean eof = false;
         try {
-            reader = new InputStreamReader(in);
+            reader = new InputStreamReader(in, "UTF-8");
             while (!eof) {
                 temp = reader.read();
                 if (temp == -1) {

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeXmlConfigResource.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeXmlConfigResource.java
@@ -130,7 +130,7 @@ public class MergeXmlConfigResource {
         StringBuilder item = new StringBuilder();
         boolean eof = false;
         try {
-            reader = new InputStreamReader(in);
+            reader = new InputStreamReader(in, "UTF-8");
             while (!eof) {
                 temp = reader.read();
                 if (temp == -1) {

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingServiceImpl.java
@@ -142,9 +142,9 @@ public class ResourceBundlingServiceImpl implements ResourceBundlingService {
                 // If we're creating a JavaScript bundle, we'll put a semicolon between each
                 // file to ensure it won't fail to compile.
                 if (versionedBundleName.endsWith(".js")) {
-                    baos.write(";".getBytes());
+                    baos.write(";".getBytes("UTF-8"));
                 }
-                baos.write(System.getProperty("line.separator").getBytes());
+                baos.write(System.getProperty("line.separator").getBytes("UTF-8"));
             }
             bytes = baos.toByteArray();
         } catch (IOException e) {

--- a/common/src/main/java/org/broadleafcommerce/common/sitemap/service/SiteMapBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sitemap/service/SiteMapBuilder.java
@@ -20,6 +20,7 @@
 
 package org.broadleafcommerce.common.sitemap.service;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.file.domain.FileWorkArea;
@@ -33,8 +34,10 @@ import org.broadleafcommerce.common.util.FormatUtil;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Date;
@@ -87,7 +90,7 @@ public class SiteMapBuilder {
      * @param fileName
      */
     protected void persistXMLDocument(String fileName, Object xmlObject) {
-
+        Writer writer = null;
         try {
             JAXBContext context = JAXBContext.newInstance(xmlObject.getClass());
             Marshaller m = context.createMarshaller();
@@ -102,16 +105,17 @@ public class SiteMapBuilder {
             if (!file.exists()) {
                 file.createNewFile();
             }
-            Writer writer = new BufferedWriter(new FileWriter(file.getAbsoluteFile()));
+            writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
             writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             m.marshal(xmlObject, writer);
-            writer.close();
         } catch (IOException ioe) {
             LOG.error("IOException occurred persisting XML Document", ioe);
             throw new RuntimeException("Error persisting XML document when trying to build Sitemap", ioe);
         } catch (JAXBException je) {
             LOG.error("JAXBException occurred persisting XML Document", je);
             throw new RuntimeException("Error persisting XML document when trying to build Sitemap", je);
+        } finally {
+            IOUtils.closeQuietly(writer);
         }
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/util/PomEvaluator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/PomEvaluator.java
@@ -20,8 +20,10 @@
 package org.broadleafcommerce.common.util;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -196,7 +198,7 @@ public class PomEvaluator {
                 fileName = args[0];
             }
 
-            br = new BufferedReader(new FileReader(fileName));
+            br = new BufferedReader(new InputStreamReader(new FileInputStream(fileName), "UTF-8"));
 
             forwardToTag("<dependencies>", br);
 

--- a/common/src/main/java/org/broadleafcommerce/common/util/StringUtil.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/StringUtil.java
@@ -34,7 +34,7 @@ public class StringUtil {
 
     public static long getChecksum(String test) {
         try {
-            byte buffer[] = test.getBytes();
+            byte buffer[] = test.getBytes("UTF-8");
             ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
             CheckedInputStream cis = new CheckedInputStream(bais, new Adler32());
             byte readBuffer[] = new byte[buffer.length];

--- a/common/src/main/java/org/broadleafcommerce/common/util/sql/HibernateToolTask.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/sql/HibernateToolTask.java
@@ -33,9 +33,13 @@ import org.hibernate.tool.ant.ConfigurationTask;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -204,8 +208,8 @@ public class HibernateToolTask extends Task {
             BufferedWriter writer = null;
             BufferedReader reader = null;
             try{
-                writer = new BufferedWriter(new FileWriter(startFile, true));
-                reader = new BufferedReader(new FileReader(nextFile));
+                writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(startFile, true), "UTF-8"));
+                reader = new BufferedReader(new InputStreamReader(new FileInputStream(nextFile), "UTF-8"));
                 boolean eof = false;
                 String temp = null;
                 while (!eof) {

--- a/common/src/main/java/org/broadleafcommerce/common/vendor/service/AbstractVendorService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/vendor/service/AbstractVendorService.java
@@ -44,7 +44,7 @@ public abstract class AbstractVendorService {
 
         OutputStreamWriter osw = null;
         try {
-            osw = new OutputStreamWriter(connection.getOutputStream());
+            osw = new OutputStreamWriter(connection.getOutputStream(), "UTF-8");
             boolean isFirst = true;
             for (String key : content.keySet()) {
                 if (!isFirst) {

--- a/common/src/test/java/org/broadleafcommerce/common/file/service/BroadleafFileServiceImplTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/file/service/BroadleafFileServiceImplTest.java
@@ -19,10 +19,14 @@
  */
 package org.broadleafcommerce.common.file.service;
 
+import org.apache.commons.io.IOUtils;
 import org.broadleafcommerce.common.file.domain.FileWorkArea;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,9 +78,13 @@ public class BroadleafFileServiceImplTest extends TestCase {
     public void testCreateAddFile() throws Exception {        
         FileWorkArea workArea1 = bfs.initializeWorkArea();
         File f1 = new File(workArea1.getFilePathLocation() + "test.txt");
-        FileWriter fw = new FileWriter(f1);
-        fw.append("Test File");
-        fw.close();
+        Writer fw = null;
+        try {
+            fw = new OutputStreamWriter(new FileOutputStream(f1), "UTF-8");
+            fw.append("Test File");
+        } finally {
+            IOUtils.closeQuietly(fw);
+        }
         
         bfs.addOrUpdateResource(workArea1, f1, false);
         
@@ -95,14 +103,23 @@ public class BroadleafFileServiceImplTest extends TestCase {
     public void testCreateAddFiles() throws Exception {
         FileWorkArea workArea1 = bfs.initializeWorkArea();
         File f1 = new File(workArea1.getFilePathLocation() + "test2.txt");
-        FileWriter fw = new FileWriter(f1);
-        fw.append("Test File 2");
-        fw.close();
+        Writer fw = null;
+        try {
+            fw = new OutputStreamWriter(new FileOutputStream(f1), "UTF-8");
+            fw.append("Test File 2");
+        } finally {
+            IOUtils.closeQuietly(fw);
+        }
 
         File f2 = new File(workArea1.getFilePathLocation() + "test3.txt");
-        FileWriter fw2 = new FileWriter(f2);
-        fw2.append("Test File 3");
-        fw2.close();
+        fw = null;
+        try {
+            fw = new OutputStreamWriter(new FileOutputStream(f2), "UTF-8");
+            fw.append("Test File 3");
+        } finally {
+            IOUtils.closeQuietly(fw);
+        }
+
 
         List<File> files = new ArrayList<File>();
         files.add(f1);
@@ -127,14 +144,22 @@ public class BroadleafFileServiceImplTest extends TestCase {
     public void testCreateFilesCopyWorkarea() throws Exception {
         FileWorkArea workArea1 = bfs.initializeWorkArea();
         File f1 = new File(workArea1.getFilePathLocation() + "test4.txt");
-        FileWriter fw = new FileWriter(f1);
-        fw.append("Test File 4");
-        fw.close();
+        Writer fw = null;
+        try {
+            fw = new OutputStreamWriter(new FileOutputStream(f1), "UTF-8");
+            fw.append("Test File 4");
+        } finally {
+            IOUtils.closeQuietly(fw);
+        }
 
         File f2 = new File(workArea1.getFilePathLocation() + "test5.txt");
-        FileWriter fw2 = new FileWriter(f2);
-        fw2.append("Test File 5");
-        fw2.close();
+        fw = null;
+        try {
+            fw = new OutputStreamWriter(new FileOutputStream(f2), "UTF-8");
+            fw.append("Test File 5");
+        } finally {
+            IOUtils.closeQuietly(fw);
+        }
 
         bfs.addOrUpdateResources(workArea1, false);
         bfs.closeWorkArea(workArea1);

--- a/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
@@ -139,7 +139,7 @@ public class SiteMapGeneratorTest {
 
     protected String convertFileToString(File file) throws IOException {
         FileInputStream fin = new FileInputStream(file);
-        BufferedReader br = new BufferedReader(new InputStreamReader(fin));
+        BufferedReader br = new BufferedReader(new InputStreamReader(fin, "UTF-8"));
         StringBuilder sb = new StringBuilder();
         String line;
         while ((line = br.readLine()) != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -70,10 +70,13 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -151,7 +154,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
             LOG.trace("Contents of solr.xml:");
             BufferedReader br = null;
             try {
-                br = new BufferedReader(new FileReader(solrXml));
+                br = new BufferedReader(new InputStreamReader(new FileInputStream(solrXml), "UTF-8"));
                 String line;
                 while ((line = br.readLine()) != null) {
                     LOG.trace(line);


### PR DESCRIPTION
These are not all cases because there are a few String.getBytes() that I didn't want to mess with because .getBytes(String charsetName) throws an Exception.

In some cases I also made sure the streams were closed properly.