### PR TITLE
If someone wants to register a CurrencyConversionService there is a exception beeing thrown into CurrencyConversionContext

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/money/CurrencyConversionContext.java
+++ b/common/src/main/java/org/broadleafcommerce/common/money/CurrencyConversionContext.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 
 public class CurrencyConversionContext {
     
-    private static final ThreadLocal<CurrencyConversionService> currencyConversionService = ThreadLocalManager.createThreadLocal(CurrencyConversionService.class);
+    private static final ThreadLocal<CurrencyConversionService> currencyConversionService = ThreadLocalManager.createThreadLocal(CurrencyConversionService.class, false);
 
     private static final ThreadLocal<HashMap> currencyConversionContext = ThreadLocalManager.createThreadLocal(HashMap.class);
 


### PR DESCRIPTION
if someone wants to use this conversion service this would fail, because ``ThreadLocalManager.createThreadLocal(CurrencyConversionService.class)`` will fail because ``CurrencyConversionService`` is an interface and cannot be instatiated