### PR TITLE
#1411 - `@AdminPresentation` the field name in 3.0.xsd needs to match…

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/org/broadleafcommerce/schema/mo/mo-3.0.xsd
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/org/broadleafcommerce/schema/mo/mo-3.0.xsd
@@ -126,7 +126,7 @@
             <xsd:enumeration value="columnWidth"/>
             <xsd:enumeration value="broadleafEnumeration"/>
             <xsd:enumeration value="readOnly"/>
-            <xsd:enumeration value="toolTip"/>
+            <xsd:enumeration value="tooltip"/>
             <xsd:enumeration value="helpText"/>
             <xsd:enumeration value="hint"/>
             <xsd:enumeration value="lookupDisplayProperty"/>


### PR DESCRIPTION
 The field name in 3.0.xsd needs to match the field name in `@AdminPresentation` in order for mo:override to work for tooltip.
. Merge is to address BroadleafCommerce/BroadleafCommerce#1411