### PR TITLE
Limit the url to one successUrl parameter on a failed login attempt

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/security/BroadleafAdminAuthenticationFailureHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/security/BroadleafAdminAuthenticationFailureHandler.java
@@ -58,15 +58,29 @@ public class BroadleafAdminAuthenticationFailureHandler extends SimpleUrlAuthent
         if (BooleanUtils.isTrue(sessionTimeout)) {
             failureUrl = "?sessionTimeout=true";
         }
-        //Grab url the user, was redirected from
-        successUrlParam = request.getHeader("referer");
+
+        if (StringUtils.isEmpty(successUrlParam)) {
+            //Grab url the user, was redirected from
+            successUrlParam = request.getHeader("referer");
+        }
+        
         if (failureUrl != null) {
             if (!StringUtils.isEmpty(successUrlParam)) {
+            	//Preserve the original successUrl from the referer.  If there is one, it must be the last url segment
+            	int successUrlPos = successUrlParam.indexOf("successUrl");
+            	if (successUrlPos >= 0) {
+            		successUrlParam = successUrlParam.substring(successUrlPos);
+            	} else {
+            		successUrlParam = "successUrl=" + successUrlParam;
+            	}
+
                 if (!failureUrl.contains("?")) {
-                    failureUrl += "?successUrl=" + successUrlParam;
+                    failureUrl += "?" + successUrlParam;
                 } else {
-                    failureUrl += "&successUrl=" + successUrlParam;
+                    failureUrl += "&" + successUrlParam;
                 }
+            } else {
+            	
             }
 
             saveException(request, exception);


### PR DESCRIPTION
This is a cherry pick from a 4.1.  Repeated failed login attempts continuously appends parameters to the url.  For example, two failed login attempts produces multiple "login_error" and "successUrl" parameters:
?login_error=true&successUrl=http://test.blcqa.com/admin/login
?login_error=true&successUrl=http://test.blcqa.com/admin/

Fixes BroadleafCommerce#1281.  Relates to BroadleafCommerce/QA#368