### PR TITLE
Removed OnPropertyChanged due to Issue 1197

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/entityListWithUploadForm.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/entityListWithUploadForm.html
@@ -4,7 +4,7 @@
     id="assetUploadForm">
     
     <span style="display: block; margin-bottom: 5px; margin-left: 60px;"><i class="icon-camera"></i> Upload Asset</span>
-    <input id="assetUploadFile" type="file" name="file" onpropertychange="$('#assetUploadForm').submit()" value="Upload Asset"/>
+    <input id="assetUploadFile" type="file" name="file" value="Upload Asset"/>
 </blc:form>
     
 <div th:include="views/entityList" th:remove="tag" />


### PR DESCRIPTION
 I changed the **entityListWithUploadForm.html** by removing the **onpropertychanged** attribute. This is because as the pre-existing code was failing for IE 8. 

With this change, I tested on IE 8,9, 10, Chrome (latest - 39.0.x), Firefox, Safari. This change worked for the limited test scenarios for the browsers as mentioned.

Refer:- [Issue 1197] (https://github.com/BroadleafCommerce/BroadleafCommerce/issues/1197)