### PR TITLE
When removing a resource, also delete any locale cached versions of the file

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/file/service/BroadleafFileServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/file/service/BroadleafFileServiceImpl.java
@@ -314,11 +314,7 @@ public class BroadleafFileServiceImpl implements BroadleafFileService {
             }
         });
         for (File cache : children) {
-            try {
-                cache.delete();
-            } catch (Exception e) {
-                LOG.warn(String.format("Unable to delete an asset cache file from the local filesystem (%s)", cache.getAbsolutePath()), e);
-            }
+            FileUtils.deleteQuietly(cache);
         }
     }
 


### PR DESCRIPTION
Repo specific issue is #1431. 

This pull request exposes additional functionality to the remove method so that any locally cached modifications to a file are cleaned up as well upon a delete (thumbnails, etc...)