### PR TITLE
#1383 - updated BroadleafUpdateAccountController to create a new user/pass token

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafUpdateAccountController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafUpdateAccountController.java
@@ -30,6 +30,7 @@ import org.broadleafcommerce.profile.core.service.CustomerService;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.broadleafcommerce.profile.web.core.service.login.LoginService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -70,31 +71,35 @@ public class BroadleafUpdateAccountController extends BroadleafAbstractControlle
 
     public String processUpdateAccount(HttpServletRequest request, Model model, UpdateAccountForm form, BindingResult result, RedirectAttributes redirectAttributes) throws ServiceException {
         updateAccountValidator.validate(form, result);
+        
         if (result.hasErrors()) {
             return getUpdateAccountView();
         }
+        
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+    		throw new AuthenticationCredentialsNotFoundException("Authentication was null, not authenticated, or not logged in.");
+    	}
+        
         Customer customer = CustomerState.getCustomer();
         customer.setEmailAddress(form.getEmailAddress());
         customer.setFirstName(form.getFirstName());
         customer.setLastName(form.getLastName());
         
-
         if (useEmailForLogin) {
             customer.setUsername(form.getEmailAddress());
         }
         
         customer = customerService.saveCustomer(customer);
-        redirectAttributes.addFlashAttribute("successMessage", getAccountUpdatedMessage());
         
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        
-        if (useEmailForLogin && auth != null && auth.isAuthenticated()) {
+        if (useEmailForLogin) {
         	UserDetails principal = userDetailsService.loadUserByUsername(customer.getUsername());
             UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), auth.getAuthorities());
             
             SecurityContextHolder.getContext().setAuthentication(token);
         }
         
+        redirectAttributes.addFlashAttribute("successMessage", getAccountUpdatedMessage());
         return getAccountRedirectView();
     }
 


### PR DESCRIPTION
Fixes #1383 and BroadleafCommerce/QA#616

Changed the `processUpdateAccount` method to create a new `UsernamePasswordAuthenticationToken` for the new username and with the old authorities from the last authentication if `useEmailForLogin` is `true`.