### PR TITLE
#1389 - updated robots.txt controller to include setting the site instance

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafRobotsController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafRobotsController.java
@@ -27,6 +27,7 @@ import org.broadleafcommerce.common.page.dto.PageDTO;
 import org.broadleafcommerce.common.time.SystemTime;
 import org.broadleafcommerce.common.web.BaseUrlResolver;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.broadleafcommerce.common.web.resource.BroadleafContextUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,10 +54,13 @@ public class BroadleafRobotsController {
 
     @Resource(name = "blPageService")
     private PageService pageService;
+    
+    @Resource(name = "blBroadleafContextUtil")
+    protected BroadleafContextUtil blcContextUtil;
 
     public String getRobotsFile(HttpServletRequest request, HttpServletResponse response) {
-        BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
-
+    	blcContextUtil.establishThinRequestContext();
+    	
         response.setContentType("text/plain");
         response.setCharacterEncoding("UTF-8");
 


### PR DESCRIPTION
Used the `BroadleafContextUtil` method `establishThinRequestContext`  in the `getRobotsFile` function to ensure the robots.txt file uses a site-specific sitemap.

Here are the results of this change on DemoSitePrivate:

![example](http://cl.ly/image/3u36191b3f07/Image%202015-06-05%20at%202.16.37%20PM.png)

Fixes #1389