### PR TITLE
Qa 685 admin entity not found

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/exception/EntityNotFoundException.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/exception/EntityNotFoundException.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.exception;
+
+/**
+ * Created by Jon on 6/24/15.
+ */
+public class EntityNotFoundException extends IllegalArgumentException {
+    /**
+     * Constructs an <code>EntityNotFoundException</code> with no
+     * detail message.
+     */
+    public EntityNotFoundException() {
+        super();
+    }
+
+    /**
+     * Constructs an <code>EntityNotFoundException</code> with the
+     * specified detail message.
+     *
+     * @param   s   the detail message.
+     */
+    public EntityNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
@@ -58,7 +58,6 @@ import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
 import org.broadleafcommerce.openadmin.web.form.entity.Field;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +69,6 @@ import java.util.Map.Entry;
 
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 
 /**
@@ -124,7 +122,9 @@ public class AdminEntityServiceImpl implements AdminEntityService {
 
         PersistenceResponse response = fetch(request);
         Entity[] entities = response.getDynamicResultSet().getRecords();
-        if (entities == null || entities.length != 1) throw new EntityNotFoundException();
+        if (ArrayUtils.isEmpty(entities)) {
+            throw new EntityNotFoundException();
+        }
 
         return response;
     }
@@ -267,7 +267,9 @@ public class AdminEntityServiceImpl implements AdminEntityService {
 
             response = fetch(ppr);
             Entity[] entities = response.getDynamicResultSet().getRecords();
-            if (entities == null || entities.length != 1) throw new EntityNotFoundException();
+            if (ArrayUtils.isEmpty(entities)) {
+                throw new EntityNotFoundException();
+            }
         } else if (md instanceof MapMetadata) {
             MapMetadata mmd = (MapMetadata) md;
             FilterAndSortCriteria fasc = new FilterAndSortCriteria(ppr.getForeignKey().getManyToField());
@@ -290,12 +292,6 @@ public class AdminEntityServiceImpl implements AdminEntityService {
         } else {
             throw new IllegalArgumentException(String.format("The specified field [%s] for class [%s] was not an " +
                     "advanced collection field.", collectionProperty.getName(), containingClassMetadata.getCeilingType()));
-        }
-
-        if (response == null) {
-            throw new NoResultException(String.format("Could not find record for class [%s], field [%s], main entity id " +
-                    "[%s], collection entity id [%s]", containingClassMetadata.getCeilingType(),
-                    collectionProperty.getName(), containingEntityId, collectionItemId));
         }
 
         return response;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
@@ -48,6 +48,7 @@ import org.broadleafcommerce.openadmin.dto.MapStructure;
 import org.broadleafcommerce.openadmin.dto.PersistencePackage;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.dto.SectionCrumb;
+import org.broadleafcommerce.openadmin.exception.EntityNotFoundException;
 import org.broadleafcommerce.openadmin.server.domain.PersistencePackageRequest;
 import org.broadleafcommerce.openadmin.server.factory.PersistencePackageFactory;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceResponse;
@@ -123,7 +124,7 @@ public class AdminEntityServiceImpl implements AdminEntityService {
 
         PersistenceResponse response = fetch(request);
         Entity[] entities = response.getDynamicResultSet().getRecords();
-        Assert.isTrue(entities != null && entities.length == 1, "Entity not found");
+        if (entities == null || entities.length != 1) throw new EntityNotFoundException();
 
         return response;
     }
@@ -266,7 +267,7 @@ public class AdminEntityServiceImpl implements AdminEntityService {
 
             response = fetch(ppr);
             Entity[] entities = response.getDynamicResultSet().getRecords();
-            Assert.isTrue(entities != null && entities.length == 1, "Entity not found");
+            if (entities == null || entities.length != 1) throw new EntityNotFoundException();
         } else if (md instanceof MapMetadata) {
             MapMetadata mmd = (MapMetadata) md;
             FilterAndSortCriteria fasc = new FilterAndSortCriteria(ppr.getForeignKey().getManyToField());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/handler/AdminMappingExceptionResolver.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/handler/AdminMappingExceptionResolver.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.openadmin.web.handler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.web.controller.BroadleafControllerUtility;
+import org.broadleafcommerce.openadmin.exception.EntityNotFoundException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 
@@ -57,6 +58,14 @@ public class AdminMappingExceptionResolver extends SimpleMappingExceptionResolve
             // Add the message to the model so we can render it 
             return mav;
         } else {
+            // If the exception is "Entity not found" redirect to main listgrid view
+            if (ex.getClass().equals(EntityNotFoundException.class)) {
+                String servletPath = request.getServletPath();
+
+                // Remove erroneous entity Id from servletPath
+                servletPath = servletPath.substring(0, servletPath.lastIndexOf('/'));
+                return new ModelAndView("redirect:" + servletPath);
+            }
             return super.resolveException(request, response, handler, ex);
         }
     }


### PR DESCRIPTION
Fixes #1454
When a user tries to access an entity that does not exist, they will be redirected up one level to the main listgrid view for the entity type.

This issue was found by switching sandboxes while on an entity that does not exist in the target sandbox.