### PR TITLE
Prevent NPE from Java 8 lambdas in ClassTransformers

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/convert/EntityMarkerClassTransformer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/convert/EntityMarkerClassTransformer.java
@@ -67,6 +67,11 @@ public class EntityMarkerClassTransformer extends AbstractClassTransformer imple
 
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        // Synthetic classes, e.g. from lambda resolution, may have no name
+        if (className == null) {
+            return null;
+        }
+
         String convertedClassName = className.replace('/', '.');
         
         if (isIgnored(convertedClassName)) {


### PR DESCRIPTION
Synthetic classes, e.g. from lambda resolution, may have no name. This causes EntityMarkerClassTransformer to throw NPE. I think it's reasonable to assume that classes with no name also don't have any JPA annotations, so EntityMarkerClassTransformer can bail out when className == null.
