### PR TITLE
1485 - Ensure that startIndex and maxIndex are not sent as FilterAndSortCriteria during admin pagination

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -442,8 +442,10 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
         
         List<FilterAndSortCriteria> result = new ArrayList<FilterAndSortCriteria>();
         for (Entry<String, List<String>> entry : requestParams.entrySet()) {
-            if (!entry.getKey().equals(FilterAndSortCriteria.SORT_PROPERTY_PARAMETER) &&
-                    !entry.getKey().equals(FilterAndSortCriteria.SORT_DIRECTION_PARAMETER)) {
+            if (!entry.getKey().equals(FilterAndSortCriteria.SORT_PROPERTY_PARAMETER)
+                    && !entry.getKey().equals(FilterAndSortCriteria.SORT_DIRECTION_PARAMETER)
+                    && !entry.getKey().equals(FilterAndSortCriteria.MAX_INDEX_PARAMETER)
+                    && !entry.getKey().equals(FilterAndSortCriteria.START_INDEX_PARAMETER)) {
                 List<String> values = entry.getValue();
                 List<String> collapsedValues = new ArrayList<String>();
                 for (String value : values) {
@@ -573,6 +575,7 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
     /**
      * @deprecated in favor of {@link #attachSectionSpecificInfo(PersistencePackageRequest, Map)}
      */
+    @Deprecated
     protected void attachSectionSpecificInfo(PersistencePackageRequest ppr) {
         
     }
@@ -662,6 +665,7 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
     /**
      * @deprecated in favor of {@link #getSectionPersistencePackageRequest(String, List, Map)}
      */
+    @Deprecated
     protected PersistencePackageRequest getSectionPersistencePackageRequest(String sectionClassName, List<SectionCrumb> sectionCrumbs) {
         return getSectionPersistencePackageRequest(sectionClassName, sectionCrumbs, null);
     }
@@ -691,6 +695,7 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
     /**
      * @deprecated in favor of {@link #getSectionPersistencePackageRequest(String, MultiValueMap, List, Map)}
      */
+    @Deprecated
     protected PersistencePackageRequest getSectionPersistencePackageRequest(String sectionClassName, 
             MultiValueMap<String, String> requestParams, List<SectionCrumb> sectionCrumbs) {
         return getSectionPersistencePackageRequest(sectionClassName, requestParams, sectionCrumbs, null);


### PR DESCRIPTION
Fixes #1485

The admin can interpret these as actual properties and they shouldn't be since they are handled differently.

Child issue of BroadleafCommerce/QA#698