### PR TITLE
prevent unwanted translation permutations

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/handler/TranslationCustomPersistenceHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/handler/TranslationCustomPersistenceHandler.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2014 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.openadmin.server.service.handler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.config.service.SystemPropertiesService;
+import org.broadleafcommerce.common.exception.ServiceException;
+import org.broadleafcommerce.common.i18n.domain.Translation;
+import org.broadleafcommerce.common.i18n.service.TranslationService;
+import org.broadleafcommerce.openadmin.dto.Entity;
+import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.broadleafcommerce.openadmin.dto.PersistencePackage;
+import org.broadleafcommerce.openadmin.dto.PersistencePerspective;
+import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+/**
+ * Custom persistence handler for Translations, it verifies on "add" that the combination of the 4 "key" fields
+ * is not repeated (as in a software-enforced unique index, which is not utilized because of sandboxing and multitenancy concerns).
+ * 
+ * @author gdiaz
+ */
+@Component("blTranslationCustomPersistenceHandler")
+public class TranslationCustomPersistenceHandler extends CustomPersistenceHandlerAdapter {
+
+    private final Log LOG = LogFactory.getLog(TranslationCustomPersistenceHandler.class);
+
+    @Resource(name = "blSystemPropertiesService")
+    protected SystemPropertiesService spService;
+
+    @Resource(name = "blTranslationService")
+    protected TranslationService translationService;
+
+    protected Boolean classMatches(PersistencePackage persistencePackage) {
+        String ceilingEntityFullyQualifiedClassname = persistencePackage.getCeilingEntityFullyQualifiedClassname();
+        return Translation.class.getName().equals(ceilingEntityFullyQualifiedClassname);
+    }
+
+    @Override
+    public Boolean canHandleAdd(PersistencePackage persistencePackage) {
+        return classMatches(persistencePackage);
+    }
+
+    @Override
+    public Boolean canHandleUpdate(PersistencePackage persistencePackage) {
+        return false;
+    }
+
+    @Override
+    public Entity add(PersistencePackage persistencePackage, DynamicEntityDao dynamicEntityDao, RecordHelper helper) throws ServiceException {
+        Entity entity = persistencePackage.getEntity();
+        try {
+            // Get an instance of SystemProperty with the updated values from the form
+            PersistencePerspective persistencePerspective = persistencePackage.getPersistencePerspective();
+            Translation adminInstance = (Translation) Class.forName(entity.getType()[0]).newInstance();
+            Map<String, FieldMetadata> adminProperties = helper.getSimpleMergedProperties(Translation.class.getName(), persistencePerspective);
+            adminInstance = (Translation) helper.createPopulatedInstance(adminInstance, entity, adminProperties, false);
+
+            Translation res = translationService.getTranslation(adminInstance.getEntityType(), adminInstance.getEntityId(), adminInstance.getFieldName(), adminInstance.getLocaleCode());
+            if (res == null) {
+                adminInstance = dynamicEntityDao.merge(adminInstance);
+                Entity adminEntity = helper.getRecord(adminProperties, adminInstance, null, null);
+                return adminEntity;
+            } else {
+                Entity errorEntity = new Entity();
+                errorEntity.addValidationError("localeCode", "translation.record.exists.for.locale");
+                return errorEntity;
+            }
+        } catch (Exception e) {
+            throw new ServiceException("Unable to perform add for entity: " + Translation.class.getName(), e);
+        }
+    }
+
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/compatibility/JSFieldNameCompatibilityInterceptor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/compatibility/JSFieldNameCompatibilityInterceptor.java
@@ -45,10 +45,12 @@ public class JSFieldNameCompatibilityInterceptor extends HandlerInterceptorAdapt
             EntityForm entityForm = (EntityForm) modelAndView.getModelMap().get("entityForm");
     
             if (entity != null) {
+                if (entity.getProperties()!=null){
                 for (Property property : entity.getProperties()) {
                     if (property.getName().contains(".")) {
                         property.setName(JSCompatibilityHelper.encode(property.getName()));
                     }
+                }
                 }
             }
     

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -39,6 +39,8 @@ import org.broadleafcommerce.openadmin.web.service.TranslationFormBuilderService
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -176,6 +178,8 @@ public class AdminTranslationController extends AdminAbstractController {
         entityFormValidator.validate(entityForm, entity, result);
         if (result.hasErrors()) {
             entityForm.setPreventSubmit();
+            String jsErrorMap = resultToJS(result);
+            entityForm.setJsErrorMap(jsErrorMap);
             model.addAttribute("entity", entity);
             model.addAttribute("entityForm", entityForm);
             model.addAttribute("viewType", "modal/translationAdd");
@@ -185,6 +189,30 @@ public class AdminTranslationController extends AdminAbstractController {
         } else {
             return viewTranslation(request, response, model, form, result);
         }
+    }
+
+    /**
+     * analyzes the error information, and converts it into a Javascript object  string, which can be passed to to the HTML form through the entityForm
+     * @param result
+     * @return
+     */
+    private String resultToJS(BindingResult result) {
+        StringBuffer sb = new StringBuffer("[");
+        List<ObjectError> errors = result.getAllErrors();
+        for (ObjectError objectError : errors) {
+            if (objectError instanceof FieldError) {
+                FieldError ferr = (FieldError) objectError;
+                sb.append("{");
+                sb.append("\"").append(ferr.getField()).append("\":");
+                sb.append("\"").append(ferr.getDefaultMessage()).append("\"");
+                sb.append("},");
+            }
+        }
+        if (sb.length() > 1) {
+            sb.deleteCharAt(sb.length() - 1); //the last comma
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
     @RequestMapping(value = "/update", method = RequestMethod.GET)

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -25,6 +25,8 @@ import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
 import org.broadleafcommerce.common.i18n.domain.Translation;
 import org.broadleafcommerce.common.i18n.domain.TranslationImpl;
 import org.broadleafcommerce.common.i18n.service.TranslationService;
+import org.broadleafcommerce.common.util.BLCMessageUtils;
+import org.broadleafcommerce.common.util.StringUtil;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.SectionCrumb;
 import org.broadleafcommerce.openadmin.server.security.remote.EntityOperationType;
@@ -203,8 +205,10 @@ public class AdminTranslationController extends AdminAbstractController {
             if (objectError instanceof FieldError) {
                 FieldError ferr = (FieldError) objectError;
                 sb.append("{");
-                sb.append("\"").append(ferr.getField()).append("\":");
-                sb.append("\"").append(ferr.getDefaultMessage()).append("\"");
+                String fieldOnly = StringUtil.extractFieldNameFromExpression(ferr.getField());
+                sb.append("\"").append(fieldOnly).append("\":");
+                String localizedMessage = BLCMessageUtils.getMessage(ferr.getDefaultMessage());
+                sb.append("\"").append(localizedMessage).append("\"");
                 sb.append("},");
             }
         }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -45,7 +45,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
@@ -119,7 +118,6 @@ public class AdminTranslationController extends AdminAbstractController {
         adminRemoteSecurityService.securityCheck(form.getCeilingEntity(), EntityOperationType.FETCH);
 
         EntityForm entityForm = formService.buildTranslationForm(form, TranslationFormAction.ADD);
-
         model.addAttribute("entityForm", entityForm);
         model.addAttribute("viewType", "modal/translationAdd");
         model.addAttribute("currentUrl", request.getRequestURL().toString());
@@ -175,14 +173,9 @@ public class AdminTranslationController extends AdminAbstractController {
 
         Entity entity = service.addEntity(entityForm, getSectionCustomCriteria(), sectionCrumbs).getEntity();
 
-        for (Map.Entry<String, Field> entry : entityForm.getFields().entrySet()) {
-            String key = entry.getKey();
-            Field value = entry.getValue();
-            System.out.println("key=" + key + " value=" + value);
-        }
-
         entityFormValidator.validate(entityForm, entity, result);
         if (result.hasErrors()) {
+            entityForm.setPreventSubmit();
             model.addAttribute("entity", entity);
             model.addAttribute("entityForm", entityForm);
             model.addAttribute("viewType", "modal/translationAdd");

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
@@ -67,6 +67,12 @@ public class EntityForm {
      */
     protected Boolean preventSubmit = false;
 
+    /**
+     * a string representation of a Javascript object containing a map of fields => errors
+     * Useful when filling a translation form, as the (only) way to determine to which fields error messaging needs to be attached
+     */
+    protected String jsErrorMap;
+
     protected String translationCeilingEntity;
     protected String translationId;
 
@@ -619,6 +625,14 @@ public class EntityForm {
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    public String getJsErrorMap() {
+        return jsErrorMap;
+    }
+
+    public void setJsErrorMap(String jsErrorMap) {
+        this.jsErrorMap = jsErrorMap;
     }
 
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
@@ -44,7 +44,7 @@ import java.util.TreeSet;
 public class EntityForm {
 
     protected static final Log LOG = LogFactory.getLog(EntityForm.class);
-    
+
     public static final String HIDDEN_GROUP = "hiddenGroup";
     public static final String MAP_KEY_GROUP = "keyGroup";
     public static final String DEFAULT_GROUP_NAME = "Default";
@@ -60,11 +60,18 @@ public class EntityForm {
     protected String mainEntityName;
     protected String sectionKey;
     protected Boolean readOnly = false;
-    
+
+    /**
+     * special member used for only for a Translation entity form. Set at the controller, in order to populate a hidden field in the form
+     * indicating that there were errors and the form should not be allowed to submit.
+     */
+    protected Boolean preventSubmit = false;
+
     protected String translationCeilingEntity;
     protected String translationId;
-    
+
     protected Set<Tab> tabs = new TreeSet<Tab>(new Comparator<Tab>() {
+
         @Override
         public int compare(Tab o1, Tab o2) {
             return new CompareToBuilder()
@@ -77,16 +84,16 @@ public class EntityForm {
 
     // This is used to data-bind when this entity form is submitted
     protected Map<String, Field> fields = null;
-    
+
     // This is used in cases where there is a sub-form on this page that is dynamically
     // rendered based on other values on this entity form. It is keyed by the name of the
     // property that drives the dynamic form.
     protected Map<String, EntityForm> dynamicForms = new LinkedHashMap<String, EntityForm>();
-    
+
     // These values are used when dynamic forms are in play. They are not rendered to the client,
     // but they can be used when performing actions on the submit event
     protected Map<String, DynamicEntityFormInfo> dynamicFormInfos = new LinkedHashMap<String, DynamicEntityFormInfo>();
-    
+
     protected List<EntityFormAction> actions = new ArrayList<EntityFormAction>();
 
     protected Map<String, Object> attributes = new HashMap<String, Object>();
@@ -114,13 +121,13 @@ public class EntityForm {
             }
             fields = map;
         }
-        
+
         for (Entry<String, EntityForm> entry : dynamicForms.entrySet()) {
             Map<String, Field> dynamicFormFields = entry.getValue().getFields();
             for (Entry<String, Field> dynamicField : dynamicFormFields.entrySet()) {
                 if (fields.containsKey(dynamicField.getKey())) {
                     LOG.info("Excluding dynamic field " + dynamicField.getKey() + " as there is already an occurrance in" +
-                    		" this entityForm");
+                            " this entityForm");
                 } else {
                     fields.put(dynamicField.getKey(), dynamicField.getValue());
                 }
@@ -129,7 +136,7 @@ public class EntityForm {
 
         return fields;
     }
-    
+
     /**
      * Clears out the cached 'fields' variable which is used to render the form on the frontend. Use this method
      * if you want to force the entityForm to rebuild itself based on the tabs and groups that have been assigned and 
@@ -138,7 +145,7 @@ public class EntityForm {
     public void clearFieldsMap() {
         fields = null;
     }
-    
+
     public List<ListGrid> getAllListGrids() {
         List<ListGrid> list = new ArrayList<ListGrid>();
         for (Tab tab : tabs) {
@@ -148,7 +155,7 @@ public class EntityForm {
         }
         return list;
     }
-    
+
     /**
      * Convenience method for grabbing a grid by its collection field name. This is very similar to {@link #findField(String)}
      * but differs in that this only searches through the sub collections for the current entity
@@ -173,7 +180,7 @@ public class EntityForm {
         }
         return null;
     }
-    
+
     public Tab findTabForField(String fieldName) {
         fieldName = sanitizeFieldName(fieldName);
         for (Tab tab : tabs) {
@@ -201,7 +208,7 @@ public class EntityForm {
         }
         return null;
     }
-    
+
     /**
      * Since this field name could come from the frontend (where all fields are referenced like fields[name].value,
      * we need to strip that part out to look up the real field name in this entity
@@ -236,18 +243,18 @@ public class EntityForm {
         if (fieldToRemove != null) {
             containingGroup.removeField(fieldToRemove);
         }
-        
+
         if (fields != null) {
             fieldToRemove = fields.remove(fieldName);
         }
-        
+
         return fieldToRemove;
     }
-    
+
     public void removeTab(Tab tab) {
         tabs.remove(tab);
     }
-    
+
     public void removeTab(String tabName) {
         if (tabs != null) {
             Iterator<Tab> tabIterator = tabs.iterator();
@@ -259,6 +266,7 @@ public class EntityForm {
             }
         }
     }
+
     public ListGrid removeListGrid(String subCollectionFieldName) {
         ListGrid lgToRemove = null;
         Tab containingTab = null;
@@ -278,11 +286,11 @@ public class EntityForm {
         if (lgToRemove != null) {
             containingTab.removeListGrid(lgToRemove);
         }
-        
+
         if (containingTab != null && containingTab.getListGrids().size() == 0 && containingTab.getFields().size() == 0) {
             removeTab(containingTab);
         }
-        
+
         return lgToRemove;
     }
 
@@ -306,7 +314,7 @@ public class EntityForm {
         groupOrder = groupOrder == null ? DEFAULT_GROUP_ORDER : groupOrder;
         tabName = tabName == null ? DEFAULT_TAB_NAME : tabName;
         tabOrder = tabOrder == null ? DEFAULT_TAB_ORDER : tabOrder;
-        
+
         // Tabs and groups should be looked up by their display, translated name since 2 unique strings can display the same
         // thing when they are looked up in message bundles after display
         // When displayed on the form the duplicate groups and tabs look funny
@@ -315,7 +323,7 @@ public class EntityForm {
             groupName = context.getMessageSource().getMessage(groupName, null, groupName, context.getJavaLocale());
             tabName = context.getMessageSource().getMessage(tabName, null, tabName, context.getJavaLocale());
         }
-        
+
         Tab tab = findTab(tabName);
         if (tab == null) {
             tab = new Tab();
@@ -368,35 +376,43 @@ public class EntityForm {
     public void addAction(EntityFormAction action) {
         actions.add(action);
     }
-    
+
     public void removeAction(EntityFormAction action) {
         actions.remove(action);
     }
-    
+
     public void removeAllActions() {
         actions.clear();
     }
-    
+
     public EntityForm getDynamicForm(String name) {
         return getDynamicForms().get(name);
     }
-    
+
     public void putDynamicForm(String name, EntityForm ef) {
         getDynamicForms().put(name, ef);
     }
-    
+
     public DynamicEntityFormInfo getDynamicFormInfo(String name) {
         return getDynamicFormInfos().get(name);
     }
-    
+
     public void putDynamicFormInfo(String name, DynamicEntityFormInfo info) {
         getDynamicFormInfos().put(name, info);
     }
-    
+
     public Boolean getReadOnly() {
         return readOnly;
     }
-    
+
+    public Boolean getPreventSubmit() {
+        return preventSubmit;
+    }
+
+    public void setPreventSubmit() {
+        this.preventSubmit = true;
+    }
+
     public void setReadOnly() {
         setReadOnly(true);
     }
@@ -407,34 +423,34 @@ public class EntityForm {
                 entry.getValue().setReadOnly(readOnly);
             }
         }
-        
+
         if (getAllListGrids() != null) {
             for (ListGrid lg : getAllListGrids()) {
                 lg.setReadOnly(readOnly);
             }
         }
-        
+
         if (getDynamicForms() != null) {
             for (Entry<String, EntityForm> entry : getDynamicForms().entrySet()) {
                 entry.getValue().setReadOnly(readOnly);
             }
         }
-        
+
         actions.clear();
         this.readOnly = readOnly;
     }
-    
+
     public List<EntityFormAction> getActions() {
         List<EntityFormAction> clonedActions = new ArrayList<EntityFormAction>(actions);
         Collections.reverse(clonedActions);
         return Collections.unmodifiableList(clonedActions);
     }
-    
+
     public FieldGroup collapseToOneFieldGroup() {
         Tab newTab = new Tab();
         FieldGroup newFg = new FieldGroup();
         newTab.getFieldGroups().add(newFg);
-        
+
         for (Tab tab : getTabs()) {
             for (FieldGroup fg : tab.getFieldGroups()) {
                 for (Field field : fg.getFields()) {
@@ -442,29 +458,29 @@ public class EntityForm {
                 }
             }
         }
-        
+
         getTabs().clear();
         getTabs().add(newTab);
-        
+
         return newFg;
     }
-    
+
     public String getTranslationCeilingEntity() {
         return translationCeilingEntity == null ? ceilingEntityClassname : translationCeilingEntity;
     }
-    
+
     public void setTranslationCeilingEntity(String translationCeilingEntity) {
         this.translationCeilingEntity = translationCeilingEntity;
     }
-    
+
     public String getTranslationId() {
         return translationId == null ? id : translationId;
     }
-    
+
     public void setTranslationId(String translationId) {
         this.translationId = translationId;
     }
-    
+
     /* *********************** */
     /* GENERIC GETTERS/SETTERS */
     /* *********************** */
@@ -488,7 +504,7 @@ public class EntityForm {
     public String getIdProperty() {
         return idProperty;
     }
-    
+
     public void setIdProperty(String idProperty) {
         this.idProperty = idProperty;
     }
@@ -508,11 +524,11 @@ public class EntityForm {
     public void setEntityType(String entityType) {
         this.entityType = entityType;
     }
-    
+
     public String getMainEntityName() {
         return StringUtils.isBlank(mainEntityName) ? "" : mainEntityName;
     }
-    
+
     public void setMainEntityName(String mainEntityName) {
         this.mainEntityName = mainEntityName;
     }
@@ -520,11 +536,11 @@ public class EntityForm {
     public String getSectionKey() {
         return sectionKey.charAt(0) == '/' ? sectionKey : '/' + sectionKey;
     }
-    
+
     public void setSectionKey(String sectionKey) {
         this.sectionKey = sectionKey;
     }
-    
+
     public Set<Tab> getTabs() {
         return tabs;
     }
@@ -540,7 +556,7 @@ public class EntityForm {
     public void setDynamicForms(Map<String, EntityForm> dynamicForms) {
         this.dynamicForms = dynamicForms;
     }
-    
+
     public Map<String, DynamicEntityFormInfo> getDynamicFormInfos() {
         return dynamicFormInfos;
     }
@@ -589,20 +605,20 @@ public class EntityForm {
             sb.append(section.getSectionIdentifier());
             sb.append("--");
             sb.append(section.getSectionId());
-            if (index < sectionCrumbs.size()-1) {
+            if (index < sectionCrumbs.size() - 1) {
                 sb.append(",");
             }
             index++;
         }
         return sb.toString();
     }
-    
+
     public Map<String, Object> getAttributes() {
         return attributes;
     }
-    
+
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
     }
-    
+
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/processor/ErrorsProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/processor/ErrorsProcessor.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.openadmin.web.processor;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.util.StringUtil;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.openadmin.web.form.entity.DynamicEntityFormInfo;
 import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
@@ -119,8 +120,8 @@ public class ErrorsProcessor extends AbstractAttrProcessor {
                         }
                     } else {
                         //this is the code that is executed when a Translations add action contains errors
-                        //TODO: research what else can be sent from this stage
-                        String fieldName = extractFieldName(err);
+                        //this branch of the code just puts a placeholder "tabErrors", to avoid errprProcessor parsing errors, and
+                        //avoids checking on tabs, fieldGroups or fields (which for translations are empty), thus skipping any warning
                         Map<String, Object> localVariables = new HashMap<String, Object>();
                         localVariables.put("tabErrors", tabErrors);
                         return ProcessorResult.setLocalVariables(localVariables);
@@ -153,7 +154,7 @@ public class ErrorsProcessor extends AbstractAttrProcessor {
 
     private String extractFieldName(FieldError err) {
         String fieldExpression = err.getField();
-        String fieldName = fieldExpression.substring(fieldExpression.indexOf('[') + 1, fieldExpression.lastIndexOf(']'));
+        String fieldName = StringUtil.extractFieldNameFromExpression(fieldExpression);
         return fieldName;
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormAction.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormAction.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.openadmin.web.service;
+
+import org.broadleafcommerce.common.BroadleafEnumerationType;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The type of action the translation form is built for 
+ * Created by gdiaz.
+ */
+public class TranslationFormAction implements Serializable, BroadleafEnumerationType {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Map<String, TranslationFormAction> TYPES = new LinkedHashMap<String, TranslationFormAction>();
+
+    public static final TranslationFormAction ADD = new TranslationFormAction("ADD", "Translation Form - Add");
+    public static final TranslationFormAction UPDATE = new TranslationFormAction("UPDATE", "Translation Form - Update");
+    public static final TranslationFormAction OTHER = new TranslationFormAction("OTHER", "Translation Form - Other actions");
+
+    public static TranslationFormAction getInstance(final String type) {
+        return TYPES.get(type);
+    }
+
+    private String type;
+    private String friendlyType;
+
+    public TranslationFormAction() {
+        //do nothing
+    }
+
+    public TranslationFormAction(final String type, final String friendlyType) {
+        this.friendlyType = friendlyType;
+        setType(type);
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String getFriendlyType() {
+        return friendlyType;
+    }
+
+    private void setType(final String type) {
+        this.type = type;
+        if (!TYPES.containsKey(type)) {
+            TYPES.put(type, this);
+        } else {
+            throw new IllegalArgumentException("Cannot add the type: (" + type + "). It already exists as a type via " + getInstance(type).getClass().getName());
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!getClass().isAssignableFrom(obj.getClass()))
+            return false;
+        TranslationFormAction other = (TranslationFormAction) obj;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        return true;
+    }
+
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormBuilderService.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormBuilderService.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.web.service;
 
 import org.broadleafcommerce.common.i18n.domain.Translation;
@@ -41,9 +42,9 @@ public interface TranslationFormBuilderService {
      * Builds an EntityForm used to create or edit a translation value
      * 
      * @param formProperties
+     * @param action (values "add", "update" or "other")
      * @return the entity form
      */
-    public EntityForm buildTranslationForm(TranslationForm formProperties);
-
+    public EntityForm buildTranslationForm(TranslationForm formProperties, TranslationFormAction action);
 
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/TranslationFormBuilderServiceImpl.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.web.service;
 
 import org.apache.commons.lang3.StringUtils;
@@ -44,36 +45,35 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
-
 @Service("blTranslationFormBuilderService")
 public class TranslationFormBuilderServiceImpl implements TranslationFormBuilderService {
-    
+
     @Resource(name = "blFormBuilderService")
     protected FormBuilderService formBuilderService;
-    
+
     @Resource(name = "blLocaleService")
     protected LocaleService localeService;
-    
+
     @Override
     public ListGrid buildListGrid(List<Translation> translations, boolean isRte) {
         // Set up the two header fields we're interested in for the translations list grid
         List<Field> headerFields = new ArrayList<Field>();
         headerFields.add(new Field()
-            .withName("localeCode")
-            .withFriendlyName("Translation_localeCode")
-            .withOrder(0));
-        
+                .withName("localeCode")
+                .withFriendlyName("Translation_localeCode")
+                .withOrder(0));
+
         headerFields.add(new Field()
-            .withName("translatedValue")
-            .withFriendlyName("Translation_translatedValue")
-            .withOrder(10));
-        
+                .withName("translatedValue")
+                .withFriendlyName("Translation_translatedValue")
+                .withOrder(10));
+
         // Create the list grid and set its basic properties
         ListGrid listGrid = new ListGrid();
         listGrid.getHeaderFields().addAll(headerFields);
         listGrid.setListGridType(ListGrid.Type.TRANSLATION);
         listGrid.setCanFilterAndSort(false);
-        
+
         // Allow add/update/remove actions, but provisioned especially for translation. Because of this, we will clone
         // the default actions so that we may change the class
         ListGridAction addAction = DefaultListGridActions.ADD.clone();
@@ -85,97 +85,104 @@ public class TranslationFormBuilderServiceImpl implements TranslationFormBuilder
         listGrid.addToolbarAction(addAction);
         listGrid.addRowAction(removeAction);
         listGrid.addRowAction(updateAction);
-        
+
         //TODO rework code elsewhere so these don't have to be added
         listGrid.setSubCollectionFieldName("translation");
         listGrid.setSectionKey("translation");
-        
+
         // Create records for each of the entries in the translations list
         for (Translation t : translations) {
             ListGridRecord record = new ListGridRecord();
             record.setListGrid(listGrid);
             record.setId(String.valueOf(t.getId()));
-            
+
             Locale locale = localeService.findLocaleByCode(t.getLocaleCode());
-            
+
             record.getFields().add(new Field()
-                .withName("localeCode")
-                .withFriendlyName("Translation_localeCode")
-                .withOrder(0)
-                .withValue(locale.getLocaleCode())
-                .withDisplayValue(locale.getFriendlyName()));
-            
+                    .withName("localeCode")
+                    .withFriendlyName("Translation_localeCode")
+                    .withOrder(0)
+                    .withValue(locale.getLocaleCode())
+                    .withDisplayValue(locale.getFriendlyName()));
+
             record.getFields().add(new Field()
-                .withName("translatedValue")
-                .withFriendlyName("Translation_translatedValue")
-                .withOrder(10)
-                .withValue(t.getTranslatedValue())
-                .withDisplayValue(isRte ? getLocalizedEditToViewMessage() : t.getTranslatedValue()));
-            
+                    .withName("translatedValue")
+                    .withFriendlyName("Translation_translatedValue")
+                    .withOrder(10)
+                    .withValue(t.getTranslatedValue())
+                    .withDisplayValue(isRte ? getLocalizedEditToViewMessage() : t.getTranslatedValue()));
+
             listGrid.getRecords().add(record);
         }
-        
+
         return listGrid;
     }
-    
+
     @Override
-    public EntityForm buildTranslationForm(TranslationForm formProperties) {
+    public EntityForm buildTranslationForm(TranslationForm formProperties, TranslationFormAction action) {
         EntityForm ef = new EntityForm();
-        
+
         EntityFormAction saveAction = DefaultEntityFormActions.SAVE.clone();
         saveAction.setButtonClass("translation-submit-button");
         ef.addAction(saveAction);
-        
-        ef.addField(getLocaleField(formProperties.getLocaleCode()));
-        
-        ef.addField(new Field()
-            .withName("translatedValue")
-            .withFieldType(formProperties.getIsRte() ? "html" : "string")
-            .withFriendlyName("Translation_translatedValue")
-            .withValue(formProperties.getTranslatedValue())
-            .withOrder(10));
-        
+
+        ComboField comboField = getLocaleField(formProperties.getLocaleCode());
+        ef.addField(comboField);
+
+        Field translatedValueValueField = new Field()
+                .withName("translatedValue")
+                .withFieldType(formProperties.getIsRte() ? "html" : "string")
+                .withFriendlyName("Translation_translatedValue")
+                .withValue(formProperties.getTranslatedValue())
+                .withOrder(10);
+
+        ef.addField(translatedValueValueField);
+
+        if (action.equals(TranslationFormAction.UPDATE)) {
+            comboField.setReadOnly(true);
+        }
+
         ef.addHiddenField(new Field()
-            .withName("ceilingEntity")
-            .withValue(formProperties.getCeilingEntity()));
-        
+                .withName("ceilingEntity")
+                .withValue(formProperties.getCeilingEntity()));
+
         ef.addHiddenField(new Field()
-            .withName("entityId")
-            .withValue(formProperties.getEntityId()));
-        
+                .withName("entityId")
+                .withValue(formProperties.getEntityId()));
+
         ef.addHiddenField(new Field()
-            .withName("propertyName")
-            .withValue(formProperties.getPropertyName()));
-        
+                .withName("propertyName")
+                .withValue(formProperties.getPropertyName()));
+
         ef.addHiddenField(new Field()
-            .withName("isRte")
-            .withValue(String.valueOf(formProperties.getIsRte())));
-        
+                .withName("isRte")
+                .withValue(String.valueOf(formProperties.getIsRte())));
+
         return ef;
     }
-    
+
     protected ComboField getLocaleField(String value) {
         ComboField f = new ComboField();
         f.setName("localeCode");
         f.setFriendlyName("Translation_localeCode");
         f.setFieldType(SupportedFieldType.EXPLICIT_ENUMERATION.toString());
         f.setOrder(0);
-        
+
         if (StringUtils.isNotBlank(value)) {
             f.setValue(value);
         }
-        
+
         List<Locale> locales = localeService.findAllLocales();
-        
+
         Map<String, String> localeMap = new HashMap<String, String>();
         for (Locale l : locales) {
             localeMap.put(l.getLocaleCode(), l.getFriendlyName());
         }
         f.setOptions(localeMap);
-        
+
         return f;
     }
-    
+
     protected String getLocalizedEditToViewMessage() {
         BroadleafRequestContext ctx = BroadleafRequestContext.getBroadleafRequestContext();
         if (ctx != null && ctx.getMessageSource() != null) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/bl-open-admin-contentCreator-applicationContext.xml
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/bl-open-admin-contentCreator-applicationContext.xml
@@ -79,6 +79,7 @@
                 <ref bean="blAdminUserCustomPersistenceHandler" />
                 <ref bean="blAdminPermissionCustomPersistenceHandler" />
                 <ref bean="blSystemPropertyCustomPersistenceHandler" />
+                <ref bean="blTranslationCustomPersistenceHandler" />
             </list>
         </property>
     </bean>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -303,3 +303,5 @@ PasswordChange_success=Password change successful
 errorDuplicateSandBoxName=The SandBox name must be unique
 
 constraintViolationError=Could not remove because other objects relate
+
+translation.record.exists.for.locale=Another translation already exists for this locale

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
@@ -66,7 +66,7 @@ $(document).ready(function() {
 						//"name" and "value" are the field name and the internationalized error message, respectively
 						//now, build the jQuery search string to pinpoint the field's box, and add the error message right after the label
 						var searchString = ".field-box[id=field-" + name + "]";
-						$form.find(searchString).find(".field-label").append("<span class='error'>" + value + "</span>");
+						$form.find(searchString).find(".field-label").append("<span class='fieldError error'>" + value + "</span>");
 					}
 				});
 			}

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
@@ -58,10 +58,15 @@ $(document).ready(function() {
 			}else{
 				var errorMapString = $(data).find(".modal-body").find("input[name=jsErrorMapString]").attr("value");
 				var errorMap = JSON.parse(errorMapString);
+				//clear all previous error spans
+				$form.find("span.error").remove();
 				errorMap.forEach(function(item){
 					for (var name in item){
 						var value = item[name];
-                        console.log('field ' + name + ' has error ' + value);						
+						//"name" and "value" are the field name and the internationalized error message, respectively
+						//now, build the jQuery search string to pinpoint the field's box, and add the error message right after the label
+						var searchString = ".field-box[id=field-" + name + "]";
+						$form.find(searchString).find(".field-label").append("<span class='error'>" + value + "</span>");
 					}
 				});
 			}

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
@@ -49,8 +49,13 @@ $(document).ready(function() {
 			type: "POST",
 			data: $form.serialize()
 		}, function(data) {
-            BLCAdmin.listGrid.replaceRelatedListGrid($(data));
-            BLCAdmin.hideCurrentModal();
+			//prevenSubmit is a hidden field whose value is sent from the translations controller, when there are errors
+			//"data" contains the new copy of the form, validated 
+			var preventSubmit = $(data).find(".modal-body").find("input[name=preventSubmit]").attr("value");
+			if (!preventSubmit){
+              BLCAdmin.listGrid.replaceRelatedListGrid($(data));
+              BLCAdmin.hideCurrentModal();
+			}
 	    });
 		
 		return false;

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/translations.js
@@ -55,6 +55,15 @@ $(document).ready(function() {
 			if (!preventSubmit){
               BLCAdmin.listGrid.replaceRelatedListGrid($(data));
               BLCAdmin.hideCurrentModal();
+			}else{
+				var errorMapString = $(data).find(".modal-body").find("input[name=jsErrorMapString]").attr("value");
+				var errorMap = JSON.parse(errorMapString);
+				errorMap.forEach(function(item){
+					for (var name in item){
+						var value = item[name];
+                        console.log('field ' + name + ' has error ' + value);						
+					}
+				});
 			}
 	    });
 		

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
@@ -25,8 +25,7 @@
     <input type="hidden" th:field="*{sectionCrumbs}"  />
     <input type="hidden" th:field="*{mainEntityName}" />
     <input type="hidden" name="preventSubmit" th:value="*{preventSubmit}" />
-
-
+    <input type="hidden" name="jsErrorMapString" th:value="*{jsErrorMap}" />
 
     <div th:unless="${hideTopLevelErrors}" class="errors" blc_admin:errors="*{*}" th:if="${#fields.hasErrors('*')}">
           <div class="tabError" th:each="tab : ${tabErrors.entrySet()}" th:inline="text">

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
@@ -24,9 +24,12 @@
     <input type="hidden" th:field="*{id}" />
     <input type="hidden" th:field="*{sectionCrumbs}"  />
     <input type="hidden" th:field="*{mainEntityName}" />
+    <input type="hidden" name="preventSubmit" th:value="*{preventSubmit}" />
+
+
 
     <div th:unless="${hideTopLevelErrors}" class="errors" blc_admin:errors="*{*}" th:if="${#fields.hasErrors('*')}">
-        <div class="tabError" th:each="tab : ${tabErrors.entrySet()}" th:inline="text">
+          <div class="tabError" th:each="tab : ${tabErrors.entrySet()}" th:inline="text">
             <b>[[${tab.key}]]</b>
             <span th:if="${#lists.size(field.value) &gt; 1}" class="fieldError error" th:each="field : ${tab.value.entrySet()}">
                 <span th:remove="tag" th:text="#{${field.key}}"></span>: <span th:each="message : ${field.value}">[[#{__${message}__}]]</span>
@@ -35,7 +38,7 @@
                 <span th:remove="tag" th:text="#{${field.key}}"></span>: <span th:remove="tag" th:text="#{${field.value.get(0)}}"></span>
             </span>
             <br />
-        </div>
+          </div>
     </div>
 
     <div class="tabs-container" th:if="${renderTabs}">
@@ -93,9 +96,9 @@
             </div>
 
             <div th:each="collectionListGrid : ${tab.listGrids}" class="listgrid-container" th:id="${collectionListGrid.subCollectionFieldName}">
-                <label th:text="#{${collectionListGrid.friendlyName}}" />
-                <div th:include="components/listGridToolbar" th:with="listGrid=${collectionListGrid}" th:remove="tag" />
-                <div th:include="components/listGrid" th:with="listGrid=${collectionListGrid}" th:remove="tag" />
+              <label th:text="#{${collectionListGrid.friendlyName}}" />
+              <div th:include="components/listGridToolbar" th:with="listGrid=${collectionListGrid}" th:remove="tag" />
+              <div th:include="components/listGrid" th:with="listGrid=${collectionListGrid}" th:remove="tag" />
             </div>
 
         </li>

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/Translation.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/Translation.java
@@ -22,14 +22,16 @@ package org.broadleafcommerce.common.i18n.domain;
 
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 
+import java.io.Serializable;
+
 /**
  * This domain object represents a translated value for a given property on an entity for a specific locale.
  * 
  * @author Andre Azzolini (apazzolini)
  * @see TranslatedEntity
  */
-public interface Translation extends MultiTenantCloneable<Translation> {
-    
+public interface Translation extends MultiTenantCloneable<Translation>, Serializable {
+
     public Long getId();
 
     public void setId(Long id);

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslationImpl.java
@@ -28,15 +28,25 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Table;
+import org.hibernate.annotations.Type;
 
-import javax.persistence.*;
-import javax.persistence.Entity;
 import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Lob;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -45,10 +55,10 @@ import java.io.Serializable;
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "TranslationImpl_baseTranslation")
 //multi-column indexes don't appear to get exported correctly when declared at the field level, so declaring here as a workaround
 @Table(appliesTo = "BLC_TRANSLATION", indexes = {
-        @Index(name = "TRANSLATION_INDEX", columnNames = {"ENTITY_TYPE","ENTITY_ID","FIELD_NAME","LOCALE_CODE"})
+        @Index(name = "TRANSLATION_INDEX", columnNames = { "ENTITY_TYPE", "ENTITY_ID", "FIELD_NAME", "LOCALE_CODE" })
 })
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
@@ -59,13 +69,12 @@ public class TranslationImpl implements Serializable, Translation {
     @Id
     @GeneratedValue(generator = "TranslationId")
     @GenericGenerator(
-        name = "TranslationId",
-        strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-                @Parameter(name = "segment_value", value = "TranslationImpl"),
-                @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.i18n.domain.TranslationImpl")
-        }
-    )
+            name = "TranslationId",
+            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            parameters = {
+                    @Parameter(name = "segment_value", value = "TranslationImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.i18n.domain.TranslationImpl")
+            })
     @Column(name = "TRANSLATION_ID")
     protected Long id;
 
@@ -88,7 +97,7 @@ public class TranslationImpl implements Serializable, Translation {
     @Column(name = "TRANSLATED_VALUE", length = Integer.MAX_VALUE - 1)
     @Lob
     @Type(type = "org.hibernate.type.StringClobType")
-    @AdminPresentation(friendlyName = "TranslationImpl_TranslatedValue", prominent = true)
+    @AdminPresentation(friendlyName = "TranslationImpl_TranslatedValue", prominent = true, requiredOverride = RequiredOverride.REQUIRED)
     protected String translatedValue;
 
     /* ************************ */
@@ -108,7 +117,7 @@ public class TranslationImpl implements Serializable, Translation {
     /* ************************** */
     /* STANDARD GETTERS / SETTERS */
     /* ************************** */
-    
+
     @Override
     public Long getId() {
         return id;
@@ -118,7 +127,7 @@ public class TranslationImpl implements Serializable, Translation {
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     @Override
     public String getEntityId() {
         return entityId;

--- a/common/src/main/java/org/broadleafcommerce/common/util/StringUtil.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/StringUtil.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.common.util;
 
 import org.codehaus.jettison.json.JSONObject;
@@ -57,12 +58,12 @@ public class StringUtil {
         calc.enter(myChecksum);
         return calc.getStandardDeviation();
     }
-    
+
     /**
      * Protect against HTTP Response Splitting
      * @return
      */
-    public static String cleanseUrlString(String input){
+    public static String cleanseUrlString(String input) {
         return removeSpecialCharacters(decodeUrl(input));
     }
 
@@ -81,6 +82,16 @@ public class StringUtil {
             input = input.replaceAll("[ \\r\\n]", "");
         }
         return input;
+    }
+
+    /**
+     * given a string with the format "fields[someFieldName].value" (very common in error validation), returns
+     * only "someFieldName
+     * @param expression
+     * @return
+     */
+    public static String extractFieldNameFromExpression(String expression) {
+        return expression.substring(expression.indexOf('[') + 1, expression.lastIndexOf(']'));
     }
 
     public static String getMapAsJson(Map<String, Object> objectMap) {


### PR DESCRIPTION
This PR would avoid entity field translations with unwanted, possibly overlapping results. 
The way it achieves it, is by disabling the internationalization submenu, disabling the locale combo on edition, and adding error handling to the ad-hoc Translations form  (which had none at all).

The originating QA issue was https://github.com/BroadleafCommerce/QA/issues/622

This closes issue #1464, which was created to encompass BLC work on this. 