### PR TITLE
Changed AND to OR while checking for OrderStatus value if Payment can be applied to Order

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/DefaultPaymentGatewayCheckoutService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/DefaultPaymentGatewayCheckoutService.java
@@ -115,7 +115,7 @@ public class DefaultPaymentGatewayCheckoutService implements PaymentGatewayCheck
         Long orderId = Long.parseLong(responseDTO.getOrderId());
         Order order = orderService.findOrderById(orderId);
         
-        if (!OrderStatus.IN_PROCESS.equals(order.getStatus()) && !OrderStatus.CSR_OWNED.equals(order.getStatus())) {
+        if (!OrderStatus.IN_PROCESS.equals(order.getStatus()) || !OrderStatus.CSR_OWNED.equals(order.getStatus())) {
             throw new IllegalArgumentException("Cannot apply another payment to an Order that is not IN_PROCESS or CSR_OWNED");
         }
         


### PR DESCRIPTION
Another Payment can be applied to an Order only if the Order Status should not be IN_PROCESS or CSR_OWNED. Hence, changing the AND condition to OR. 