### PR TITLE
 SiteImpl.java - Site Identifier Type and Site Identifier Value fields are changed as required fields. In order to force site creation with a Site Identifier to avoid exception while preview on site

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
@@ -95,13 +95,13 @@ public class SiteImpl implements Site, AdminMainEntity {
     @Column (name = "SITE_IDENTIFIER_TYPE")
     @AdminPresentation(friendlyName = "SiteImpl_Site_Identifier_Type", order = 2000,
             gridOrder = 2, prominent = true,
-            broadleafEnumeration = "org.broadleafcommerce.common.site.service.type.SiteResolutionType",
+            broadleafEnumeration = "org.broadleafcommerce.common.site.service.type.SiteResolutionType", requiredOverride=RequiredOverride.REQUIRED,
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION)
     protected String siteIdentifierType;
 
     @Column (name = "SITE_IDENTIFIER_VALUE")
     @AdminPresentation(friendlyName = "SiteImpl_Site_Identifier_Value", order = 3000,
-            gridOrder = 3, prominent = true)
+            gridOrder = 3, prominent = true, requiredOverride=RequiredOverride.REQUIRED)
     @Index(name = "BLC_SITE_ID_VAL_INDEX", columnNames = { "SITE_IDENTIFIER_VALUE" })
     protected String siteIdentifierValue;
 


### PR DESCRIPTION
Fix for #341 - Site Identifier Type and Site Identifier Value fields are changed as required fields. In order to force site creation with a Site Identifier to avoid exception while preview on site