### PR TITLE
Refactor ValidateAndConfirmPaymentsActivity for easier extension

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOService.java
@@ -24,6 +24,7 @@ import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.payment.PaymentType;
 import org.broadleafcommerce.common.payment.dto.PaymentRequestDTO;
 import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.service.FulfillmentGroupService;
 import org.broadleafcommerce.core.payment.domain.PaymentTransaction;
 
 /**
@@ -56,5 +57,20 @@ public interface OrderToPaymentRequestDTOService {
      * the amount from <b>transactionAmount<b>
      */
     public PaymentRequestDTO translatePaymentTransaction(Money transactionAmount, PaymentTransaction paymentTransaction);
+    
+    public void populateTotals(Order order, PaymentRequestDTO requestDTO);
+    
+    public void populateCustomerInfo(Order order, PaymentRequestDTO requestDTO);
+    
+    /**
+     * Uses the first shippable fulfillment group to populate the {@link PaymentRequestDTO#shipTo()} object
+     * @param order the {@link Order} to get data from
+     * @param requestDTO the {@link PaymentRequestDTO} that should be populated
+     * @see {@link FulfillmentGroupService#getFirstShippableFulfillmentGroup(Order)}
+     */
+    public void populateShipTo(Order order, PaymentRequestDTO requestDTO);
+    
+    public void populateBillTo(Order order, PaymentRequestDTO requestDTO);
 
+    public void populateDefaultLineItemsAndSubtotal(Order order, PaymentRequestDTO requestDTO);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
@@ -92,7 +92,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
         return requestDTO;
     }
 
-    protected void populateTotals(Order order, PaymentRequestDTO requestDTO) {
+    public void populateTotals(Order order, PaymentRequestDTO requestDTO) {
         String total = ZERO_TOTAL;
         String shippingTotal = ZERO_TOTAL;
         String taxTotal = ZERO_TOTAL;
@@ -115,7 +115,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
                 .orderCurrencyCode(order.getCurrency().getCurrencyCode());
     }
 
-    protected void populateCustomerInfo(Order order, PaymentRequestDTO requestDTO) {
+    public void populateCustomerInfo(Order order, PaymentRequestDTO requestDTO) {
         Customer customer = order.getCustomer();
         String phoneNumber = null;
         if (customer.getCustomerPhones() != null && !customer.getCustomerPhones().isEmpty()) {
@@ -143,7 +143,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
      * @param requestDTO the {@link PaymentRequestDTO} that should be populated
      * @see {@link FulfillmentGroupService#getFirstShippableFulfillmentGroup(Order)}
      */
-    protected void populateShipTo(Order order, PaymentRequestDTO requestDTO) {
+    public void populateShipTo(Order order, PaymentRequestDTO requestDTO) {
         List<FulfillmentGroup> fgs = order.getFulfillmentGroups();
         if (fgs != null && fgs.size() > 0) {
             FulfillmentGroup defaultFg = fgService.getFirstShippableFulfillmentGroup(order);
@@ -187,7 +187,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
         }
     }
 
-    protected void populateBillTo(Order order, PaymentRequestDTO requestDTO) {
+    public void populateBillTo(Order order, PaymentRequestDTO requestDTO) {
         for (OrderPayment payment : order.getPayments()) {
             if (payment.isActive() && PaymentType.CREDIT_CARD.equals(payment.getType())) {
                 Address billAddress = payment.getBillingAddress();
@@ -254,7 +254,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
      * @param order
      * @param requestDTO
      */
-    protected void populateDefaultLineItemsAndSubtotal(Order order, PaymentRequestDTO requestDTO) {
+    public void populateDefaultLineItemsAndSubtotal(Order order, PaymentRequestDTO requestDTO) {
         String subtotal = ZERO_TOTAL;
         if (order.getSubTotal() != null) {
             subtotal = order.getSubTotal().toString();

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/checkout/service/workflow/ValidateAndConfirmPaymentActivitySpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/checkout/service/workflow/ValidateAndConfirmPaymentActivitySpec.groovy
@@ -174,7 +174,8 @@ class ValidateAndConfirmPaymentActivitySpec extends BaseCheckoutActivitySpec {
         mockRequestService.translatePaymentTransaction(*_) >> new PaymentRequestDTO()
         OrderPaymentService mockOrderPaymentService = Mock()
         mockOrderPaymentService.createTransaction() >> new PaymentTransactionImpl()
-        mockOrderPaymentService.save(_) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as OrderPayment) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as PaymentTransaction) >> {PaymentTransaction transaction -> transaction}
 
         activity = new ValidateAndConfirmPaymentActivity().with {
             paymentConfigurationServiceProvider = mockProvider
@@ -218,7 +219,8 @@ class ValidateAndConfirmPaymentActivitySpec extends BaseCheckoutActivitySpec {
         mockRequestService.translatePaymentTransaction(*_) >> new PaymentRequestDTO()
         OrderPaymentService mockOrderPaymentService = Mock()
         mockOrderPaymentService.createTransaction() >> new PaymentTransactionImpl()
-        mockOrderPaymentService.save(_) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as OrderPayment) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as PaymentTransaction) >> {PaymentTransaction transaction -> transaction}
 
         activity = new ValidateAndConfirmPaymentActivity().with {
             paymentConfigurationServiceProvider = mockProvider
@@ -268,7 +270,8 @@ class ValidateAndConfirmPaymentActivitySpec extends BaseCheckoutActivitySpec {
         mockRequestService.translatePaymentTransaction(*_) >> new PaymentRequestDTO()
         OrderPaymentService mockOrderPaymentService = Mock()
         mockOrderPaymentService.createTransaction() >> new PaymentTransactionImpl()
-        mockOrderPaymentService.save(_) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as OrderPayment) >> {OrderPayment payment -> payment}
+        mockOrderPaymentService.save(_ as PaymentTransaction) >> {PaymentTransaction transaction -> transaction}
 
         activity = new ValidateAndConfirmPaymentActivity().with {
             paymentConfigurationServiceProvider = mockProvider


### PR DESCRIPTION
This includes some code consolidation and making sure that subclasses have all of the information that they need in order to deal with failed transactions that get confirmed in this activity.

This also fixes a bug in this activity where a payment was not invalidated if the confirmation failed from the activity itself.