### PR TITLE
Allow graceful session timeouts in the admin so that data is not inadvertently lost

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -17,9 +17,11 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.web.controller.entity;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.web.JsonResponse;
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
 import org.broadleafcommerce.openadmin.dto.ClassMetadata;
 import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
@@ -57,10 +59,10 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Controller("blAdminBasicOperationsController")
 public class AdminBasicOperationsController extends AdminAbstractController {
-    
+
     @Resource(name = "blSearchFieldResolver")
     protected SearchFieldResolver searchFieldResolver;
-    
+
     /**
      * Shows the modal dialog that is used to select a "to-one" collection item. For example, this could be used to show
      * a list of categories for the ManyToOne field "defaultCategory" in Product.
@@ -76,9 +78,9 @@ public class AdminBasicOperationsController extends AdminAbstractController {
      */
     @RequestMapping(value = "/{owningClass:.*}/{collectionField:.*}/select", method = RequestMethod.GET)
     public String showSelectCollectionItem(HttpServletRequest request, HttpServletResponse response, Model model,
-            @PathVariable  Map<String, String> pathVars,
+            @PathVariable Map<String, String> pathVars,
             @PathVariable(value = "owningClass") String owningClass,
-            @PathVariable(value="collectionField") String collectionField,
+            @PathVariable(value = "collectionField") String collectionField,
             @RequestParam(required = false) String requestingEntityId,
             @RequestParam(defaultValue = "false") boolean dynamicField,
             @RequestParam MultiValueMap<String, String> requestParams) throws Exception {
@@ -90,7 +92,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         ppr.addCustomCriteria("owningClass=" + owningClass);
         ppr.addCustomCriteria("requestingField=" + collectionField);
         ClassMetadata mainMetadata = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
-        
+
         // Only get collection property metadata when there is a non-structured content field that I am looking for
         Property collectionProperty = null;
         FieldMetadata md = null;
@@ -99,7 +101,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
             md = collectionProperty.getMetadata();
             ppr = PersistencePackageRequest.fromMetadata(md, sectionCrumbs);
         }
-        
+
         ppr.addFilterAndSortCriteria(getCriteria(requestParams));
         ppr.setStartIndex(getStartIndex(requestParams));
         ppr.setMaxIndex(getMaxIndex(requestParams));
@@ -107,9 +109,9 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         ppr.addCustomCriteria("requestingEntityId=" + requestingEntityId);
         ppr.addCustomCriteria("owningClass=" + owningClass);
         ppr.addCustomCriteria("requestingField=" + collectionField);
-        
+
         modifyFetchPersistencePackageRequest(ppr, pathVars);
-        
+
         DynamicResultSet drs = service.getRecords(ppr).getDynamicResultSet();
         ListGrid listGrid = null;
         // If we're dealing with a lookup from a dynamic field, we need to build the list grid differently
@@ -125,7 +127,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         } else if (md instanceof BasicFieldMetadata) {
             listGrid = formService.buildCollectionListGrid(null, drs, collectionProperty, owningClass, sectionCrumbs);
         }
-        
+
         model.addAttribute("listGrid", listGrid);
         model.addAttribute("viewType", "modal/simpleSelectEntity");
 
@@ -137,11 +139,11 @@ public class AdminBasicOperationsController extends AdminAbstractController {
     }
 
     @RequestMapping(value = "/{owningClass:.*}/{collectionField:.*}/typeahead", method = RequestMethod.GET)
-    public @ResponseBody List<Map<String, String>> getTypeaheadResults(HttpServletRequest request, 
+    public @ResponseBody List<Map<String, String>> getTypeaheadResults(HttpServletRequest request,
             HttpServletResponse response, Model model,
             @PathVariable Map<String, String> pathVars,
             @PathVariable(value = "owningClass") String owningClass,
-            @PathVariable(value="collectionField") String collectionField,
+            @PathVariable(value = "collectionField") String collectionField,
             @RequestParam(required = false) String query,
             @RequestParam(required = false) String requestingEntityId,
             @RequestParam MultiValueMap<String, String> requestParams) throws Exception {
@@ -158,7 +160,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         ppr.removeFilterAndSortCriteria("query");
         ppr.removeFilterAndSortCriteria("requestingEntityId");
         ppr.addCustomCriteria("requestingEntityId=" + requestingEntityId);
-        
+
         // This list of datums will populate the typeahead suggestions.
         List<Map<String, String>> responses = new ArrayList<Map<String, String>>();
         if (md instanceof BasicFieldMetadata) {
@@ -185,6 +187,18 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         return responses;
     }
 
+    /*
+     * @return - Integer representing the number of minutes for session timeout
+     */
+    @RequestMapping(value = "/sessionTimerInactiveInterval", method = RequestMethod.GET)
+    public @ResponseBody String sessionTimerInactiveInterval(HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        long maxInterval = request.getSession().getMaxInactiveInterval() * 1000;
+        return (new JsonResponse(response)).with("maxInterval", maxInterval).with("resetTime", System.currentTimeMillis()).done();
+    }
+    
+    
+
     /**
      * Hook method to allow a user to modify the persistence package request for a fetch on a select lookup.
      * 
@@ -192,6 +206,6 @@ public class AdminBasicOperationsController extends AdminAbstractController {
      * @param pathVars
      */
     protected void modifyFetchPersistencePackageRequest(PersistencePackageRequest ppr, Map<String, String> pathVars) {
-        
+
     }
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -193,9 +193,9 @@ public class AdminBasicOperationsController extends AdminAbstractController {
     @RequestMapping(value = "/sessionTimerReset", method = RequestMethod.GET)
     public @ResponseBody String sessionTimerReset(HttpServletRequest request,
             HttpServletResponse response) throws Exception {
-        long maxInterval = request.getSession().getMaxInactiveInterval() * 1000;
+        long serverSessionTimeoutInterval = request.getSession().getMaxInactiveInterval() * 1000;
         return (new JsonResponse(response))
-                .with("maxInterval", maxInterval)
+                .with("serverSessionTimeoutInterval", serverSessionTimeoutInterval)
                 .done();
     }
     

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -190,15 +190,13 @@ public class AdminBasicOperationsController extends AdminAbstractController {
     /*
      * @return - Integer representing the number of minutes for session timeout
      */
-    @RequestMapping(value = "/sessionTimerInactiveInterval", method = RequestMethod.GET)
+    @RequestMapping(value = "/sessionTimerReset", method = RequestMethod.GET)
     public @ResponseBody String sessionTimerInactiveInterval(HttpServletRequest request,
             HttpServletResponse response) throws Exception {
         long maxInterval = request.getSession().getMaxInactiveInterval() * 1000;
         return (new JsonResponse(response)).with("maxInterval", maxInterval).with("resetTime", System.currentTimeMillis()).done();
     }
     
-    
-
     /**
      * Hook method to allow a user to modify the persistence package request for a fetch on a select lookup.
      * 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -188,13 +188,15 @@ public class AdminBasicOperationsController extends AdminAbstractController {
     }
 
     /*
-     * @return - Integer representing the number of minutes for session timeout
+     * @return - JSON String containing the number of milliseconds before a session times out
      */
     @RequestMapping(value = "/sessionTimerReset", method = RequestMethod.GET)
-    public @ResponseBody String sessionTimerInactiveInterval(HttpServletRequest request,
+    public @ResponseBody String sessionTimerReset(HttpServletRequest request,
             HttpServletResponse response) throws Exception {
         long maxInterval = request.getSession().getMaxInactiveInterval() * 1000;
-        return (new JsonResponse(response)).with("maxInterval", maxInterval).with("resetTime", System.currentTimeMillis()).done();
+        return (new JsonResponse(response))
+                .with("maxInterval", maxInterval)
+                .done();
     }
     
     /**

--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -147,6 +147,8 @@ Dashboard=Dashboard
 
 header.loading=Loading
 header.logout=Logout
+header.stay.logged.in=Stay Logged In
+header.session.expire=Session Expiring ... 
 header.password.change=Change Password
 header.profile.edit=Edit Profile
 save.successful=Successfully saved

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/components.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/components.css
@@ -17,6 +17,57 @@
  * limitations under the License.
  * #L%
  */
+ 
+#lightbox {
+    /** Default lightbox to hidden */
+    display: none;
+    z-index: 1030;
+}
+
+#lightbox #expire-message {
+    height: 300px;
+    text-align: center;
+    top: 50%;
+    width: 500px;
+    margin-left: -250px;
+    margin-top: -150px;
+}
+
+#lightbox #expire-message #expire-header {
+    text-align: left;
+    background: linear-gradient(to bottom, #525252 0%,#424242 100%);
+    border: 1px solid #464646;
+    
+}
+
+#lightbox #expire-message #expire-header #expire-header-message {
+    color: #F0F0F0;
+    margin-left: 10px;
+    font-weight: bold;
+}
+
+#lightbox #expire-message #expire-header span {
+    margin-left: 10px;
+}
+
+#lightbox #expire-message .expire-button {
+    background: linear-gradient(to bottom, #525252 0%,#424242 100%);
+    border: 1px solid #464646;
+    color: #F0F0F0;
+    margin-top: 25px;
+    
+}
+
+#lightbox #expire-message #expire-text {
+    color: #333;
+    font-size: 16px;
+}
+
+#lightbox #expire-message #expire-text span {
+    color: #8EAA2B;
+    font-weight: bold;
+}
+
 ul.entity-type-selection {
 	list-style-type: none;
 }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
@@ -45,7 +45,7 @@
         $.fn.broadleafListgrid          ? $doc.broadleafListgrid() : null;
     
         BLCAdmin.initializeFields();
-        BLCAdmin.sessionTimer.initTimer();
+        
 
     });
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
@@ -45,6 +45,8 @@
         $.fn.broadleafListgrid          ? $doc.broadleafListgrid() : null;
     
         BLCAdmin.initializeFields();
+        BLCAdmin.sessionTimer.initTimer();
+
     });
 
     // UNCOMMENT THE LINE YOU WANT BELOW IF YOU WANT IE8 SUPPORT AND ARE USING .block-grids

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
@@ -45,7 +45,6 @@
         $.fn.broadleafListgrid          ? $doc.broadleafListgrid() : null;
     
         BLCAdmin.initializeFields();
-        
 
     });
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -59,7 +59,8 @@
                  * the session will timeout.
                  */
                 defaultSessionTime = data.maxInterval - 60000;
-                $.cookie("sessionResetTime", data.resetTime - (data.resetTime % pingInterval) , { path : BLC.servletContext });
+                resetTime = (new Date()).getTime();
+                $.cookie("sessionResetTime", resetTime - (resetTime % pingInterval) , { path : BLC.servletContext });
                 BLCAdmin.sessionTimer.updateTimeLeft();
             });
         },

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -119,7 +119,7 @@
         updateTimer : function() {
             
             BLCAdmin.sessionTimer.updateTimeLeft();
-            console.log(BLCAdmin.sessionTimer.getTimeLeft());
+            
             /*
              * If the time left is less than the expire message time, then we know to display the expire message.
              */

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -1,0 +1,179 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * @author Nick Crum
+ */
+
+(function($, BLCAdmin) {
+
+    var sessionTimeLeft = 0;
+    var activityPingInterval = 30000;
+    var pingInterval = 1000;
+    var defaultSessionTime = 0;
+    var EXPIRE_MESSAGE_TIME = 60000;
+
+    BLCAdmin.sessionTimer = {
+
+        initTimer : function() {
+            this.resetTimer();
+
+        },
+
+        resetTimer : function() {
+            BLC.get({
+                url : BLC.servletContext + "/sessionTimerInactiveInterval"
+            }, function(data) {
+                sessionTimeLeft = data.maxInterval * 2 / 3;
+                defaultSessionTime = sessionTimeLeft;
+                $.cookie("sessionResetTime", data.resetTime);
+            });
+        },
+
+        getTimeLeft : function() {
+            return sessionTimeLeft;
+        },
+
+        getTimeLeftSeconds : function() {
+            return sessionTimeLeft / 1000;
+        },
+
+        isExpired : function() {
+            return sessionTimeLeft <= 0;
+        },
+
+        getDefaultSessionTime : function() {
+            return defaultSessionTime;
+        },
+
+        decrement : function(val) {
+            sessionTimeLeft -= val;
+        },
+
+        getActivityPingInterval : function() {
+            return activityPingInterval;
+        },
+
+        getPingInterval : function() {
+            return pingInterval;
+        },
+
+        getExpireMessageTime : function() {
+            return EXPIRE_MESSAGE_TIME;
+        },
+
+        timeSinceLastReset : function() {
+            return (new Date()).getTime() - $.cookie("sessionResetTime");
+        },
+
+        verifyAndUpdateTimeLeft : function() {
+            var exactTimeLeft = (this.getDefaultSessionTime() - this
+                    .timeSinceLastReset());
+            exactTimeLeft = exactTimeLeft - (exactTimeLeft % pingInterval);
+
+            if (exactTimeLeft > sessionTimeLeft) {
+                sessionTimeLeft = exactTimeLeft;
+                return true;
+            }
+            return false;
+        },
+
+        invalidateSession : function() {
+            BLC.get({
+                url : BLC.servletContext + "/adminLogout.htm"
+            }, function(data) {
+                window.location.replace(BLC.servletContext
+                        + "/login?sessionTimeout=true");
+            });
+        }
+
+    };
+})(jQuery, BLCAdmin);
+
+$(document).ready(function() {
+    
+    var activityCount = 0;
+    $(document).keypress(function(e) {
+        activityCount++;
+    });
+
+    var updateTimer = function() {
+
+        BLCAdmin.sessionTimer.decrement(BLCAdmin.sessionTimer
+                .getPingInterval());
+
+        if (BLCAdmin.sessionTimer.verifyAndUpdateTimeLeft()) {
+            $("#lightbox").fadeOut("slow");
+            return true;
+        }
+
+        if (BLCAdmin.sessionTimer.getTimeLeft() < BLCAdmin.sessionTimer
+                .getExpireMessageTime()) {
+
+            if (BLCAdmin.sessionTimer.isExpired()) {
+                $("#lightbox").fadeOut("slow");
+                BLCAdmin.sessionTimer.invalidateSession();
+                return false;
+            }
+
+            $("#expire-text")
+                    .html(
+                            BLCAdmin.messages.sessionCountdown
+                                    + BLCAdmin.sessionTimer
+                                            .getTimeLeftSeconds()
+                                    + BLCAdmin.messages.sessionCountdownEnd);
+
+            $("#lightbox").fadeIn("slow");
+            activityCount = 0;
+
+            return true;
+
+        } else if (BLCAdmin.sessionTimer.getTimeLeft()
+                % BLCAdmin.sessionTimer
+                        .getActivityPingInterval() == 0) {
+            if (activityCount > 0) {
+                BLCAdmin.sessionTimer.resetTimer();
+                activityCount = 0;
+                return true;
+            }
+
+        }
+
+        return true;
+    };
+
+    stayLoggedIn = function() {
+        $.doTimeout('update');
+        $("#lightbox").fadeOut("slow");
+        activityCount = 0;
+        BLCAdmin.sessionTimer.resetTimer();
+        $.doTimeout('update', BLCAdmin.sessionTimer
+                .getPingInterval(), updateTimer);
+    }
+
+    $("#stay-logged-in").click(function() {
+        stayLoggedIn();
+        return false;
+    });
+
+    BLCAdmin.sessionTimer.resetTimer();
+    $.doTimeout('update', BLCAdmin.sessionTimer
+            .getPingInterval(), updateTimer);
+
+});

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -24,8 +24,8 @@
 (function($, BLCAdmin) {
 
     var pingInterval = 1000;
-    var defaultSessionTime = 60000*15;
-    var sessionTimeLeft = defaultSessionTime;
+    var sessionTimeoutInterval = 60000*15;
+    var sessionTimeLeft = sessionTimeoutInterval;
     var EXPIRE_MESSAGE_TIME = 60000;
     
     var activityPingInterval = 30000;
@@ -49,7 +49,6 @@
              * The session time is temporarily set to a high value to prevent a request that takes an inordinate
              * amount of time from causing the session to expire prematurely.
              */
-            sessionTimeLeft = 60000*15;
             
             BLC.get({
                 url : BLC.servletContext + "/sessionTimerReset"
@@ -58,7 +57,7 @@
                  * We deduct one minute from the actual session timeout interval so we can control when
                  * the session will timeout.
                  */
-                defaultSessionTime = data.maxInterval - 60000;
+                sessionTimeoutInterval = data.serverSessionTimeoutInterval - 60000;
                 resetTime = (new Date()).getTime();
                 $.cookie("sessionResetTime", resetTime - (resetTime % pingInterval) , { path : BLC.servletContext });
                 BLCAdmin.sessionTimer.updateTimeLeft();
@@ -77,8 +76,8 @@
             return sessionTimeLeft <= 0;
         },
 
-        getDefaultSessionTime : function() {
-            return defaultSessionTime;
+        getSessionTimeoutInterval : function() {
+            return sessionTimeoutInterval;
         },
 
         getActivityPingInterval : function() {
@@ -98,7 +97,7 @@
         },
 
         updateTimeLeft : function() {
-            var exactTimeLeft = (BLCAdmin.sessionTimer.getDefaultSessionTime() - BLCAdmin.sessionTimer.timeSinceLastReset());
+            var exactTimeLeft = (BLCAdmin.sessionTimer.getSessionTimeoutInterval() - BLCAdmin.sessionTimer.timeSinceLastReset());
             exactTimeLeft = exactTimeLeft - (exactTimeLeft % pingInterval);
 
             sessionTimeLeft = exactTimeLeft;

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -24,7 +24,7 @@
 (function($, BLCAdmin) {
 
     var pingInterval = 1000;
-    var sessionTimeoutInterval = 60000*15;
+    var sessionTimeoutInterval = Number.MAX_VALUE; // the actual value for sessionTimeoutInterval get set by way of an ajax request
     var sessionTimeLeft = sessionTimeoutInterval;
     var EXPIRE_MESSAGE_TIME = 60000;
     
@@ -54,8 +54,8 @@
                 url : BLC.servletContext + "/sessionTimerReset"
             }, function(data) {
                 /*
-                 * We deduct one minute from the actual session timeout interval so we can control when
-                 * the session will timeout.
+                 * We deduct one minute from the actual session timeout interval to ensure that the server-side session
+                 * doesn't expire before the client session
                  */
                 sessionTimeoutInterval = data.serverSessionTimeoutInterval - 60000;
                 resetTime = (new Date()).getTime();

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/sessionTimer.js
@@ -23,10 +23,10 @@
 
 (function($, BLCAdmin) {
 
-    var sessionTimeLeft = 0;
+    var sessionTimeLeft = 999999;
     var activityPingInterval = 30000;
     var pingInterval = 1000;
-    var defaultSessionTime = 0;
+    var defaultSessionTime = 999999;
     var EXPIRE_MESSAGE_TIME = 60000;
 
     BLCAdmin.sessionTimer = {
@@ -37,16 +37,17 @@
         },
 
         resetTimer : function() {
+            sessionTimeLeft = 999999;
             BLC.get({
                 url : BLC.servletContext + "/sessionTimerInactiveInterval"
             }, function(data) {
-                sessionTimeLeft = data.maxInterval * 2 / 3;
+                sessionTimeLeft = data.maxInterval - 60000;
                 defaultSessionTime = sessionTimeLeft;
                 $.cookie("sessionResetTime", data.resetTime);
             });
         },
 
-        getTimeLeft : function() {
+        getTimeLeft : function() { 
             return sessionTimeLeft;
         },
 
@@ -108,6 +109,8 @@
 
 $(document).ready(function() {
     
+    
+    
     var activityCount = 0;
     $(document).keypress(function(e) {
         activityCount++;
@@ -117,7 +120,9 @@ $(document).ready(function() {
 
         BLCAdmin.sessionTimer.decrement(BLCAdmin.sessionTimer
                 .getPingInterval());
-
+        
+        
+        
         if (BLCAdmin.sessionTimer.verifyAndUpdateTimeLeft()) {
             $("#lightbox").fadeOut("slow");
             return true;
@@ -171,8 +176,8 @@ $(document).ready(function() {
         stayLoggedIn();
         return false;
     });
-
-    BLCAdmin.sessionTimer.resetTimer();
+    
+    BLCAdmin.sessionTimer.resetTimer()
     $.doTimeout('update', BLCAdmin.sessionTimer
             .getPingInterval(), updateTimer);
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
@@ -41,9 +41,15 @@
         forbidden403 : '403 Forbidden',
         errorOccurred : 'An error occurred',
         loading : 'Loading',
+        
+        // Session timer messages
+        sessionCountdown: 'Your session expires in <span>',
+        sessionCountdownEnd: '</span> seconds',
+
         problemSaving : 'There was a problem saving. See errors below',
         problemDeleting : 'There was a problem deleting this record. See errors below',
         globalErrors : 'Global Errors'
+
     };
             
 })(jQuery, BLCAdmin);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/footer.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/footer.html
@@ -76,11 +76,13 @@
                        admin/components/listGrid.js,
                        admin/components/listGrid-filter.js,
                        admin/components/listGrid-paginate.js,
-                       admin/components/typeahead.js" />
+                       admin/components/typeahead.js,
+                       admin/components/sessionTimer.js" />
                       
     <blc:bundle name="admin-init.js" 
                 mapping-prefix="/js/"
                 files="admin/blc-admin-init.js" />
+                          
 
     <div th:substituteby="layout/partials/postFooterContent" />
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/header.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/header.html
@@ -1,5 +1,11 @@
 <header class="top-bar">
+
+    
+	
     <div class="attached">
+    
+        
+        
         <div class="brand">
             <span><a th:href="@{/}"><img th:src="@{/img/admin/blc-logo-header.png}" width='155'/></a></span>
         </div>
@@ -21,5 +27,22 @@
                 <a class="small button radius dark" th:href="@{/adminLogout.htm}" th:text="#{header.logout}" />
             </li>
         </ul>
+        
+        <div id="lightbox">
+        
+            <div id="expire-message" class="modal in">
+                <div id="expire-header" class="brand">
+                <div id="expire-header-message" th:text="#{header.session.expire}"></div>
+                </div>
+                <div id="expire-content">
+                    <a id="stay-logged-in" class="expire-button button medium dark radius" href="#" th:text="#{header.stay.logged.in}"></a>
+                    <a class="expire-button button medium dark radius" th:href="@{/adminLogout.htm}" th:text="#{header.logout}"></a>
+                    <div id="expire-text">
+                
+                    </div>
+                </div>
+            </div>
+            <div  class="modal-backdrop"></div>
+        </div>
     </div>
 </header>


### PR DESCRIPTION
Originally captured and written in #356, reverted because of issues reported in BroadleafCommerce/QA#266 and BroadleafCommerce/QA#272.

One of the problems reported in BroadleafCommerce/QA#266 (`"TypeError: BLCAdmin.sessionTimer is undefined"`) has been resolved so we don't need to keep investigating that one. We should take a closer look at this and try to get this back in shortly after 4.0 GA.