### PR TITLE
Boolean system property should be represented as a radio button in the admin.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/SystemPropertyFormBuilderExtensionHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/SystemPropertyFormBuilderExtensionHandler.java
@@ -1,0 +1,42 @@
+package org.broadleafcommerce.openadmin.web.service;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.config.domain.SystemProperty;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+@Component
+public class SystemPropertyFormBuilderExtensionHandler extends AbstractFormBuilderExtensionHandler {
+    
+    protected static final Log LOG = LogFactory.getLog(SystemPropertyFormBuilderExtensionHandler.class);
+    
+    @Resource(name = "blFormBuilderExtensionManager")
+    protected FormBuilderExtensionManager extensionManager;
+    
+    @PostConstruct
+    public void init() {
+        if (isEnabled()) {
+            extensionManager.registerHandler(this);
+        }
+    }
+    
+    
+    @Override
+    public ExtensionResultStatusType modifyUnpopulatedEntityForm(EntityForm ef) {
+        try {
+            if (SystemProperty.class.isAssignableFrom(Class.forName(ef.getCeilingEntityClassname()))) {
+                ef.findField("value").setFieldType("system_property_value");
+            }
+            
+            return ExtensionResultStatusType.HANDLED;
+        } catch (ClassNotFoundException e) {
+            LOG.warn("No class found for the given entity form, not modifying grid");
+        }
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/SystemPropertyFormBuilderExtensionHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/SystemPropertyFormBuilderExtensionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
 
-@Component
+@Component("blSystemPropertyFormBuilderExtensionHandler")
 public class SystemPropertyFormBuilderExtensionHandler extends AbstractFormBuilderExtensionHandler {
     
     protected static final Log LOG = LogFactory.getLog(SystemPropertyFormBuilderExtensionHandler.class);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/system_property_value.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/system_property_value.html
@@ -1,0 +1,6 @@
+<div class="system-property-value-string" style="display:none">
+	<div th:substituteby="${'fields/string'}" />
+</div>
+<div class="system-property-value-boolean" style="display:none">
+	<div th:substituteby="${'fields/boolean'}"/>
+</div>

--- a/common/src/main/resources/common_style/js/BLC-system-property.js
+++ b/common/src/main/resources/common_style/js/BLC-system-property.js
@@ -24,3 +24,38 @@
     }
 
 })(jQuery, BLC);
+
+$(document).ready(function() {
+	
+	/**
+	 * This function is updating the value input field for system properties so that if the property is a boolean then
+	 * the user has radio buttons instead of just a normal text field.
+	 */
+	function updateValueInput(event) {
+		var $this = $(this).is('select') ? $(this) : $('select');
+		var $boolean = $('.system-property-value-boolean');
+		var $string = $('.system-property-value-string');
+		if ($string !== undefined && $boolean !== undefined) {
+			
+			var value = $this.val().toLowerCase();
+
+			if (value === "boolean_type") {
+				$string.hide();
+				$boolean.show();
+				$string.find('input').attr('disabled', 'disabled');
+				$boolean.find('input').removeAttr('disabled');
+			} else {
+				$boolean.hide()
+				$string.show();
+				$boolean.find('input').attr('disabled', 'disabled');
+				$string.find('input').removeAttr('disabled');
+			}
+		}
+	}
+	
+	updateValueInput();
+	
+	// Sets onchange listener so that the input is updated at the right time.
+	$('body').on('change', 'select', updateValueInput);
+	
+});

--- a/common/src/main/resources/common_style/js/BLC-system-property.js
+++ b/common/src/main/resources/common_style/js/BLC-system-property.js
@@ -37,7 +37,11 @@ $(document).ready(function() {
 		var $string = $('.system-property-value-string');
 		if ($string !== undefined && $boolean !== undefined) {
 			
-			var value = $this.val().toLowerCase();
+			var value = $this.val()
+			if (value === undefined) {
+				return;
+			}
+			value = value.toLowerCase();
 
 			if (value === "boolean_type") {
 				$string.hide();

--- a/common/src/main/resources/common_style/js/BLC-system-property.js
+++ b/common/src/main/resources/common_style/js/BLC-system-property.js
@@ -18,7 +18,7 @@
  * #L%
  */
 (function($, BLC) {
-    
+
     BLC.systemProperty = {
         urlFragmentSeparator : "BLC_PROP:url.fragment.separator"
     }
@@ -26,40 +26,41 @@
 })(jQuery, BLC);
 
 $(document).ready(function() {
-	
-	/**
-	 * This function is updating the value input field for system properties so that if the property is a boolean then
-	 * the user has radio buttons instead of just a normal text field.
-	 */
-	function updateValueInput(event) {
-		var $this = $(this).is('select') ? $(this) : $('select');
-		var $boolean = $('.system-property-value-boolean');
-		var $string = $('.system-property-value-string');
-		if ($string !== undefined && $boolean !== undefined) {
-			
-			var value = $this.val()
-			if (value === undefined) {
-				return;
-			}
-			value = value.toLowerCase();
 
-			if (value === "boolean_type") {
-				$string.hide();
-				$boolean.show();
-				$string.find('input').attr('disabled', 'disabled');
-				$boolean.find('input').removeAttr('disabled');
-			} else {
-				$boolean.hide()
-				$string.show();
-				$boolean.find('input').attr('disabled', 'disabled');
-				$string.find('input').removeAttr('disabled');
-			}
-		}
-	}
-	
-	updateValueInput();
-	
-	// Sets onchange listener so that the input is updated at the right time.
-	$('body').on('change', 'select', updateValueInput);
-	
+    /**
+     * This function is updating the value input field for system properties so
+     * that if the property is a boolean then the user has radio buttons instead
+     * of just a normal text field.
+     */
+    function updateValueInput(event) {
+        var $this = $(this).is('select') ? $(this) : $('select');
+        var $boolean = $('.system-property-value-boolean');
+        var $string = $('.system-property-value-string');
+        if ($string.is('div') && $boolean.is('div')) {
+
+            var value = $this.val()
+            if (value === undefined) {
+                return;
+            }
+            value = value.toLowerCase();
+
+            if (value === "boolean_type") {
+                $string.hide();
+                $boolean.show();
+                $string.find('input').attr('disabled', 'disabled');
+                $boolean.find('input').removeAttr('disabled');
+            } else {
+                $boolean.hide()
+                $string.show();
+                $boolean.find('input').attr('disabled', 'disabled');
+                $string.find('input').removeAttr('disabled');
+            }
+        }
+    }
+
+    updateValueInput();
+
+    // Sets onchange listener so that the input is updated at the right time.
+    $('body').on('change', 'select', updateValueInput);
+
 });


### PR DESCRIPTION
Fixes issue #955 by adding a form builder extension handler to create a new field type, creating a new template that has both a string input and radio button input, and added js functionality to change between inputs depending on the selected item in the system property select list.