### PR TITLE
Remove Address requirement from CustomerPayment

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
@@ -93,7 +93,7 @@ public class CustomerPaymentImpl implements CustomerPayment {
     @AdminPresentation(excluded = true)
     protected Customer customer;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = AddressImpl.class, optional = false)
+    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = AddressImpl.class, optional = true)
     @JoinColumn(name = "ADDRESS_ID")
     protected Address billingAddress;
 


### PR DESCRIPTION
Some Payment Gateways do not require an Address for the payment to go through, so Address should be `allow null` for CustomerPayment.