### PR TITLE
Updated dirty form fields immediately after submission 

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -416,8 +416,36 @@ public class AdminBasicEntityController extends AdminAbstractController {
         if (result.hasErrors()) {
             populateJsonValidationErrors(entityForm, result, json);
         }
+        List<String> dirtyList = buildDirtyList(pathVars, request, id);
+        if (!dirtyList.isEmpty()) {
+            json.with("dirty", dirtyList);
+        }
 
         return json.done();
+    }
+    
+    public List<String> buildDirtyList(Map<String, String> pathVars, HttpServletRequest request, String id) {
+        List<String> dirtyList = new ArrayList<>();
+        String sectionKey = getSectionKey(pathVars);
+        String sectionClassName = getClassNameForSection(sectionKey);
+        List<SectionCrumb> sectionCrumbs = getSectionCrumbs(request, sectionKey, id);
+        PersistencePackageRequest ppr = getSectionPersistencePackageRequest(sectionClassName, sectionCrumbs, pathVars);
+        ClassMetadata cmd = null;
+        Entity entity = null;
+        try {
+            cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
+            entity = service.getRecord(ppr, id, cmd, false).getDynamicResultSet().getRecords()[0];
+
+        } catch (ServiceException e) {
+            return null;
+        }
+        
+        for (Property p: entity.getProperties()) {
+            if (p.getIsDirty()) {
+                dirtyList.add(p.getName());
+            }
+        }
+        return dirtyList;
     }
     
     /**

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -417,14 +417,14 @@ public class AdminBasicEntityController extends AdminAbstractController {
             populateJsonValidationErrors(entityForm, result, json);
         }
         List<String> dirtyList = buildDirtyList(pathVars, request, id);
-        if (!dirtyList.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(dirtyList)) {
             json.with("dirty", dirtyList);
         }
 
         return json.done();
     }
     
-    public List<String> buildDirtyList(Map<String, String> pathVars, HttpServletRequest request, String id) {
+    public List<String> buildDirtyList(Map<String, String> pathVars, HttpServletRequest request, String id) throws ServiceException {
         List<String> dirtyList = new ArrayList<>();
         String sectionKey = getSectionKey(pathVars);
         String sectionClassName = getClassNameForSection(sectionKey);
@@ -432,13 +432,8 @@ public class AdminBasicEntityController extends AdminAbstractController {
         PersistencePackageRequest ppr = getSectionPersistencePackageRequest(sectionClassName, sectionCrumbs, pathVars);
         ClassMetadata cmd = null;
         Entity entity = null;
-        try {
-            cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
-            entity = service.getRecord(ppr, id, cmd, false).getDynamicResultSet().getRecords()[0];
-
-        } catch (ServiceException e) {
-            return null;
-        }
+        cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
+        entity = service.getRecord(ppr, id, cmd, false).getDynamicResultSet().getRecords()[0];
         
         for (Property p: entity.getProperties()) {
             if (p.getIsDirty()) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -98,17 +98,6 @@ $(document).ready(function() {
                     showErrors(data, BLCAdmin.messages.problemSaving);
                 }
                 
-                if (data.dirty) {
-                    for (var i = 0; i < data.dirty.length; i++) {
-                        var field = String(data.dirty[i]);
-                        field = field.replace(".", "--");
-                        var fieldLabel = $("#field-" + field);
-                        fieldLabel.addClass("dirty");
-                        BLCAdmin.workflow.initializeDirtyStates(fieldLabel.closest("form"));
-                    }
-
-                }
-                
                 BLCAdmin.runPostFormSubmitHandlers($form, data);
             });
         }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -98,6 +98,17 @@ $(document).ready(function() {
                     showErrors(data, BLCAdmin.messages.problemSaving);
                 }
                 
+                if (data.dirty) {
+                    for (var i = 0; i < data.dirty.length; i++) {
+                        var field = String(data.dirty[i]);
+                        field = field.replace(".", "--");
+                        var fieldLabel = $("#field-" + field);
+                        fieldLabel.addClass("dirty");
+                        BLCAdmin.workflow.initializeDirtyStates(fieldLabel.closest("form"));
+                    }
+
+                }
+                
                 BLCAdmin.runPostFormSubmitHandlers($form, data);
             });
         }


### PR DESCRIPTION
Fixes #1446 by updating entity controller so that the fields that are dirty are sent in the JSON response and by updating the entityForm.js so that the dirty fields are highlighted based on the JSON response.

Original QA issue BroadleafCommerce/QA#581