### PR TITLE
Test to ensure that product options are correctly sorted by displayOrder

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -742,7 +742,7 @@ public class ProductImpl implements Product, Status, AdminMainEntity, Locatable,
             }
             
         });
-        return productOptions;
+        return sorted;
     }
 
     @Override

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
@@ -90,4 +90,45 @@ class ProductSpec extends Specification {
         output.get(2) == testPox3
         output.get(2).getProductOption() == testPo3
     }
+    
+    def "Test if Product Options are returned sorted by displayOrder when one has no displayOrder"(){
+        ArrayList<ProductOptionXref> testProductOptions = new ArrayList<ProductOptionXref>();
+        setup:
+        ProductOption testPo = new ProductOptionImpl();
+        ProductOption testPo2 = new ProductOptionImpl();
+        testPo2.setDisplayOrder(2);
+        ProductOption testPo3 = new ProductOptionImpl();
+        testPo3.setDisplayOrder(1);
+        ProductOptionXref testPox = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo
+            id = 1
+            it
+        }
+        ProductOptionXref testPox2 = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo2
+            id = 2
+            it
+        }
+        ProductOptionXref testPox3 = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo3
+            id = 3
+            it
+        }
+        testProductOptions = Arrays.asList(testPox,testPox2,testPox3);
+        product.setProductOptionXrefs(testProductOptions);
+        
+        when:
+        List<ProductOptionXref> output = product.getProductOptionXrefs();
+        
+        then:
+        output.get(0) == testPox
+        output.get(0).getProductOption() == testPo
+        output.get(1) == testPox3
+        output.get(1).getProductOption() == testPo3
+        output.get(2) == testPox2
+        output.get(2).getProductOption() == testPo2
+    }
 }

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
@@ -1,0 +1,49 @@
+package org.broadleafcommerce.core.spec.catalog.domain
+
+import org.broadleafcommerce.core.catalog.domain.Product
+import org.broadleafcommerce.core.catalog.domain.ProductImpl
+import org.broadleafcommerce.core.catalog.domain.ProductOption
+import org.broadleafcommerce.core.catalog.domain.ProductOptionImpl
+import org.broadleafcommerce.core.catalog.domain.ProductOptionXref
+import org.broadleafcommerce.core.catalog.domain.ProductOptionXrefImpl
+
+import spock.lang.Specification
+
+
+class ProductSpec extends Specification {
+    
+    Product product;
+    def setup() {
+        product = new ProductImpl();
+    }
+    
+    def "Test if Product Options are returned sorted by displayOrder"(){
+        ArrayList<ProductOptionXref> testProductOptions = new ArrayList<ProductOptionXref>();
+        setup:
+        ProductOption testPo = new ProductOptionImpl();
+        testPo.setDisplayOrder(2);
+        ProductOption testPo2 = new ProductOptionImpl();
+        testPo2.setDisplayOrder(0);
+        ProductOptionXref testPox = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo
+            id = 1
+            it
+        }
+        ProductOptionXref testPox2 = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo2
+            id = 2
+            it
+        }
+        testProductOptions = Arrays.asList(testPox,testPox2);
+        product.setProductOptionXrefs(testProductOptions);
+        
+        when:
+        List<ProductOptionXref> output = product.getProductOptionXrefs();
+        
+        then:
+        output.get(0).getProductOption() == testPo2
+        output.get(1).getProductOption() == testPo
+    }
+}

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/catalog/domain/ProductSpec.groovy
@@ -44,6 +44,50 @@ class ProductSpec extends Specification {
         
         then:
         output.get(0).getProductOption() == testPo2
+        output.get(0) == testPox2
         output.get(1).getProductOption() == testPo
+        output.get(1) == testPox
+    }
+    
+    def "Test if Product Options are returned sorted by displayOrder when already in order"(){
+        ArrayList<ProductOptionXref> testProductOptions = new ArrayList<ProductOptionXref>();
+        setup:
+        ProductOption testPo = new ProductOptionImpl();
+        testPo.setDisplayOrder(0);
+        ProductOption testPo2 = new ProductOptionImpl();
+        testPo2.setDisplayOrder(1);
+        ProductOption testPo3 = new ProductOptionImpl();
+        testPo3.setDisplayOrder(2);
+        ProductOptionXref testPox = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo
+            id = 1
+            it
+        }
+        ProductOptionXref testPox2 = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo2
+            id = 2
+            it
+        }
+        ProductOptionXref testPox3 = new ProductOptionXrefImpl().with{
+            product = product
+            productOption = testPo3
+            id = 3
+            it
+        }
+        testProductOptions = Arrays.asList(testPox,testPox2,testPox3);
+        product.setProductOptionXrefs(testProductOptions);
+        
+        when:
+        List<ProductOptionXref> output = product.getProductOptionXrefs();
+        
+        then:
+        output.get(0) == testPox
+        output.get(0).getProductOption() == testPo
+        output.get(1) == testPox2
+        output.get(1).getProductOption() == testPo2
+        output.get(2) == testPox3
+        output.get(2).getProductOption() == testPo3
     }
 }


### PR DESCRIPTION
This pertains to issue BroadleafCommerce/QA#419.
While testing the solution to this issue I found a small oversight where the method was returning productOptions list instead of the sorted list it had just created. 

Here are my steps:
1. Create ProductSpec.groovy to test product options being returned sorted by displayOrder
2. Test failed
3. Changed return value within getProductOptionXrefs() from 'productOptions' to 'sorted'
4. Test succeeded

@phillipuniverse - please take a look and let me know what you think