### PR TITLE
Add support for DefaultValues in AdminPresentation Annotation.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -84,6 +84,7 @@ public class BasicFieldMetadata extends FieldMetadata {
     protected String ruleIdentifier;
     protected LookupType lookupType;
     protected Boolean translatable;
+    protected String defaultValue;
 
     //for MapFields
     protected String mapFieldValueClass;
@@ -523,6 +524,14 @@ public class BasicFieldMetadata extends FieldMetadata {
         this.translatable = translatable;
     }
 
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
     @Override
     public FieldMetadata cloneFieldMetadata() {
         BasicFieldMetadata metadata = new BasicFieldMetadata();
@@ -600,6 +609,7 @@ public class BasicFieldMetadata extends FieldMetadata {
         metadata.lookupType = lookupType;
         metadata.translatable = translatable;
         metadata.isDerived = isDerived;
+        metadata.defaultValue = defaultValue;
 
         metadata = (BasicFieldMetadata) populate(metadata);
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
@@ -122,6 +122,7 @@ public class FieldMetadataOverride {
     private String ruleIdentifier;
     private Boolean translatable;
     private LookupType lookupType;
+    private String defaultValue;
 
     //@AdminPresentationMapField derived fields
     private Boolean searchable;
@@ -324,6 +325,14 @@ public class FieldMetadataOverride {
     
     public void setTranslatable(Boolean translatable) {
         this.translatable = translatable;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 
     public String getTab() {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
@@ -513,6 +513,7 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
             override.setCurrencyCodeField(annot.currencyCodeField());
             override.setRuleIdentifier(annot.ruleIdentifier());
             override.setTranslatable(annot.translatable());
+            override.setDefaultValue(annot.defaultValue());
 
             if (annot.validationConfigurations().length != 0) {
                 processValidationAnnotations(annot.validationConfigurations(), override);
@@ -752,6 +753,9 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
         }
         if (basicFieldMetadata.getIsDerived() != null) {
             metadata.setDerived(basicFieldMetadata.getIsDerived());
+        }
+        if (basicFieldMetadata.getDefaultValue() != null) {
+            metadata.setDefaultValue(basicFieldMetadata.getDefaultValue());
         }
 
         attributes.put(field.getName(), metadata);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderService.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderService.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.openadmin.web.service;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.openadmin.dto.AdornedTargetCollectionMetadata;
 import org.broadleafcommerce.openadmin.dto.AdornedTargetList;
+import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
 import org.broadleafcommerce.openadmin.dto.ClassMetadata;
 import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
 import org.broadleafcommerce.openadmin.dto.Entity;
@@ -71,6 +72,18 @@ public interface FormBuilderService {
      */
     public ListGrid buildCollectionListGrid(String containingEntityId, DynamicResultSet drs, Property field, String sectionKey, List<SectionCrumb> sectionCrumbs)
             throws ServiceException;
+
+    /**
+     * Extracts the DefaultValue from the FieldMetaData and parses it based on the
+     * {@link org.broadleafcommerce.common.presentation.client.SupportedFieldType} that the field uses.
+     *
+     * Logs a warning in the event of failure to parse the value and returns null.
+     *
+     * @param fieldType
+     * @param fmd
+     * @return The value to be used on the form field.
+     */
+    public String extractDefaultValueFromFieldData(String fieldType, BasicFieldMetadata fmd);
 
     /**
      * Loops through all of the fields that are specified in given class metadata and removes fields that

--- a/admin/broadleaf-open-admin-platform/src/main/resources/org/broadleafcommerce/schema/mo/mo-3.0.xsd
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/org/broadleafcommerce/schema/mo/mo-3.0.xsd
@@ -166,6 +166,7 @@
             <xsd:enumeration value="showIfProperty"/>
             <xsd:enumeration value="forceFreeFormKeys"/>
             <xsd:enumeration value="translatable"/>
+            <xsd:enumeration value="defaultValue"/>
         </xsd:restriction>
     </xsd:simpleType>
 </xsd:schema>

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
@@ -307,4 +307,17 @@ public @interface AdminPresentation {
      * @return whether or not this field is translatable
      */
     boolean translatable() default false;
+
+    /**
+     * <p>Optional - only required if you want to display a default value to the user when adding a new entity</p>
+     *
+     * <p>The default value to present to a user for this field when adding a new entity.</p>
+     *
+     * <p>Default values on <code>Boolean</code> require {@code "true"} or {@code "false"}.</p>
+     * <p>Default values on <code>Date</code> support the string {@code "today"} and strings with the
+     * format of {@code "2020.12.11 11:11:11"}.</p>
+     *
+     * @return the defaultValue set for the field.
+     */
+    String defaultValue() default "";
 }

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
@@ -50,6 +50,7 @@ public class PropertyType {
         public static final String RULEIDENTIFIER = "ruleIdentifier";
         public static final String READONLY = "readOnly";
         public static final String VALIDATIONCONFIGURATIONS = "validationConfigurations";
+        public static final String DEFAULTVALUE = "defaultValue";
     }
 
     public static class AdminPresentationToOneLookup {


### PR DESCRIPTION
Added support for allowing default values in the AdminPresentation Annotation. Reference issue is #1193.

When building the form while adding a new entity the we extract the default values and parse them to verify that they are valid based on the `SupportedFieldType`. If the parsing fails we log a WARN and do not use the value.

Also added support for using `today` as a default value on dates which will set the current **now** date.