### PR TITLE
#1435 - updated readonly.html to properly check media urls for empty strings before loading media

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/readonly.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/readonly.html
@@ -3,8 +3,8 @@
 <div class="twelve" style="margin-left: 20px; margin-bottom: 10px;" th:switch="*{fields['__${field.name}__'].fieldType}">
 
     <span th:case="'MEDIA'" th:remove="tag">
-        <a th:if="*{fields['__${field.name}__'].media != null and fields['__${field.name}__'].media.url != null}"
-           th:href="@{*{fields['__${field.name}__'].media.url}}" target="_blank">
+        <a th:if="*{fields['__${field.name}__'].media != null and fields['__${field.name}__'].media.url != null and !#strings.isEmpty(fields['__${field.name}__'].media.url)}" 
+            th:href="@{*{fields['__${field.name}__'].media.url}}" target="_blank">
             <img class="thumbnail"
                 th:src="@{*{fields['__${field.name}__'].media.url + '?largeAdminThumbnail'}}" />
         </a>


### PR DESCRIPTION
Fixes #1435 and BroadleafCommerce/QA#677

Originally when a readonly user would view a product, if there wasn't a media, it would try to create a link to an empty url, causing a thymeleaf error.

To fix this I updated readonly.html to check if the media url is an empty string as well as null, the page now loads correctly. 