### PR TITLE
Populate totals and line items only for PaymentType.UNCONFIRMED

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
@@ -22,7 +22,7 @@ package org.broadleafcommerce.core.payment.service;
 
 import org.apache.commons.lang.StringUtils;
 import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.payment.PaymentType;
+import org.broadleafcommerce.common.payment.PaymentTransactionType;
 import org.broadleafcommerce.common.payment.dto.PaymentRequestDTO;
 import org.broadleafcommerce.common.util.BLCSystemProperty;
 import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
@@ -87,8 +87,12 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
         populateCustomerInfo(order, requestDTO);
         populateShipTo(order, requestDTO);
         populateBillTo(order, requestDTO);
-        populateTotals(order, requestDTO);
-        populateDefaultLineItemsAndSubtotal(order, requestDTO);
+
+        // Only set totals and line items when in a Payment flow
+        if (PaymentTransactionType.UNCONFIRMED.equals(paymentTransaction.getType())) {
+            populateTotals(order, requestDTO);
+            populateDefaultLineItemsAndSubtotal(order, requestDTO);
+        }
         
         //Copy Additional Fields from PaymentTransaction into the Request DTO.
         //This will contain any gateway specific information needed to perform actions on this transaction


### PR DESCRIPTION
Added an `if check` to only populate totals and line items for `PaymentType.UNCONFIRMED`

Fixes #1449 

Reference to https://github.com/BroadleafCommerce/QA/issues/684