### PR TITLE
additions to SearchFacetGrid fields, and "order" member to Filter&Sort and FilterMappings

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/bl-admin-applicationContext.xml
+++ b/admin/broadleaf-admin-module/src/main/resources/bl-admin-applicationContext.xml
@@ -45,6 +45,7 @@
                 <ref bean="blSkuCustomPersistenceHandler" />
                 <ref bean="blISOCountryPersistenceHandler"/>
                 <ref bean="blSkuBundleItemCustomPersistenceHandler" />
+                <ref bean="blSearchFacetRangeCustomPersistenceHandler" />
             </list>
         </property>
     </bean>

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/CriteriaTransferObject.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/CriteriaTransferObject.java
@@ -24,7 +24,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.criteri
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +39,7 @@ public class CriteriaTransferObject {
     private Integer firstResult;
     private Integer maxResults;
 
-    private Map<String, FilterAndSortCriteria> criteriaMap = new LinkedHashMap<String, FilterAndSortCriteria>();
+    private Map<String, FilterAndSortCriteria> criteriaMap = new HashMap<String, FilterAndSortCriteria>();
 
     private List<FilterMapping> additionalFilterMappings = new ArrayList<FilterMapping>();
     private List<FilterMapping> nonCountAdditionalFilterMappings = new ArrayList<FilterMapping>();

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/CriteriaTransferObject.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/CriteriaTransferObject.java
@@ -17,14 +17,14 @@
  * limitations under the License.
  * #L%
  */
-package org.broadleafcommerce.openadmin.dto;
 
+package org.broadleafcommerce.openadmin.dto;
 
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FilterMapping;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,12 +38,12 @@ public class CriteriaTransferObject {
 
     private Integer firstResult;
     private Integer maxResults;
-    
-    private Map<String, FilterAndSortCriteria> criteriaMap = new HashMap<String, FilterAndSortCriteria>();
+
+    private Map<String, FilterAndSortCriteria> criteriaMap = new LinkedHashMap<String, FilterAndSortCriteria>();
 
     private List<FilterMapping> additionalFilterMappings = new ArrayList<FilterMapping>();
     private List<FilterMapping> nonCountAdditionalFilterMappings = new ArrayList<FilterMapping>();
-    
+
     /**
      * The index of records in the database for which a fetch will start.
      *
@@ -52,7 +52,7 @@ public class CriteriaTransferObject {
     public Integer getFirstResult() {
         return firstResult;
     }
-    
+
     /**
      * The index of records in the datastore for which a fetch will start.
      *
@@ -61,7 +61,7 @@ public class CriteriaTransferObject {
     public void setFirstResult(Integer firstResult) {
         this.firstResult = firstResult;
     }
-    
+
     /**
      * The max number of records from the datastore to return.
      *
@@ -70,7 +70,7 @@ public class CriteriaTransferObject {
     public Integer getMaxResults() {
         return maxResults;
     }
-    
+
     /**
      * The max number of records from the datastore to return.
      *
@@ -79,7 +79,7 @@ public class CriteriaTransferObject {
     public void setMaxResults(Integer maxResults) {
         this.maxResults = maxResults;
     }
-    
+
     /**
      * Add a {@link FilterAndSortCriteria} instance. Contains information about which records are retrieved
      * and in what direction they're sorted.
@@ -89,7 +89,7 @@ public class CriteriaTransferObject {
     public void add(FilterAndSortCriteria criteria) {
         criteriaMap.put(criteria.getPropertyId(), criteria);
     }
-    
+
     /**
      * Add all {@link FilterAndSortCriteria} instances. Contains information about which records are retrieved
      * and in what direction they're sorted.
@@ -110,7 +110,7 @@ public class CriteriaTransferObject {
     public Map<String, FilterAndSortCriteria> getCriteriaMap() {
         return criteriaMap;
     }
-    
+
     public void setCriteriaMap(Map<String, FilterAndSortCriteria> criteriaMap) {
         this.criteriaMap = criteriaMap;
     }
@@ -138,7 +138,7 @@ public class CriteriaTransferObject {
     public List<FilterMapping> getAdditionalFilterMappings() {
         return additionalFilterMappings;
     }
-    
+
     public void setAdditionalFilterMappings(List<FilterMapping> additionalFilterMappings) {
         this.additionalFilterMappings = additionalFilterMappings;
     }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.dto;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -36,38 +37,74 @@ public class FilterAndSortCriteria {
     public static final String SORT_DIRECTION_PARAMETER = "sortDirection";
     public static final String START_INDEX_PARAMETER = "startIndex";
     public static final String MAX_INDEX_PARAMETER = "maxIndex";
-    
+
     public static final String IS_NULL_FILTER_VALUE = new String("BLC_SPECIAL_FILTER_VALUE:NULL").intern();
     public static final String IS_NOT_NULL_FILTER_VALUE = new String("BLC_SPECIAL_FILTER_VALUE:NOT_NULL").intern();
 
     protected String propertyId;
     protected List<String> filterValues = new ArrayList<String>();
     protected RestrictionType restrictionType;
+    protected int order;
 
     protected SortDirection sortDirection;
 
+    public FilterAndSortCriteria(String propertyId, int order) {
+        this.propertyId = propertyId;
+        this.order = order;
+    }
+
     public FilterAndSortCriteria(String propertyId) {
+        this.order = 0;
         this.propertyId = propertyId;
     }
-    
+
     public FilterAndSortCriteria(String propertyId, String filterValue) {
         this.propertyId = propertyId;
+        this.order = 0;
         setFilterValue(filterValue);
     }
-    
-    public FilterAndSortCriteria(String propertyId, List<String> filterValues) {
+
+    public FilterAndSortCriteria(String propertyId, String filterValue, int order) {
+        this.propertyId = propertyId;
+        this.order = order;
+        setFilterValue(filterValue);
+    }
+
+    public FilterAndSortCriteria(String propertyId, List<String> filterValues, int order) {
         setPropertyId(propertyId);
+        this.order = order;
         setFilterValues(filterValues);
     }
-    
-    public FilterAndSortCriteria(String propertyId, List<String> filterValues, SortDirection sortDirection) {
+
+    public FilterAndSortCriteria(String propertyId, List<String> filterValues) {
+        setPropertyId(propertyId);
+        this.order = 0;
+        setFilterValues(filterValues);
+    }
+
+    public FilterAndSortCriteria(String propertyId, List<String> filterValues, SortDirection sortDirection, int order) {
+        this.order = order;
         setPropertyId(propertyId);
         setFilterValues(filterValues);
         setSortDirection(sortDirection);
     }
-    
+
+    public FilterAndSortCriteria(String propertyId, List<String> filterValues, SortDirection sortDirection) {
+        this.order = 0;
+        setPropertyId(propertyId);
+        setFilterValues(filterValues);
+        setSortDirection(sortDirection);
+    }
+
+    public FilterAndSortCriteria(String propertyId, String[] filterValues, int order) {
+        this.propertyId = propertyId;
+        this.order = order;
+        setFilterValues(Arrays.asList(filterValues));
+    }
+
     public FilterAndSortCriteria(String propertyId, String[] filterValues) {
         this.propertyId = propertyId;
+        this.order = 0;
         setFilterValues(Arrays.asList(filterValues));
     }
 
@@ -143,6 +180,7 @@ public class FilterAndSortCriteria {
 
     protected TypedPredicate<String> getPredicateForSpecialValues(final boolean inclusive) {
         return new TypedPredicate<String>() {
+
             @Override
             public boolean eval(String value) {
                 // Note that this static String is the result of a call to String.intern(). This means that we are
@@ -155,6 +193,14 @@ public class FilterAndSortCriteria {
                 }
             }
         };
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
     }
 
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
@@ -27,6 +27,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.criteri
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 public class FilterAndSortCriteria {
@@ -201,6 +202,17 @@ public class FilterAndSortCriteria {
 
     public void setOrder(int order) {
         this.order = order;
+    }
+
+    public static class ComparatorByOrder implements Comparator<FilterAndSortCriteria> {
+
+        @Override
+        public int compare(FilterAndSortCriteria o1, FilterAndSortCriteria o2) {
+            Integer firstValue = o1.getOrder();
+            Integer secondValue = o2.getOrder();
+            return firstValue.compareTo(secondValue);
+        }
+
     }
 
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/handler/AdminPermissionCustomPersistenceHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/handler/AdminPermissionCustomPersistenceHandler.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.server.security.handler;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -62,7 +63,7 @@ public class AdminPermissionCustomPersistenceHandler extends CustomPersistenceHa
     public Boolean canHandleUpdate(PersistencePackage persistencePackage) {
         return canHandleAdd(persistencePackage);
     }
-    
+
     @Override
     public Boolean canHandleFetch(PersistencePackage persistencePackage) {
         String ceilingEntityFullyQualifiedClassname = persistencePackage.getCeilingEntityFullyQualifiedClassname();
@@ -93,7 +94,7 @@ public class AdminPermissionCustomPersistenceHandler extends CustomPersistenceHa
     }
 
     protected Entity checkPermissionName(PersistencePackage persistencePackage) throws ServiceException {
-        Entity entity  = persistencePackage.getEntity();
+        Entity entity = persistencePackage.getEntity();
         Property prop = entity.findProperty("name");
         String name = prop.getValue();
         name = name.toUpperCase();
@@ -138,14 +139,14 @@ public class AdminPermissionCustomPersistenceHandler extends CustomPersistenceHa
 
         PersistenceModule myModule = helper.getCompatibleModule(persistencePackage.getPersistencePerspective().getOperationTypes().getFetchType());
         DynamicResultSet results = myModule.fetch(persistencePackage, cto);
-        
+
         return results;
     }
-    
+
     protected void addFriendlyRestriction(CriteriaTransferObject cto) {
-        cto.add(new FilterAndSortCriteria("isFriendly", "true"));
+        cto.add(new FilterAndSortCriteria("isFriendly", "true", cto.getCriteriaMap().size()));
     }
-    
+
     protected void addDefaultSort(CriteriaTransferObject cto) {
         boolean userSort = false;
         for (FilterAndSortCriteria fasc : cto.getCriteriaMap().values()) {
@@ -163,5 +164,5 @@ public class AdminPermissionCustomPersistenceHandler extends CustomPersistenceHa
             descriptionSort.setSortAscending(true);
         }
     }
-    
+
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
 import org.apache.commons.beanutils.PropertyUtils;
@@ -91,6 +92,9 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -110,6 +114,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -126,7 +131,7 @@ import javax.annotation.Resource;
 @Component("blBasicPersistenceModule")
 @Scope("prototype")
 public class BasicPersistenceModule implements PersistenceModule, RecordHelper, ApplicationContextAware {
-    
+
     private static final Log LOG = LogFactory.getLog(BasicPersistenceModule.class);
 
     public static final String MAIN_ENTITY_NAME_PROPERTY = "MAIN_ENTITY_NAME";
@@ -138,19 +143,19 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     @Resource(name = "blEntityValidatorService")
     protected EntityValidatorService entityValidatorService;
 
-    @Resource(name="blPersistenceProviders")
+    @Resource(name = "blPersistenceProviders")
     protected List<FieldPersistenceProvider> fieldPersistenceProviders = new ArrayList<FieldPersistenceProvider>();
-    
-    @Resource(name="blPopulateValueRequestValidators")
+
+    @Resource(name = "blPopulateValueRequestValidators")
     protected List<PopulateValueRequestValidator> populateValidators;
 
-    @Resource(name= "blDefaultFieldPersistenceProvider")
+    @Resource(name = "blDefaultFieldPersistenceProvider")
     protected FieldPersistenceProvider defaultFieldPersistenceProvider;
 
-    @Resource(name="blCriteriaTranslator")
+    @Resource(name = "blCriteriaTranslator")
     protected CriteriaTranslator criteriaTranslator;
 
-    @Resource(name="blRestrictionFactory")
+    @Resource(name = "blRestrictionFactory")
     protected RestrictionFactory restrictionFactory;
 
     @Resource(name = "blBasicPersistenceModuleExtensionManager")
@@ -159,12 +164,14 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     @PostConstruct
     public void init() {
         Collections.sort(fieldPersistenceProviders, new Comparator<FieldPersistenceProvider>() {
+
             @Override
             public int compare(FieldPersistenceProvider o1, FieldPersistenceProvider o2) {
                 return Integer.compare(o1.getOrder(), o2.getOrder());
             }
         });
         Collections.sort(populateValidators, new Comparator<PopulateValueRequestValidator>() {
+
             @Override
             public int compare(PopulateValueRequestValidator o1, PopulateValueRequestValidator o2) {
                 return Integer.compare(o1.getOrder(), o2.getOrder());
@@ -186,9 +193,9 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     public FieldManager getFieldManager() {
         return persistenceManager.getDynamicEntityDao().getFieldManager();
     }
-    
+
     @Override
-    public DecimalFormat getDecimalFormatter()  {
+    public DecimalFormat getDecimalFormatter() {
         BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
         Locale locale = brc.getJavaLocale();
         DecimalFormat format = (DecimalFormat) NumberFormat.getInstance(locale);
@@ -254,13 +261,13 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     }
 
     @Override
-    public Serializable createPopulatedInstance(Serializable instance, Entity entity, 
+    public Serializable createPopulatedInstance(Serializable instance, Entity entity,
             Map<String, FieldMetadata> unfilteredProperties, Boolean setId) throws ValidationException {
         return createPopulatedInstance(instance, entity, unfilteredProperties, setId, true);
     }
 
     @Override
-    public Serializable createPopulatedInstance(Serializable instance, Entity entity, 
+    public Serializable createPopulatedInstance(Serializable instance, Entity entity,
             Map<String, FieldMetadata> unfilteredProperties, Boolean setId, Boolean validateUnsubmittedProperties) throws ValidationException {
         final Map<String, FieldMetadata> mergedProperties = filterOutCollectionMetadata(unfilteredProperties);
         FieldManager fieldManager = getFieldManager();
@@ -280,15 +287,16 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         //Order media field, map field and rule builder fields last, as they will have some validation components that depend on previous values
         Property[] sortedProperties = entity.getProperties();
         Arrays.sort(sortedProperties, new Comparator<Property>() {
+
             @Override
             public int compare(Property o1, Property o2) {
                 BasicFieldMetadata mo1 = (BasicFieldMetadata) mergedProperties.get(o1.getName());
                 BasicFieldMetadata mo2 = (BasicFieldMetadata) mergedProperties.get(o2.getName());
-                boolean isLate1 = mo1 != null && mo1.getFieldType() != null && mo1.getName() != null && (SupportedFieldType.RULE_SIMPLE==mo1.getFieldType() ||
-                        SupportedFieldType.RULE_WITH_QUANTITY==mo1.getFieldType() || SupportedFieldType.MEDIA==mo1.getFieldType() ||
+                boolean isLate1 = mo1 != null && mo1.getFieldType() != null && mo1.getName() != null && (SupportedFieldType.RULE_SIMPLE == mo1.getFieldType() ||
+                        SupportedFieldType.RULE_WITH_QUANTITY == mo1.getFieldType() || SupportedFieldType.MEDIA == mo1.getFieldType() ||
                         o1.getName().contains(FieldManager.MAPFIELDSEPARATOR));
-                boolean isLate2 = mo2 != null && mo2.getFieldType() != null && mo2.getName() != null && (SupportedFieldType.RULE_SIMPLE==mo2.getFieldType() ||
-                        SupportedFieldType.RULE_WITH_QUANTITY==mo2.getFieldType() || SupportedFieldType.MEDIA==mo2.getFieldType() ||
+                boolean isLate2 = mo2 != null && mo2.getFieldType() != null && mo2.getName() != null && (SupportedFieldType.RULE_SIMPLE == mo2.getFieldType() ||
+                        SupportedFieldType.RULE_WITH_QUANTITY == mo2.getFieldType() || SupportedFieldType.MEDIA == mo2.getFieldType() ||
                         o2.getName().contains(FieldManager.MAPFIELDSEPARATOR));
                 if (isLate1 && !isLate2) {
                     return 1;
@@ -324,7 +332,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     }
                 }
                 if (returnType == null) {
-                    throw new IllegalAccessException("Unable to determine the value type for the property ("+property.getName()+")");
+                    throw new IllegalAccessException("Unable to determine the value type for the property (" + property.getName() + ")");
                 }
                 String value = property.getValue();
                 if (metadata != null) {
@@ -342,7 +350,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                             handled = false;
                             PopulateValueRequest request = new PopulateValueRequest(setId,
                                     fieldManager, property, metadata, returnType, value, persistenceManager, this);
-                            
+
                             boolean attemptToPopulate = true;
                             for (PopulateValueRequestValidator validator : populateValidators) {
                                 PropertyValidationResult validationResult = validator.validate(request, instance);
@@ -351,7 +359,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                                     attemptToPopulate = false;
                                 }
                             }
-                            
+
                             if (attemptToPopulate) {
                                 try {
                                     boolean isBreakDetected = false;
@@ -485,7 +493,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 entity = recordEntity;
             }
             Entity entityItem = new Entity();
-            entityItem.setType(new String[]{entity.getClass().getName()});
+            entityItem.setType(new String[] { entity.getClass().getName() });
             entities[j] = entityItem;
 
             List<Property> props = new ArrayList<Property>(primaryMergedProperties.size());
@@ -493,7 +501,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             if (alternateMergedProperties != null) {
                 extractPropertiesFromPersistentEntity(alternateMergedProperties, recordEntity, props);
             }
-            
+
             // Try to add the "main name" property. Log a debug message if we can't
             try {
                 Property p = new Property();
@@ -502,10 +510,10 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 p.setValue(mainEntityName);
                 props.add(p);
             } catch (Exception e) {
-                LOG.debug(String.format("Could not execute the getMainEntityName() method for [%s]", 
+                LOG.debug(String.format("Could not execute the getMainEntityName() method for [%s]",
                         entity.getClass().getName()), e);
             }
-            
+
             // Try to add the alternate id property if available
             if (alternateMergedProperties != null) {
                 for (Entry<String, FieldMetadata> entry : alternateMergedProperties.entrySet()) {
@@ -524,7 +532,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     }
                 }
             }
-            
+
             Property[] properties = new Property[props.size()];
             properties = props.toArray(properties);
             entityItem.setProperties(properties);
@@ -587,7 +595,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     if (!proceed) {
                         continue;
                     }
-                    
+
                     boolean isFieldAccessible = true;
                     Object value = null;
                     try {
@@ -608,7 +616,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                             boolean handled = false;
                             for (FieldPersistenceProvider fieldPersistenceProvider : fieldPersistenceProviders) {
                                 FieldProviderResponse response = fieldPersistenceProvider.extractValue(
-                                        new ExtractValueRequest(props, fieldManager, metadata, value, displayVal, 
+                                        new ExtractValueRequest(props, fieldManager, metadata, value, displayVal,
                                                 persistenceManager, this, entity), propertyItem);
                                 if (FieldProviderResponse.NOT_HANDLED != response) {
                                     handled = true;
@@ -619,7 +627,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                             }
                             if (!handled) {
                                 defaultFieldPersistenceProvider.extractValue(
-                                        new ExtractValueRequest(props, fieldManager, metadata, value, displayVal, 
+                                        new ExtractValueRequest(props, fieldManager, metadata, value, displayVal,
                                                 persistenceManager, this, entity), propertyItem);
                             }
                             break checkField;
@@ -631,11 +639,11 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                             try {
                                 //try a 'get' prefixed mutator first
                                 String temp = "get" + property.substring(0, 1).toUpperCase() + property.substring(1, property.length());
-                                method = entity.getClass().getMethod(temp, new Class[]{});
+                                method = entity.getClass().getMethod(temp, new Class[] {});
                             } catch (NoSuchMethodException e) {
-                                method = entity.getClass().getMethod(property, new Class[]{});
+                                method = entity.getClass().getMethod(property, new Class[] {});
                             }
-                            value = method.invoke(entity, new String[]{});
+                            value = method.invoke(entity, new String[] {});
                             Property propertyItem = new Property();
                             propertyItem.setName(property);
                             if (props.contains(propertyItem)) {
@@ -675,14 +683,14 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             throw new PersistenceException(e);
         }
     }
-    
+
     @Override
     public String getStringValueFromGetter(Serializable instance, String propertyName)
             throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         Object value = PropertyUtils.getProperty(instance, propertyName);
         return formatValue(value);
     }
-    
+
     @Override
     public String formatValue(Object value) {
         String strVal;
@@ -717,18 +725,18 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         try {
             Class<?>[] entities = persistenceManager.getPolymorphicEntities(persistencePackage.getCeilingEntityFullyQualifiedClassname());
             Map<String, FieldMetadata> mergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                persistencePackage.getCeilingEntityFullyQualifiedClassname(),
-                entities,
-                foreignKey,
-                persistencePerspective.getAdditionalNonPersistentProperties(),
-                persistencePerspective.getAdditionalForeignKeys(),
-                MergedPropertyType.PRIMARY,
-                persistencePerspective.getPopulateToOneFields(),
-                persistencePerspective.getIncludeFields(),
-                persistencePerspective.getExcludeFields(),
-                persistencePerspective.getConfigurationKey(),
-                ""
-            );
+                    persistencePackage.getCeilingEntityFullyQualifiedClassname(),
+                    entities,
+                    foreignKey,
+                    persistencePerspective.getAdditionalNonPersistentProperties(),
+                    persistencePerspective.getAdditionalForeignKeys(),
+                    MergedPropertyType.PRIMARY,
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
+                    persistencePerspective.getExcludeFields(),
+                    persistencePerspective.getConfigurationKey(),
+                    ""
+                    );
             if (primaryKey == null) {
                 primaryKey = getPrimaryKey(entity, mergedProperties);
             }
@@ -800,13 +808,13 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         }
         for (Property property : entity.getProperties()) {
             if (property.getName().equals(idPropertyName)) {
-                switch(metaData.getSecondaryType()) {
-                case INTEGER:
-                    primaryKey = (property.getValue() == null) ? null : Long.valueOf(property.getValue());
-                    break;
-                case STRING:
-                    primaryKey = property.getValue();
-                    break;
+                switch (metaData.getSecondaryType()) {
+                    case INTEGER:
+                        primaryKey = (property.getValue() == null) ? null : Long.valueOf(property.getValue());
+                        break;
+                    case STRING:
+                        primaryKey = property.getValue();
+                        break;
                 }
                 break;
             }
@@ -819,12 +827,15 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
 
     @Override
     public List<FilterMapping> getFilterMappings(PersistencePerspective persistencePerspective,
-                                                 CriteriaTransferObject cto,
-                                                 String ceilingEntityFullyQualifiedClassname,
-                                                 Map<String, FieldMetadata> mergedUnfilteredProperties,
-                                                 RestrictionFactory customRestrictionFactory) {
+            CriteriaTransferObject cto,
+            String ceilingEntityFullyQualifiedClassname,
+            Map<String, FieldMetadata> mergedUnfilteredProperties,
+            RestrictionFactory customRestrictionFactory) {
         Map<String, FieldMetadata> mergedProperties = filterOutCollectionMetadata(mergedUnfilteredProperties);
         List<FilterMapping> filterMappings = new ArrayList<FilterMapping>();
+
+        processCtoMap(cto);
+
         for (String propertyId : cto.getCriteriaMap().keySet()) {
             if (mergedProperties.containsKey(propertyId)) {
                 boolean handled = false;
@@ -832,8 +843,8 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     FieldProviderResponse response = fieldPersistenceProvider.addSearchMapping(
                             new AddSearchMappingRequest(persistencePerspective, cto,
                                     ceilingEntityFullyQualifiedClassname, mergedProperties,
-                                    propertyId, getFieldManager(), this, this, customRestrictionFactory==null?restrictionFactory
-                                    :customRestrictionFactory), filterMappings);
+                                    propertyId, getFieldManager(), this, this, customRestrictionFactory == null ? restrictionFactory
+                                            : customRestrictionFactory), filterMappings);
                     if (FieldProviderResponse.NOT_HANDLED != response) {
                         handled = true;
                     }
@@ -845,19 +856,36 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     defaultFieldPersistenceProvider.addSearchMapping(
                             new AddSearchMappingRequest(persistencePerspective, cto,
                                     ceilingEntityFullyQualifiedClassname, mergedProperties, propertyId,
-                                    getFieldManager(), this, this, customRestrictionFactory==null?restrictionFactory
-                                                                        :customRestrictionFactory), filterMappings);
+                                    getFieldManager(), this, this, customRestrictionFactory == null ? restrictionFactory
+                                            : customRestrictionFactory), filterMappings);
                 }
             }
         }
         return filterMappings;
     }
 
+    /**
+     * rearranges the inner map of FilterAndSortCriterias of this object, sorting its values by their "order" field
+     * @param cto
+     */
+    protected void processCtoMap(CriteriaTransferObject cto) {
+        BiMap<String, FilterAndSortCriteria> bidiMap = HashBiMap.create(cto.getCriteriaMap());
+        List<FilterAndSortCriteria> sortedFsc = new ArrayList<FilterAndSortCriteria>(bidiMap.values());
+        Collections.sort(sortedFsc, new FilterAndSortCriteria.ComparatorByOrder());
+        Map<String, FilterAndSortCriteria> sortedMap = new LinkedHashMap<String, FilterAndSortCriteria>();
+        BiMap<FilterAndSortCriteria, String> inverse = bidiMap.inverse();
+        for (FilterAndSortCriteria filterAndSortCriteria : sortedFsc) {
+            String key = inverse.get(filterAndSortCriteria);
+            sortedMap.put(key, filterAndSortCriteria);
+        }
+        cto.setCriteriaMap(sortedMap);
+    }
+
     @Override
     public List<FilterMapping> getFilterMappings(PersistencePerspective persistencePerspective,
-                                                 CriteriaTransferObject cto,
-                                                 String ceilingEntityFullyQualifiedClassname,
-                                                 Map<String, FieldMetadata> mergedUnfilteredProperties) {
+            CriteriaTransferObject cto,
+            String ceilingEntityFullyQualifiedClassname,
+            Map<String, FieldMetadata> mergedUnfilteredProperties) {
         return getFilterMappings(persistencePerspective, cto, ceilingEntityFullyQualifiedClassname, mergedUnfilteredProperties, null);
     }
 
@@ -873,6 +901,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             FieldMetadata metadata = mergedProperties.get(property);
             prop.setName(property);
             Comparator<Property> comparator = new Comparator<Property>() {
+
                 @Override
                 public int compare(Property o1, Property o2) {
                     return o1.getName().compareTo(o2.getName());
@@ -906,18 +935,18 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             PersistencePerspective persistencePerspective = persistencePackage.getPersistencePerspective();
             Class<?>[] entities = persistenceManager.getPolymorphicEntities(ceilingEntityFullyQualifiedClassname);
             Map<String, FieldMetadata> mergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                ceilingEntityFullyQualifiedClassname,
-                entities,
-                (ForeignKey) persistencePerspective.getPersistencePerspectiveItems().get(PersistencePerspectiveItemType.FOREIGNKEY),
-                persistencePerspective.getAdditionalNonPersistentProperties(),
-                persistencePerspective.getAdditionalForeignKeys(),
-                MergedPropertyType.PRIMARY,
-                persistencePerspective.getPopulateToOneFields(),
-                persistencePerspective.getIncludeFields(),
-                persistencePerspective.getExcludeFields(),
-                persistencePerspective.getConfigurationKey(),
-                ""
-            );
+                    ceilingEntityFullyQualifiedClassname,
+                    entities,
+                    (ForeignKey) persistencePerspective.getPersistencePerspectiveItems().get(PersistencePerspectiveItemType.FOREIGNKEY),
+                    persistencePerspective.getAdditionalNonPersistentProperties(),
+                    persistencePerspective.getAdditionalForeignKeys(),
+                    MergedPropertyType.PRIMARY,
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
+                    persistencePerspective.getExcludeFields(),
+                    persistencePerspective.getConfigurationKey(),
+                    ""
+                    );
             allMergedProperties.put(MergedPropertyType.PRIMARY, mergedProperties);
         } catch (Exception e) {
             throw new ServiceException("Unable to fetch results for " + ceilingEntityFullyQualifiedClassname, e);
@@ -934,7 +963,6 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         EntityResult er = update(persistencePackage, null, false);
         return er.getEntity();
     }
-
 
     @Override
     public Entity add(PersistencePackage persistencePackage) throws ServiceException {
@@ -954,18 +982,18 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         try {
             Class<?>[] entities = persistenceManager.getPolymorphicEntities(persistencePackage.getCeilingEntityFullyQualifiedClassname());
             Map<String, FieldMetadata> mergedUnfilteredProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                persistencePackage.getCeilingEntityFullyQualifiedClassname(),
-                entities,
-                foreignKey,
-                persistencePerspective.getAdditionalNonPersistentProperties(),
-                persistencePerspective.getAdditionalForeignKeys(),
-                MergedPropertyType.PRIMARY,
-                persistencePerspective.getPopulateToOneFields(),
-                persistencePerspective.getIncludeFields(),
-                persistencePerspective.getExcludeFields(),
-                persistencePerspective.getConfigurationKey(),
-                ""
-            );
+                    persistencePackage.getCeilingEntityFullyQualifiedClassname(),
+                    entities,
+                    foreignKey,
+                    persistencePerspective.getAdditionalNonPersistentProperties(),
+                    persistencePerspective.getAdditionalForeignKeys(),
+                    MergedPropertyType.PRIMARY,
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
+                    persistencePerspective.getExcludeFields(),
+                    persistencePerspective.getConfigurationKey(),
+                    ""
+                    );
             Map<String, FieldMetadata> mergedProperties = filterOutCollectionMetadata(mergedUnfilteredProperties);
 
             String idProperty = null;
@@ -1023,18 +1051,18 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         try {
             Class<?>[] entities = persistenceManager.getPolymorphicEntities(persistencePackage.getCeilingEntityFullyQualifiedClassname());
             Map<String, FieldMetadata> mergedUnfilteredProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                persistencePackage.getCeilingEntityFullyQualifiedClassname(),
-                entities,
-                foreignKey,
-                persistencePerspective.getAdditionalNonPersistentProperties(),
-                persistencePerspective.getAdditionalForeignKeys(),
-                MergedPropertyType.PRIMARY,
-                persistencePerspective.getPopulateToOneFields(),
-                persistencePerspective.getIncludeFields(),
-                persistencePerspective.getExcludeFields(),
-                persistencePerspective.getConfigurationKey(),
-                ""
-            );
+                    persistencePackage.getCeilingEntityFullyQualifiedClassname(),
+                    entities,
+                    foreignKey,
+                    persistencePerspective.getAdditionalNonPersistentProperties(),
+                    persistencePerspective.getAdditionalForeignKeys(),
+                    MergedPropertyType.PRIMARY,
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
+                    persistencePerspective.getExcludeFields(),
+                    persistencePerspective.getConfigurationKey(),
+                    ""
+                    );
             Map<String, FieldMetadata> mergedProperties = filterOutCollectionMetadata(mergedUnfilteredProperties);
             Object primaryKey = getPrimaryKey(entity, mergedProperties);
             Serializable instance = persistenceManager.getDynamicEntityDao().retrieve(Class.forName(entity.getType()[0]), primaryKey);
@@ -1095,18 +1123,18 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             Class<?>[] entities = persistenceManager.getDynamicEntityDao().getAllPolymorphicEntitiesFromCeiling(Class.forName(ceilingEntityFullyQualifiedClassname));
 
             Map<String, FieldMetadata> mergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                ceilingEntityFullyQualifiedClassname,
-                entities,
-                (ForeignKey) persistencePerspective.getPersistencePerspectiveItems().get(PersistencePerspectiveItemType.FOREIGNKEY),
-                persistencePerspective.getAdditionalNonPersistentProperties(),
-                persistencePerspective.getAdditionalForeignKeys(),
-                MergedPropertyType.PRIMARY,
-                persistencePerspective.getPopulateToOneFields(),
-                persistencePerspective.getIncludeFields(),
-                persistencePerspective.getExcludeFields(),
-                persistencePerspective.getConfigurationKey(),
-                ""
-            );
+                    ceilingEntityFullyQualifiedClassname,
+                    entities,
+                    (ForeignKey) persistencePerspective.getPersistencePerspectiveItems().get(PersistencePerspectiveItemType.FOREIGNKEY),
+                    persistencePerspective.getAdditionalNonPersistentProperties(),
+                    persistencePerspective.getAdditionalForeignKeys(),
+                    MergedPropertyType.PRIMARY,
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
+                    persistencePerspective.getExcludeFields(),
+                    persistencePerspective.getConfigurationKey(),
+                    ""
+                    );
 
             return mergedProperties;
         } catch (Exception e) {
@@ -1170,7 +1198,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     @Override
     public Serializable getMaxValue(String ceilingEntity, List<FilterMapping> filterMappings, String maxField) {
         return criteriaTranslator.translateMaxQuery(persistenceManager.getDynamicEntityDao(),
-                        ceilingEntity, filterMappings, maxField).getSingleResult();
+                ceilingEntity, filterMappings, maxField).getSingleResult();
     }
 
     @Override
@@ -1189,7 +1217,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
     }
 
     @Override
-    public boolean validate(Entity entity, Serializable populatedInstance, Map<String, FieldMetadata> mergedProperties, 
+    public boolean validate(Entity entity, Serializable populatedInstance, Map<String, FieldMetadata> mergedProperties,
             boolean validateUnsubmittedProperties) {
         entityValidatorService.validate(entity, populatedInstance, mergedProperties, this, validateUnsubmittedProperties);
         return !entity.isValidationFailure();
@@ -1281,7 +1309,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         }
         for (FilterMapping mapping : filterMappings) {
             if (mapping.getSortDirection() != null) {
-                String mappingProperty = mapping.getFieldPath()==null?null:mapping.getFieldPath().getTargetProperty();
+                String mappingProperty = mapping.getFieldPath() == null ? null : mapping.getFieldPath().getTargetProperty();
                 if (StringUtils.isEmpty(mappingProperty)) {
                     mappingProperty = mapping.getFullPropertyName();
                 }
@@ -1305,7 +1333,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
         List<TQRestriction> restrictions = new ArrayList<TQRestriction>();
         for (FilterMapping mapping : filterMappings) {
             checkProperty: {
-                String mappingProperty = mapping.getFieldPath()==null?null:mapping.getFieldPath().getTargetProperty();
+                String mappingProperty = mapping.getFieldPath() == null ? null : mapping.getFieldPath().getTargetProperty();
                 if (StringUtils.isEmpty(mappingProperty)) {
                     mappingProperty = mapping.getFullPropertyName();
                 }
@@ -1381,7 +1409,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             Class<?> clazz = (Class<?>) pType.getActualTypeArguments()[1];
             Class<?>[] entities = persistenceManager.getDynamicEntityDao().getAllPolymorphicEntitiesFromCeiling(clazz);
             if (!ArrayUtils.isEmpty(entities)) {
-                returnType = entities[entities.length-1];
+                returnType = entities[entities.length - 1];
             }
         }
         return returnType;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/FilterMapping.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/FilterMapping.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.server.service.persistence.module.criteria;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -41,6 +42,12 @@ public class FilterMapping {
     protected FieldPath fieldPath;
     protected Class<?> inheritedFromClass;
     protected Boolean nullsLast = true;
+    protected int order;
+
+    public FilterMapping withOrder(int order) {
+        setOrder(order);
+        return this;
+    }
 
     public FilterMapping withFullPropertyName(String fullPropertyName) {
         setFullPropertyName(fullPropertyName);
@@ -51,7 +58,7 @@ public class FilterMapping {
         setFilterValues(filterValues);
         return this;
     }
-    
+
     public FilterMapping withDirectFilterValues(List directFilterValues) {
         setDirectFilterValues(directFilterValues);
         return this;
@@ -71,7 +78,7 @@ public class FilterMapping {
         setFieldPath(fieldPath);
         return this;
     }
-    
+
     public FilterMapping withInheritedFromClass(Class<?> inheritedFromClass) {
         setInheritedFromClass(inheritedFromClass);
         return this;
@@ -93,7 +100,7 @@ public class FilterMapping {
         if (CollectionUtils.isNotEmpty(directFilterValues)) {
             throw new IllegalArgumentException("Cannot set both filter values and direct filter values");
         }
-        
+
         List<String> parsedValues = new ArrayList<String>();
         for (String unfiltered : filterValues) {
             parsedValues.addAll(Arrays.asList(parseFilterValue(unfiltered)));
@@ -124,18 +131,18 @@ public class FilterMapping {
     public void setFieldPath(FieldPath fieldPath) {
         this.fieldPath = fieldPath;
     }
-    
+
     public List getDirectFilterValues() {
         return directFilterValues;
     }
-    
+
     public void setDirectFilterValues(List directFilterValues) {
         if (CollectionUtils.isNotEmpty(filterValues)) {
             throw new IllegalArgumentException("Cannot set both filter values and direct filter values");
         }
         this.directFilterValues = directFilterValues;
     }
-    
+
     public Class<?> getInheritedFromClass() {
         return inheritedFromClass;
     }
@@ -150,13 +157,13 @@ public class FilterMapping {
         //in this case.
         String[] vals;
         if (filterValue.contains(RANGE_SPECIFIER_REGEX)) {
-            vals = new String[]{filterValue.substring(0, filterValue.indexOf(RANGE_SPECIFIER_REGEX)),
-                filterValue.substring(filterValue.indexOf(RANGE_SPECIFIER_REGEX) + RANGE_SPECIFIER_REGEX.length(),
-                filterValue.length())};
+            vals = new String[] { filterValue.substring(0, filterValue.indexOf(RANGE_SPECIFIER_REGEX)),
+                    filterValue.substring(filterValue.indexOf(RANGE_SPECIFIER_REGEX) + RANGE_SPECIFIER_REGEX.length(),
+                            filterValue.length()) };
         } else {
-            vals = new String[]{filterValue};
+            vals = new String[] { filterValue };
         }
-        for (int j=0;j<vals.length;j++) {
+        for (int j = 0; j < vals.length; j++) {
             vals[j] = vals[j].trim();
         }
         return vals;
@@ -168,5 +175,13 @@ public class FilterMapping {
 
     public void setNullsLast(Boolean nullsLast) {
         this.nullsLast = nullsLast;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
     }
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -45,8 +46,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.criteri
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.RestrictionType;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.predicate.IsNotNullPredicateProvider;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.predicate.IsNullPredicateProvider;
-import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.extension
-        .BasicFieldPersistenceProviderExtensionManager;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.extension.BasicFieldPersistenceProviderExtensionManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.AddSearchMappingRequest;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.ExtractValueRequest;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.PopulateValueRequest;
@@ -114,9 +114,9 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                 metadata.getFieldType() == SupportedFieldType.ASSET_URL ||
                 metadata.getFieldType() == SupportedFieldType.ID) &&
                 (property == null ||
-                        !property.getName().contains(FieldManager.MAPFIELDSEPARATOR));
+                !property.getName().contains(FieldManager.MAPFIELDSEPARATOR));
     }
-    
+
     protected boolean detectAdditionalSearchTypes(FieldMetadata md, Property property) {
         if (!(md instanceof BasicFieldMetadata)) {
             return false;
@@ -135,7 +135,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
     }
 
     protected boolean canHandleSearchMapping(AddSearchMappingRequest addSearchMappingRequest,
-                                             List<FilterMapping> filterMappings) {
+            List<FilterMapping> filterMappings) {
         FieldMetadata metadata = addSearchMappingRequest.getMergedProperties().get
                 (addSearchMappingRequest.getPropertyName());
         Property property = null;
@@ -181,7 +181,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                     dirty = !StringUtils.equals(oldValue, populateValueRequest.getRequestedValue());
                     populateValueRequest.getFieldManager().setFieldValue(instance,
                             populateValueRequest.getProperty().getName(), populateValueRequest.getDataFormatProvider().
-                            getSimpleDateFormatter().parse(populateValueRequest.getRequestedValue()));
+                                    getSimpleDateFormatter().parse(populateValueRequest.getRequestedValue()));
                     break;
                 case DECIMAL:
                     if (origValue != null) {
@@ -214,14 +214,14 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                         BigDecimal val = (BigDecimal) format.parse(populateValueRequest.getRequestedValue());
                         dirty = checkDirtyState(populateValueRequest, instance, val);
                         populateValueRequest.getFieldManager()
-                            .setFieldValue(instance, populateValueRequest.getProperty().getName(), val);
+                                .setFieldValue(instance, populateValueRequest.getProperty().getName(), val);
                         format.setParseBigDecimal(true);
                     } else if (Double.class.isAssignableFrom(populateValueRequest.getReturnType())) {
                         Double val = populateValueRequest.getDataFormatProvider().getDecimalFormatter().parse(populateValueRequest.getRequestedValue()).doubleValue();
                         dirty = checkDirtyState(populateValueRequest, instance, val);
                         LOG.warn("The requested Money field is of type double and could result in a loss of precision." +
-                        		" Broadleaf recommends that the type of all Money fields are 'BigDecimal' in order to avoid" +
-                        		" this loss of precision that could occur.");
+                                " Broadleaf recommends that the type of all Money fields be 'BigDecimal' in order to avoid" +
+                                " this loss of precision that could occur.");
                         populateValueRequest.getFieldManager().setFieldValue(instance, populateValueRequest.getProperty().getName(), val);
                     } else {
                         DecimalFormat format = populateValueRequest.getDataFormatProvider().getDecimalFormatter();
@@ -242,25 +242,25 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                         dirty = checkDirtyState(populateValueRequest, instance, Integer.valueOf(populateValueRequest.getRequestedValue()));
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), Integer.valueOf(populateValueRequest
-                                .getRequestedValue()));
+                                        .getRequestedValue()));
                     } else if (byte.class.isAssignableFrom(populateValueRequest.getReturnType()) || Byte.class
                             .isAssignableFrom(populateValueRequest.getReturnType())) {
                         dirty = checkDirtyState(populateValueRequest, instance, Byte.valueOf(populateValueRequest.getRequestedValue()));
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), Byte.valueOf(populateValueRequest
-                                .getRequestedValue()));
+                                        .getRequestedValue()));
                     } else if (short.class.isAssignableFrom(populateValueRequest.getReturnType()) || Short.class
                             .isAssignableFrom(populateValueRequest.getReturnType())) {
                         dirty = checkDirtyState(populateValueRequest, instance, Short.valueOf(populateValueRequest.getRequestedValue()));
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), Short.valueOf(populateValueRequest
-                                .getRequestedValue()));
+                                        .getRequestedValue()));
                     } else if (long.class.isAssignableFrom(populateValueRequest.getReturnType()) || Long.class
                             .isAssignableFrom(populateValueRequest.getReturnType())) {
                         dirty = checkDirtyState(populateValueRequest, instance, Long.valueOf(populateValueRequest.getRequestedValue()));
                         populateValueRequest.getFieldManager().setFieldValue(instance,
                                 populateValueRequest.getProperty().getName(), Long.valueOf(populateValueRequest
-                                .getRequestedValue()));
+                                        .getRequestedValue()));
                     }
                     break;
                 case CODE:
@@ -403,7 +403,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
 
     @Override
     public FieldProviderResponse extractValue(ExtractValueRequest extractValueRequest,
-                                              Property property) throws PersistenceException {
+            Property property) throws PersistenceException {
         if (!canHandleExtraction(extractValueRequest, property)) {
             return FieldProviderResponse.NOT_HANDLED;
         }
@@ -436,7 +436,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                     sb.append("0");
                     if (decimal.scale() > 0) {
                         sb.append(".");
-                        for (int j=0;j<decimal.scale();j++) {
+                        for (int j = 0; j < decimal.scale(); j++) {
                             sb.append("0");
                         }
                     }
@@ -518,7 +518,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
 
     @Override
     public FieldProviderResponse addSearchMapping(AddSearchMappingRequest addSearchMappingRequest,
-                                                  List<FilterMapping> filterMappings) {
+            List<FilterMapping> filterMappings) {
         if (!canHandleSearchMapping(addSearchMappingRequest, filterMappings)) {
             return FieldProviderResponse.NOT_HANDLED;
         }
@@ -537,32 +537,33 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
         }
         BasicFieldMetadata metadata = (BasicFieldMetadata) addSearchMappingRequest.getMergedProperties().get
                 (addSearchMappingRequest.getPropertyName());
-        
+
         FilterAndSortCriteria fasc = addSearchMappingRequest.getRequestedCto().get(addSearchMappingRequest.getPropertyName());
 
         FilterMapping filterMapping = new FilterMapping()
                 .withInheritedFromClass(clazz)
                 .withFullPropertyName(addSearchMappingRequest.getPropertyName())
                 .withFilterValues(fasc.getFilterValues())
-                .withSortDirection(fasc.getSortDirection());
+                .withSortDirection(fasc.getSortDirection())
+                .withOrder(fasc.getOrder());
         filterMappings.add(filterMapping);
-        
+
         if (fasc.hasSpecialFilterValue()) {
             filterMapping.setDirectFilterValues(new EmptyFilterValues());
-            
+
             // Handle special values on a case by case basis
             List<String> specialValues = fasc.getSpecialFilterValues();
             if (specialValues.contains(FilterAndSortCriteria.IS_NULL_FILTER_VALUE)) {
                 filterMapping.setRestriction(new Restriction().withPredicateProvider(new IsNullPredicateProvider()));
-            } 
+            }
             if (specialValues.contains(FilterAndSortCriteria.IS_NOT_NULL_FILTER_VALUE)) {
                 filterMapping.setRestriction(new Restriction().withPredicateProvider(new IsNotNullPredicateProvider()));
-            } 
+            }
         } else {
             if (fasc.getRestrictionType() != null) {
                 filterMapping.setRestriction(addSearchMappingRequest.getRestrictionFactory().
-                                                getRestriction(fasc.getRestrictionType().getType(),
-                                                        addSearchMappingRequest.getPropertyName()));
+                        getRestriction(fasc.getRestrictionType().getType(),
+                                addSearchMappingRequest.getPropertyName()));
             } else {
                 switch (metadata.getFieldType()) {
                     case BOOLEAN:
@@ -600,7 +601,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                                 .getFilterValues().isEmpty()) {
                             ForeignKey foreignKey = (ForeignKey) addSearchMappingRequest.getPersistencePerspective()
                                     .getPersistencePerspectiveItems().get
-                                            (PersistencePerspectiveItemType.FOREIGNKEY);
+                                    (PersistencePerspectiveItemType.FOREIGNKEY);
                             if (metadata.getForeignKeyCollection()) {
                                 if (ForeignKeyRestrictionType.COLLECTION_SIZE_EQ.toString().equals(foreignKey
                                         .getRestrictionType().toString())) {
@@ -614,12 +615,12 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                                                     addSearchMappingRequest.getPropertyName()));
                                     filterMapping.setFieldPath(new FieldPath().withTargetProperty
                                             (addSearchMappingRequest
-                                            .getPropertyName() + "." + metadata.getForeignKeyProperty()));
+                                                    .getPropertyName() + "." + metadata.getForeignKeyProperty()));
                                 }
                             } else if (addSearchMappingRequest.getRequestedCto().get(addSearchMappingRequest.getPropertyName())
                                     .getFilterValues().get(0) == null || "null".equals(addSearchMappingRequest
                                     .getRequestedCto().get
-                                            (addSearchMappingRequest.getPropertyName()).getFilterValues().get(0))) {
+                                    (addSearchMappingRequest.getPropertyName()).getFilterValues().get(0))) {
                                 filterMapping.setRestriction(addSearchMappingRequest.getRestrictionFactory().getRestriction
                                         (RestrictionType.IS_NULL_LONG.getType(), addSearchMappingRequest.getPropertyName()));
                             } else if (metadata.getSecondaryType() == SupportedFieldType.STRING) {
@@ -637,11 +638,12 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                         break;
                     case ADDITIONAL_FOREIGN_KEY:
                         int additionalForeignKeyIndexPosition = Arrays.binarySearch(addSearchMappingRequest
-                                        .getPersistencePerspective()
-                                        .getAdditionalForeignKeys(), new ForeignKey(addSearchMappingRequest
-                                        .getPropertyName(),
-                                        null, null),
+                                .getPersistencePerspective()
+                                .getAdditionalForeignKeys(), new ForeignKey(addSearchMappingRequest
+                                .getPropertyName(),
+                                null, null),
                                 new Comparator<ForeignKey>() {
+
                                     @Override
                                     public int compare(ForeignKey o1, ForeignKey o2) {
                                         return o1.getManyToField().compareTo(o2.getManyToField());
@@ -667,7 +669,7 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                         } else if (CollectionUtils.isEmpty(addSearchMappingRequest.getRequestedCto().get(addSearchMappingRequest.getPropertyName()).getFilterValues()) ||
                                 addSearchMappingRequest.getRequestedCto().get(addSearchMappingRequest.getPropertyName
                                         ()).getFilterValues().get(0) == null || "null".equals(addSearchMappingRequest.getRequestedCto().get
-                                (addSearchMappingRequest.getPropertyName()).getFilterValues().get(0))) {
+                                        (addSearchMappingRequest.getPropertyName()).getFilterValues().get(0))) {
                             filterMapping.setRestriction(addSearchMappingRequest.getRestrictionFactory().getRestriction(RestrictionType.IS_NULL_LONG.getType(), addSearchMappingRequest.getPropertyName()));
                         } else if (metadata.getSecondaryType() == SupportedFieldType.STRING) {
                             filterMapping.setRestriction(addSearchMappingRequest.getRestrictionFactory().getRestriction(RestrictionType.STRING_EQUAL.getType(), addSearchMappingRequest.getPropertyName()));

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/SearchFacetRangeCustomPersistenceHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/SearchFacetRangeCustomPersistenceHandler.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.core.catalog.dao;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.exception.ServiceException;
+import org.broadleafcommerce.core.search.domain.SearchFacetRangeImpl;
+import org.broadleafcommerce.openadmin.dto.CriteriaTransferObject;
+import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
+import org.broadleafcommerce.openadmin.dto.FilterAndSortCriteria;
+import org.broadleafcommerce.openadmin.dto.PersistencePackage;
+import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
+import org.broadleafcommerce.openadmin.server.service.handler.CustomPersistenceHandlerAdapter;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.PersistenceModule;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author gdiaz
+ */
+@Component("blSearchFacetRangeCustomPersistenceHandler")
+public class SearchFacetRangeCustomPersistenceHandler extends CustomPersistenceHandlerAdapter {
+
+    private static final Log LOG = LogFactory.getLog(SearchFacetRangeCustomPersistenceHandler.class);
+
+    @Override
+    public Boolean canHandleFetch(PersistencePackage persistencePackage) {
+        String ceilingEntityFullyQualifiedClassname = persistencePackage.getCeilingEntityFullyQualifiedClassname();
+        return SearchFacetRangeImpl.class.getName().equals(ceilingEntityFullyQualifiedClassname);
+
+    }
+
+    @Override
+    public DynamicResultSet fetch(PersistencePackage persistencePackage, CriteriaTransferObject cto, DynamicEntityDao dynamicEntityDao, RecordHelper helper) throws ServiceException {
+        addDefaultSort(cto);
+
+        PersistenceModule myModule = helper.getCompatibleModule(persistencePackage.getPersistencePerspective().getOperationTypes().getFetchType());
+        DynamicResultSet results = myModule.fetch(persistencePackage, cto);
+
+        return results;
+    }
+
+    private static String[] sortFields = new String[] { "embeddablePriceList.priceList", "minValue", "maxValue" };
+
+    protected void addDefaultSort(CriteriaTransferObject cto) {
+        boolean userSort = false;
+        for (FilterAndSortCriteria fasc : cto.getCriteriaMap().values()) {
+            if (fasc.getSortDirection() != null) {
+                userSort = true;
+                break;
+            }
+        }
+
+        if (!userSort) {
+            for (String string : sortFields) {
+                FilterAndSortCriteria fsc = cto.getCriteriaMap().get(string);
+                if (fsc == null) {
+                    fsc = new FilterAndSortCriteria(string);
+                    cto.add(fsc);
+                }
+                fsc.setSortAscending(true);
+            }
+        }
+    }
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/SearchFacetRangeCustomPersistenceHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/SearchFacetRangeCustomPersistenceHandler.java
@@ -71,10 +71,11 @@ public class SearchFacetRangeCustomPersistenceHandler extends CustomPersistenceH
         }
 
         if (!userSort) {
-            for (String string : sortFields) {
+            for (int i = 0; i < sortFields.length; i++) {
+                String string = sortFields[i];
                 FilterAndSortCriteria fsc = cto.getCriteriaMap().get(string);
                 if (fsc == null) {
-                    fsc = new FilterAndSortCriteria(string);
+                    fsc = new FilterAndSortCriteria(string, i);
                     cto.add(fsc);
                 }
                 fsc.setSortAscending(true);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.core.search.domain;
 
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -31,15 +32,24 @@ import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationOverride;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationOverrides;
 import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.CascadeType;
-import javax.persistence.*;
-import javax.persistence.Entity;
-import javax.persistence.Table;
 import java.io.Serializable;
 import java.math.BigDecimal;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -47,43 +57,42 @@ import java.math.BigDecimal;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @AdminPresentationOverrides({
-        @AdminPresentationOverride(name = "priceList.friendlyName", value = @AdminPresentation(excluded = false, friendlyName = "PriceListImpl_Friendly_Name", order=1, group = "SearchFacetRangeImpl_Description", prominent=true, visibility = VisibilityEnum.FORM_HIDDEN))
+        @AdminPresentationOverride(name = "priceList.friendlyName", value = @AdminPresentation(excluded = false, friendlyName = "PriceListImpl_Friendly_Name", order = 1, gridOrder = 1, group = "SearchFacetRangeImpl_Description", prominent = true, visibility = VisibilityEnum.FORM_HIDDEN))
 })
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class SearchFacetRangeImpl implements SearchFacetRange,Serializable {
+public class SearchFacetRangeImpl implements SearchFacetRange, Serializable {
 
     private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "SearchFacetRangeId")
     @GenericGenerator(
-        name="SearchFacetRangeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="SearchFacetRangeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchFacetRangeImpl")
-        }
-    )
+            name = "SearchFacetRangeId",
+            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SearchFacetRangeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.search.domain.SearchFacetRangeImpl")
+            })
     @Column(name = "SEARCH_FACET_RANGE_ID")
     protected Long id;
-    
+
     @ManyToOne(targetEntity = SearchFacetImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "SEARCH_FACET_ID")
-    @Index(name="SEARCH_FACET_INDEX", columnNames={"SEARCH_FACET_ID"})
+    @Index(name = "SEARCH_FACET_INDEX", columnNames = { "SEARCH_FACET_ID" })
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected SearchFacet searchFacet = new SearchFacetImpl();
-    
-    @Column(name = "MIN_VALUE", precision=19, scale=5, nullable = false) 
-    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_minValue", order=2, group = "SearchFacetRangeImpl_Description", prominent=true)
+
+    @Column(name = "MIN_VALUE", precision = 19, scale = 5, nullable = false)
+    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_minValue", order = 2, gridOrder = 2, group = "SearchFacetRangeImpl_Description", prominent = true)
     protected BigDecimal minValue;
-    
-    @Column(name = "MAX_VALUE", precision=19, scale=5)
-    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_maxValue", order=3, group = "SearchFacetRangeImpl_Description", prominent=true)
+
+    @Column(name = "MAX_VALUE", precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_maxValue", order = 3, gridOrder = 3, group = "SearchFacetRangeImpl_Description", prominent = true)
     protected BigDecimal maxValue;
-    
+
     @Override
     public Long getId() {
         return id;
@@ -93,7 +102,7 @@ public class SearchFacetRangeImpl implements SearchFacetRange,Serializable {
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     @Override
     public SearchFacet getSearchFacet() {
         return searchFacet;
@@ -136,6 +145,6 @@ public class SearchFacetRangeImpl implements SearchFacetRange,Serializable {
         if (searchFacet != null) {
             cloned.setSearchFacet(searchFacet.createOrRetrieveCopyInstance(context).getClone());
         }
-        return  createResponse;
+        return createResponse;
     }
 }


### PR DESCRIPTION
This pull request replaces a former pull request that contained only the first commit (issue #1460)
It also supersedes a previous pull request of the same title, but made agains the wrong release (4.1).

What this pull request does, is offering a way to keep track in which order FilterAndSortCriteria are added to the CriteriaTransferObject, and ensure that such order is taken into account when building the query.

It closes issues #1460 and #1492