### PR TITLE
Fixed "View Approver Sandbox" user so that they can view approvals

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/applicationContext-servlet-open-admin.xml
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/applicationContext-servlet-open-admin.xml
@@ -125,6 +125,7 @@
         <property name="dialects">
             <set>
                 <ref bean="thymeleafSpringStandardDialect" />
+                <ref bean="thymeleafSpringSecurityDialect" />
                 <ref bean="blAdminDialect" />
                 <ref bean="blDialect" />
             </set>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGridToolbar.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGridToolbar.html
@@ -12,14 +12,27 @@
         
         <ul class="inline-list small-spacing">
             <li th:each="action : ${listGrid.activeToolbarActions}">
-                <button class="tiny radius dark button" 
-                    type="button"
-                    th:classappend="${action.buttonClass}"
-                    th:attr="data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
-                             data-urlpostfix=${action.urlPostfix},
-                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
-                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
-                </button>
+            	<th:block th:if="${(#strings.contains(action.buttonClass, 'reject') or #strings.contains(action.buttonClass, 'approve')) and #strings.contains(sectionKey, 'workflow/approvals')}">
+	                <button sec:authorize="hasRole('PERMISSION_ALL_APPROVER_SANDBOX')"
+	                	class="tiny radius dark button" 
+	                    type="button"
+	                    th:classappend="${action.buttonClass}"
+	                    th:attr="data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
+	                             data-urlpostfix=${action.urlPostfix},
+	                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
+	                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+	                </button>
+              	</th:block>
+                <th:block th:unless="${(#strings.contains(action.buttonClass, 'reject') or #strings.contains(action.buttonClass, 'approve')) and #strings.contains(sectionKey, 'workflow/approvals')}">
+	                <button class="tiny radius dark button" 
+	                    type="button"
+	                    th:classappend="${action.buttonClass}"
+	                    th:attr="data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
+	                             data-urlpostfix=${action.urlPostfix},
+	                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
+	                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+	                </button>
+                </th:block>
             </li>
             
             <li style="color: #8495A5" 
@@ -27,15 +40,29 @@
                 th:text="'|'" />
 
             <li th:each="action : ${listGrid.activeRowActions}">
-                <button disabled="disabled" 
-                    class="tiny radius dark row-action button" 
-                    type="button"
-                    th:classappend="${action.buttonClass}"
-                    th:attr="data-urlpostfix=${action.urlPostfix},
-                             data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
-                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
-                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
-                </button>
+            	<th:block th:if="${#strings.contains(action.buttonClass, 'reject') or #strings.contains(action.buttonClass, 'approve')}">
+	                <button sec:authorize="hasRole('PERMISSION_ALL_APPROVER_SANDBOX')"
+	                	disabled="disabled" 
+	                    class="tiny radius dark row-action button" 
+	                    type="button"
+	                    th:classappend="${action.buttonClass}"
+	                    th:attr="data-urlpostfix=${action.urlPostfix},
+	                             data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
+	                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
+	                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+	                </button>
+	            </th:block> 
+	            <th:block th:unless="${#strings.contains(action.buttonClass, 'workflow-reject') or #strings.contains(action.buttonClass, 'workflow-approve')}">
+	            	<button disabled="disabled" 
+	                    class="tiny radius dark row-action button" 
+	                    type="button"
+	                    th:classappend="${action.buttonClass}"
+	                    th:attr="data-urlpostfix=${action.urlPostfix},
+	                             data-actionurl=@{${#strings.isEmpty(action.actionUrlOverride) ? (listGrid.path + action.urlPostfix) : action.actionUrlOverride} + ${listGrid.sectionCrumbRepresentation}},
+	                             data-queryparams=${listGrid.sectionCrumbRepresentation}">
+	                    <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+	                </button>
+	            </th:block>
             </li>
 
         </ul>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/breadcrumb.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/layout/partials/breadcrumb.html
@@ -20,15 +20,28 @@
     </ul>
 
     <div th:if="${entityForm}" class="entity-form-actions">
-        <button th:each="action : ${entityForm.actions}" 
-            class="small button radius dark" 
-            th:attr="data-url=@{${(#strings.isEmpty(action.urlOverride)) ? ('/' + sectionKey + action.urlPostfix) : action.urlOverride}},
-                     data-action=${action.urlPostfix}"
-            th:type="${action.buttonType}"
-            th:classappend="${action.buttonClass}">
-            <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
-        </button>   
-        <img th:src="@{/img/admin/ajax-loader.gif}" class="ajax-loader" />                 
+    	<th:block th:each="action : ${entityForm.actions}">
+	       	<th:block th:if="${(#strings.contains(action.buttonClass, 'reject') or #strings.contains(action.buttonClass, 'approve')) and #strings.contains(sectionKey, 'workflow/approvals')}">
+		        <button sec:authorize="hasRole('PERMISSION_ALL_APPROVER_SANDBOX')"
+		            class="small button radius dark" 
+		            th:attr="data-url=@{${(#strings.isEmpty(action.urlOverride)) ? ('/' + sectionKey + action.urlPostfix) : action.urlOverride}},
+		                     data-action=${action.urlPostfix}"
+		            th:type="${action.buttonType}"
+		            th:classappend="${action.buttonClass}">
+		            <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+		        </button>  
+	        </th:block>  
+  	       	<th:block th:unless="${(#strings.contains(action.buttonClass, 'reject') or #strings.contains(action.buttonClass, 'approve')) and #strings.contains(sectionKey, 'workflow/approvals')}">
+		        <button class="small button radius dark" 
+		            th:attr="data-url=@{${(#strings.isEmpty(action.urlOverride)) ? ('/' + sectionKey + action.urlPostfix) : action.urlOverride}},
+		                     data-action=${action.urlPostfix}"
+		            th:type="${action.buttonType}"
+		            th:classappend="${action.buttonClass}">
+		            <i th:class="${action.iconClass}"></i>&nbsp;<span th:text="#{${action.displayText}}" th:remove="tag" />
+		        </button>  
+	        </th:block>              
+        </th:block>
+        <img th:src="@{/img/admin/ajax-loader.gif}" class="ajax-loader" />   
     </div>
 
     <div class="clear"></div>

--- a/core/broadleaf-framework-web/pom.xml
+++ b/core/broadleaf-framework-web/pom.xml
@@ -123,6 +123,10 @@
             <artifactId>thymeleaf</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf-spring4</artifactId>
         </dependency>

--- a/core/broadleaf-framework-web/src/main/resources/bl-framework-web-applicationContext.xml
+++ b/core/broadleaf-framework-web/src/main/resources/bl-framework-web-applicationContext.xml
@@ -165,6 +165,8 @@
     </bean>  
     
     <bean id="thymeleafSpringStandardDialect" class="org.thymeleaf.spring4.dialect.SpringStandardDialect" />
+    <bean id="thymeleafSpringSecurityDialect" class="org.thymeleaf.extras.springsecurity3.dialect.SpringSecurityDialect"/>
+    
     
     <bean id="blMessageResolver" class="org.broadleafcommerce.common.web.BroadleafThymeleafMessageResolver" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -801,6 +801,13 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
+                <groupId>org.thymeleaf.extras</groupId>
+                <artifactId>thymeleaf-extras-springsecurity3</artifactId>
+                <version>2.1.2.RELEASE</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
                 <groupId>nz.net.ultraq.thymeleaf</groupId>
                 <artifactId>thymeleaf-layout-dialect</artifactId>
                 <version>1.2.5</version>


### PR DESCRIPTION
#1440 - The changes made affect how the "View Approver Sandbox" sees the sandbox changes. They no longer see "approve" and "disapprove" buttons so that they don't click them and see a stacktrace. Thymeleaf's spring security dialect was added in order to make it easier to filter out UI elements that lower privileged users don't need to see.