### PR TITLE
Bundles can return a 404 in BLC multi-tenant setup

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingServiceImpl.java
@@ -179,9 +179,9 @@ public class ResourceBundlingServiceImpl implements ResourceBundlingService {
                         if (bundleResource != null) {
                             saveBundle(bundleResource);
                         }
+                        Resource savedResource = readBundle(versionedBundleName);
+                        createdBundles.put(versionedBundleName, savedResource);
                     }
-                    Resource savedResource = readBundle(versionedBundleName);
-                    createdBundles.put(versionedBundleName, savedResource);
                 }
             });
         }


### PR DESCRIPTION
Resolves #1448 

After creating a bundle, add the bundle resource to the createdBundles map.    Do not add a filename to the map if it wasn't created in the current thread.