### PR TITLE
Remove any credit card payment type restrictions on populating billing/shipping/customer information from the order onto a PaymentRequestDTO

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/DefaultPaymentGatewayCheckoutService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/DefaultPaymentGatewayCheckoutService.java
@@ -27,7 +27,6 @@ import org.broadleafcommerce.common.i18n.domain.ISOCountry;
 import org.broadleafcommerce.common.i18n.service.ISOService;
 import org.broadleafcommerce.common.payment.PaymentAdditionalFieldType;
 import org.broadleafcommerce.common.payment.PaymentGatewayType;
-import org.broadleafcommerce.common.payment.PaymentType;
 import org.broadleafcommerce.common.payment.dto.AddressDTO;
 import org.broadleafcommerce.common.payment.dto.GatewayCustomerDTO;
 import org.broadleafcommerce.common.payment.dto.PaymentResponseDTO;
@@ -171,8 +170,7 @@ public class DefaultPaymentGatewayCheckoutService implements PaymentGatewayCheck
 
                     paymentsToInvalidate.add(p);
 
-                    if (PaymentType.CREDIT_CARD.equals(p.getType()) &&
-                            PaymentGatewayType.TEMPORARY.equals(p.getGatewayType()) ) {
+                    if (PaymentGatewayType.TEMPORARY.equals(p.getGatewayType()) ) {
                         tempBillingAddress = p.getBillingAddress();
                     }
                 }
@@ -201,8 +199,7 @@ public class DefaultPaymentGatewayCheckoutService implements PaymentGatewayCheck
         }
 
         //Set the Credit Card Info on the Additional Fields Map
-        if (PaymentType.CREDIT_CARD.equals(responseDTO.getPaymentType()) &&
-                responseDTO.getCreditCard() != null && responseDTO.getCreditCard().creditCardPopulated()) {
+        if (responseDTO.getCreditCard() != null && responseDTO.getCreditCard().creditCardPopulated()) {
 
             transaction.getAdditionalFields().put(PaymentAdditionalFieldType.NAME_ON_CARD.getType(),
                     responseDTO.getCreditCard().getCreditCardHolderName());

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
@@ -83,6 +83,13 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
             .orderCurrencyCode(paymentTransaction.getOrderPayment().getCurrency().getCurrencyCode())
             .orderId(paymentTransaction.getOrderPayment().getOrder().getId().toString());
         
+        Order order = paymentTransaction.getOrderPayment().getOrder();
+        populateCustomerInfo(order, requestDTO);
+        populateShipTo(order, requestDTO);
+        populateBillTo(order, requestDTO);
+        populateTotals(order, requestDTO);
+        populateDefaultLineItemsAndSubtotal(order, requestDTO);
+        
         //Copy Additional Fields from PaymentTransaction into the Request DTO.
         //This will contain any gateway specific information needed to perform actions on this transaction
         Map<String, String> additionalFields = paymentTransaction.getAdditionalFields();
@@ -196,7 +203,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
     @Override
     public void populateBillTo(Order order, PaymentRequestDTO requestDTO) {
         for (OrderPayment payment : order.getPayments()) {
-            if (payment.isActive() && PaymentType.CREDIT_CARD.equals(payment.getType())) {
+            if (payment.isActive()) {
                 Address billAddress = payment.getBillingAddress();
                 if (billAddress != null) {
                     String stateAbbr = null;


### PR DESCRIPTION
Fixes #1423 by removing any CC type restrictions in `ValidateAndConfirmPaymentsActivity` along with the `ConfirmPaymentsRollbackHandler`. I ran into a situation where a `THIRD_PARTY_HOSTED` payment type needed this info as well and realized the CC type restriction is basically moot.