### PR TITLE
#1444 - updated SandBoxDaoImpl to fix bug in retrieveAllSandBoxes method

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/sandbox/dao/SandBoxDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sandbox/dao/SandBoxDaoImpl.java
@@ -71,8 +71,8 @@ public class SandBoxDaoImpl implements SandBoxDao {
         Root<SandBoxManagementImpl> sandbox = criteria.from(SandBoxManagementImpl.class);
         criteria.select(sandbox.get("sandBox").as(SandBox.class));
         criteria.where(
-                builder.or(builder.isNull(sandbox.get("archiveStatus").get("archived").as(String.class)),
-                        builder.notEqual(sandbox.get("archiveStatus").get("archived").as(Character.class), 'Y'))
+                builder.or(builder.isNull(sandbox.get("sandBox").get("archiveStatus").get("archived").as(String.class)),
+                        builder.notEqual(sandbox.get("sandBox").get("archiveStatus").get("archived").as(Character.class), 'Y'))
         );
         TypedQuery<SandBox> query = sandBoxEntityManager.createQuery(criteria);
         return query.getResultList();


### PR DESCRIPTION
Fixes #1444 and BroadleafCommerce/QA#534.

This was simply to fix a bug in `SandBoxDaoImpl` that caused an error when you tried to use the method `retrieveAllSandboxes`.