### PR TITLE
Allow removes in the respond to validation errors

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
@@ -762,14 +762,10 @@ public class AdminEntityServiceImpl implements AdminEntityService {
 
     public PersistenceResponse remove(PersistencePackageRequest request, boolean transactional) throws ServiceException {
         PersistencePackage pkg = persistencePackageFactory.create(request);
-        try {
-            if (transactional) {
-                return service.remove(pkg);
-            } else {
-                return service.nonTransactionalRemove(pkg);
-            }
-        } catch (ValidationException e) {
-            return new PersistenceResponse().withEntity(e.getEntity());
+        if (transactional) {
+            return service.remove(pkg);
+        } else {
+            return service.nonTransactionalRemove(pkg);
         }
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/ValidationException.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/ValidationException.java
@@ -37,6 +37,11 @@ public class ValidationException extends ServiceException {
     
     protected Entity entity;
 
+    public ValidationException(Entity entity) {
+        super();
+        setEntity(entity);
+    }
+    
     public ValidationException(Entity entity, String message) {
         super(message);
         setEntity(entity);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -150,8 +150,10 @@ public class AdminBasicEntityController extends AdminAbstractController {
         
         extensionManager.getProxy().addAdditionalMainActions(sectionClassName, mainActions);
         
-        // If this came from a delete save, we'll have a request parameter
-        model.addAttribute("headerFlash", requestParams.get("headerFlash").get(0));
+        // If this came from a delete save, we'll have a headerFlash request parameter to take care of
+        if (requestParams.containsKey("headerFlash")) {
+            model.addAttribute("headerFlash", requestParams.get("headerFlash").get(0));
+        }
         
         model.addAttribute("entityFriendlyName", cmd.getPolymorphicEntities().getFriendlyName());
         model.addAttribute("currentUrl", request.getRequestURL().toString());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/processor/ErrorsProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/processor/ErrorsProcessor.java
@@ -21,6 +21,7 @@ package org.broadleafcommerce.openadmin.web.processor;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.openadmin.web.form.entity.DynamicEntityFormInfo;
 import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
 import org.broadleafcommerce.openadmin.web.form.entity.Field;
@@ -118,11 +119,17 @@ public class ErrorsProcessor extends AbstractAttrProcessor {
                 }
             }
             
+            String translatedGeneralTab = GENERAL_ERRORS_TAB_KEY;
+            BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
+            if (context != null && context.getMessageSource() != null) {
+                translatedGeneralTab = context.getMessageSource().getMessage(translatedGeneralTab, null, translatedGeneralTab, context.getJavaLocale());
+            }
+            
             for (ObjectError err : bindStatus.getErrors().getGlobalErrors()) {
                 Map<String, List<String>> tabErrors = result.get(GENERAL_ERRORS_TAB_KEY);
                 if (tabErrors == null) {
                     tabErrors = new HashMap<String, List<String>>();
-                    result.put(GENERAL_ERRORS_TAB_KEY, tabErrors);
+                    result.put(translatedGeneralTab, tabErrors);
                 }
                 addFieldError(GENERAL_ERROR_FIELD_KEY, err.getCode(), tabErrors);
             }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -153,6 +153,7 @@ header.password.change=Change Password
 header.profile.edit=Edit Profile
 save.successful=Successfully saved
 save.unsuccessful=There was a problem saving. See errors below
+delete.successful=Successfully deleted
 delete.unsuccessful=There was a problem deleting this record
 
 Translation_localeCode=Locale Code

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
@@ -153,6 +153,10 @@ div.errors {
     margin-bottom: 10px;
 }
 
+div.errors .tabError {
+    margin-bottom: 10px;
+}
+
 div.errors span {
     color: #c60f13;
     display: block;

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
@@ -41,11 +41,15 @@
         forbidden403 : '403 Forbidden',
         errorOccurred : 'An error occurred',
         loading : 'Loading',
-            
+        
         // Session timer messages
         sessionCountdown: 'Your session expires in <span>',
-        sessionCountdownEnd: '</span> seconds'
-            
+        sessionCountdownEnd: '</span> seconds',
+
+        problemSaving : 'There was a problem saving. See errors below',
+        problemDeleting : 'There was a problem deleting this record. See errors below',
+        globalErrors : 'Global Errors'
+
     };
             
 })(jQuery, BLCAdmin);

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/Site.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/Site.java
@@ -20,6 +20,7 @@
 package org.broadleafcommerce.common.site.domain;
 
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.site.service.type.SiteResolutionType;
 
 import java.io.Serializable;
@@ -28,7 +29,7 @@ import java.util.List;
 /**
  * Created by bpolster.
  */
-public interface Site extends Serializable {
+public interface Site extends Serializable, Status {
 
     /**
      * Unique/internal id for a site.
@@ -143,5 +144,6 @@ public interface Site extends Serializable {
      * @return whether or not this site is a TemplateSite
      * @deprecated Not used by Broadleaf - scheduled to remove on or after 3.3     
      */
+    @Deprecated
     public boolean isTemplateSite();
 }

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
@@ -69,7 +69,7 @@ import javax.persistence.Table;
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITEMARKER)
 })
-public class SiteImpl implements Site, Status, AdminMainEntity {
+public class SiteImpl implements Site, AdminMainEntity {
 
     private static final long serialVersionUID = 1L;
     private static final Log LOG = LogFactory.getLog(SiteImpl.class);


### PR DESCRIPTION
This reverts a change made as part of #1086 which seems to prevent CustomPersistentHandlers from persisting remove errors to the Controller via the flash header messages.  