### PR TITLE
#1427 - updated BasicFieldPersistenceProvider to treat null as false when populating values

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -331,12 +331,6 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     Boolean mutable = metadata.getMutable();
                     Boolean readOnly = metadata.getReadOnly();
 
-                    if (metadata.getFieldType().equals(SupportedFieldType.BOOLEAN)) {
-                        if (value == null) {
-                            value = "false";
-                        }
-                    }
-
                     if ((mutable == null || mutable) && (readOnly == null || !readOnly)) {
                         if (value != null) {
                             handled = false;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
@@ -45,8 +45,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.criteri
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.RestrictionType;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.predicate.IsNotNullPredicateProvider;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.predicate.IsNullPredicateProvider;
-import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.extension
-        .BasicFieldPersistenceProviderExtensionManager;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.extension.BasicFieldPersistenceProviderExtensionManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.AddSearchMappingRequest;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.ExtractValueRequest;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.PopulateValueRequest;
@@ -157,10 +156,11 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
             switch (populateValueRequest.getMetadata().getFieldType()) {
                 case BOOLEAN:
                     boolean v = Boolean.valueOf(populateValueRequest.getRequestedValue());
-                    prop.setOriginalValue(String.valueOf(origValue));
+                    boolean origBoolean = Boolean.valueOf(String.valueOf(origValue));
+                    prop.setOriginalValue(String.valueOf(origBoolean));
                     prop.setOriginalDisplayValue(prop.getOriginalValue());
                     try {
-                        dirty = checkDirtyState(populateValueRequest, instance, v);
+                        dirty = origBoolean != v;
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), v);
                     } catch (IllegalArgumentException e) {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
@@ -156,11 +156,10 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
             switch (populateValueRequest.getMetadata().getFieldType()) {
                 case BOOLEAN:
                     boolean v = Boolean.valueOf(populateValueRequest.getRequestedValue());
-                    boolean origBoolean = Boolean.valueOf(String.valueOf(origValue));
-                    prop.setOriginalValue(String.valueOf(origBoolean));
+                    prop.setOriginalValue(String.valueOf(origValue));
                     prop.setOriginalDisplayValue(prop.getOriginalValue());
                     try {
-                        dirty = origBoolean != v;
+                        dirty = checkDirtyState(populateValueRequest, instance, v);
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), v);
                     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Fixes #1427 
Fixes BroadleafCommerce/QA#433.

I made changes to `BasicFieldPersistenceProvider` to properly treat null Boolean values as false by doing a `Boolean.valueOf` on the original value. This fixed the issue where overrideGeneratedUrl would show up on the change details screen.