### PR TITLE
Fix MergeManager overrides

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeManager.java
@@ -276,8 +276,7 @@ public class MergeManager {
 
     private void setHandlers(Properties props) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
         ArrayList<MergeHandler> handlers = new ArrayList<MergeHandler>();
-        String[] keys = props.keySet().toArray(new String[props.keySet().size()]);
-        for (String key : keys) {
+        for (String key : props.stringPropertyNames()) {
             if (key.startsWith("handler.")) {
                 MergeHandler temp = (MergeHandler) Class.forName(props.getProperty(key)).newInstance();
                 String name = key.substring(8, key.length());


### PR DESCRIPTION
Properties.keySet() doesn't take default properties into account, so if an override is used then the contents of default.properties is effectively ignored. I suppose the Javadoc could justify the current behavior, but based on the behavior of MergeManager.loadProperties() it looks like the override properties are supposed to overlay default.properties and not replace it entirely.