### PR TITLE
#1386 - modified TranslatedEntity to include Site and modified SiteImpl to return a translated field

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
@@ -43,6 +43,7 @@ public class TranslatedEntity implements Serializable, BroadleafEnumerationType 
     public static final TranslatedEntity CATEGORY = new TranslatedEntity("org.broadleafcommerce.core.catalog.domain.Category", "Category");
     public static final TranslatedEntity PRODUCT_OPTION = new TranslatedEntity("org.broadleafcommerce.core.catalog.domain.ProductOption", "ProdOption");
     public static final TranslatedEntity PRODUCT_OPTION_VALUE = new TranslatedEntity("org.broadleafcommerce.core.catalog.domain.ProductOptionValue", "ProdOptionVal");
+    public static final TranslatedEntity SITE = new TranslatedEntity("org.broadleafcommerce.common.site.domain.Site", "Site");
     public static final TranslatedEntity STATIC_ASSET = new TranslatedEntity("org.broadleafcommerce.cms.file.domain.StaticAsset", "StaticAsset");
     public static final TranslatedEntity SEARCH_FACET = new TranslatedEntity("org.broadleafcommerce.core.search.domain.SearchFacet", "SearchFacet");
     public static final TranslatedEntity FULFILLMENT_OPTION = new TranslatedEntity("org.broadleafcommerce.core.order.domain.FulfillmentOption", "FulfillmentOption");

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
@@ -25,6 +25,7 @@ import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
 import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
@@ -89,7 +90,7 @@ public class SiteImpl implements Site, AdminMainEntity {
 
     @Column (name = "NAME")
     @AdminPresentation(friendlyName = "SiteImpl_Site_Name", order = 1000,
-            gridOrder = 1, prominent = true, requiredOverride = RequiredOverride.REQUIRED)
+            gridOrder = 1, prominent = true, requiredOverride = RequiredOverride.REQUIRED, translatable = true)
     protected String name;
 
     @Column (name = "SITE_IDENTIFIER_TYPE")
@@ -140,7 +141,7 @@ public class SiteImpl implements Site, AdminMainEntity {
 
     @Override
     public String getName() {
-        return name;
+        return DynamicTranslationProvider.getValue(this, "name", name);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1386 

SiteImpl was modified to allow the `name` field to be translatable, and so that `getName` uses the `DynamicTranslationProvider` to determine its return value.
TranslatedEntity was modified to include a static entity type SITE that references the Site object.

Catalog translation was not done since to do so would create a stack overflow due to an infinite call loop between `CatalogImpl` method `getValue` and `SiteImpl` method 'clone'. @elbertbautista also thought CatalogImpl does not necessarily need the translation as much as Site so this could be explored later.