### PR TITLE
Fix copy-paste issue for ProductOptionsWrapper (API)

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/api/wrapper/ProductOptionWrapper.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/api/wrapper/ProductOptionWrapper.java
@@ -74,7 +74,7 @@ public class ProductOptionWrapper extends BaseWrapper implements APIWrapper<Prod
         if (model.getProductOptionValidationStrategyType() != null) {
             this.productOptionValidationStrategyType = model.getProductOptionValidationStrategyType().getType();
         }
-        if (model.getProductOptionValidationStrategyType() != null) {
+        if (model.getProductOptionValidationType() != null) {
             this.productOptionValidationType = model.getProductOptionValidationType().getType();
         }
         this.validationString = model.getValidationString();


### PR DESCRIPTION
NPE happens if productOptionValidationStrategyType is not null, while productOptionValidationType is null.