### PR TITLE
Add compatibility with SolrCloud Replication

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrIndexServiceImpl.java
@@ -695,7 +695,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
                     String categorySortFieldName = shs.getCategorySortFieldName(shs.getCategoryId(categoryId));
                     String displayOrderKey = categoryId + "-" + shs.getProductId(product);
-                    BigDecimal displayOrder = cache.getDisplayOrdersByCategoryProduct().get(displayOrderKey);
+                    Long displayOrder = convertDisplayOrderToLong(cache, displayOrderKey);
 
                     if (document.getField(categorySortFieldName) == null) {
                         document.addField(categorySortFieldName, displayOrder);
@@ -739,7 +739,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
                     String categorySortFieldName = shs.getCategorySortFieldName(shs.getCategoryId(categoryId));
                     String displayOrderKey = categoryId + "-" + originalId;
-                    BigDecimal displayOrder = cache.getDisplayOrdersByCategoryProduct().get(displayOrderKey);
+                    Long displayOrder = convertDisplayOrderToLong(cache, displayOrderKey);
 
                     if (document.getField(categorySortFieldName) == null) {
                         document.addField(categorySortFieldName, displayOrder);
@@ -917,5 +917,18 @@ public class SolrIndexServiceImpl implements SolrIndexService {
                 LOG.trace(document);
             }
         }
+    }
+
+    /**
+     *  We multiply the BigDecimal by 1,000,000 to maintain any possible decimals in use the
+     *  displayOrder value.
+     *
+     * @param cache
+     * @param displayOrderKey
+     * @return
+     */
+    private Long convertDisplayOrderToLong(CatalogStructure cache, String displayOrderKey) {
+        BigDecimal displayOrder = cache.getDisplayOrdersByCategoryProduct().get(displayOrderKey);
+        return displayOrder.multiply(BigDecimal.valueOf(1000000)).longValue();
     }
 }


### PR DESCRIPTION
Solr indexing will now use a `Long` instead of `BigDecimal` for `CategoryProductXrefImpl.displayOrder`.

Details can be found here:
https://github.com/BroadleafCommerce/BroadleafCommerce/issues/1402

And here:
https://github.com/BroadleafCommerce/QA/issues/663