### PR TITLE
Site Map Generator Configurations set up to work with Multi-Tenant

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapGeneratorConfigurationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapGeneratorConfigurationImpl.java
@@ -20,6 +20,9 @@
 
 package org.broadleafcommerce.common.sitemap.domain;
 
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -48,6 +51,9 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 //@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blConfigurationModuleElements")
 @AdminPresentationClass(friendlyName = "SiteMapGeneratorConfigurationImpl")
+@DirectCopyTransform({
+    @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
+})
 public class SiteMapGeneratorConfigurationImpl implements SiteMapGeneratorConfiguration {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes BroadleafCommerce/QA#559

This fix adds the Site Descriptors for Sitemap Generator Configurations so that the Sitemap generated sitemap.gz.xml file now is site specific and will utilize the correct Category pages specific to that site.
