### PR TITLE
Make the catalog name translatable

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.common.i18n.domain;
 
 import org.broadleafcommerce.common.BroadleafEnumerationType;
@@ -59,18 +60,19 @@ public class TranslatedEntity implements Serializable, BroadleafEnumerationType 
     public static final TranslatedEntity COUNTRY = new TranslatedEntity("org.broadleafcommerce.profile.core.domain.Country", "Country");
     public static final TranslatedEntity COUNTRY_SUBDIVISION = new TranslatedEntity("org.broadleafcommerce.profile.core.domain.CountrySubdivision", "CountrySubdivision");
     public static final TranslatedEntity COUNTRY_SUBDIVISION_CATEGORY = new TranslatedEntity("org.broadleafcommerce.profile.core.domain.CountrySubdivisionCategory", "CountrySubdivisionCategory");
+    public static final TranslatedEntity CATALOG = new TranslatedEntity("org.broadleafcommerce.common.site.domain.Catalog", "Catalog");
 
     public static TranslatedEntity getInstance(final String type) {
         return TYPES.get(type);
     }
-    
+
     public static TranslatedEntity getInstanceFromFriendlyType(final String friendlyType) {
         for (Entry<String, TranslatedEntity> entry : TYPES.entrySet()) {
             if (entry.getValue().getFriendlyType().equals(friendlyType)) {
                 return entry.getValue();
             }
         }
-        
+
         return null;
     }
 
@@ -99,7 +101,7 @@ public class TranslatedEntity implements Serializable, BroadleafEnumerationType 
     public static Map<String, TranslatedEntity> getTypes() {
         return TYPES;
     }
-    
+
     private void setType(final String type) {
         this.type = type;
         if (!TYPES.containsKey(type)) {

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.common.site.domain;
 
 import org.apache.commons.logging.Log;
@@ -25,9 +26,11 @@ import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -57,10 +60,10 @@ import javax.persistence.Transient;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_CATALOG")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Table(name = "BLC_CATALOG")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
 @AdminPresentationClass(friendlyName = "CatalogImpl")
-@SQLDelete(sql="UPDATE BLC_CATALOG SET ARCHIVED = 'Y' WHERE CATALOG_ID = ?")
+@SQLDelete(sql = "UPDATE BLC_CATALOG SET ARCHIVED = 'Y' WHERE CATALOG_ID = ?")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITEMARKER)
 })
@@ -69,25 +72,24 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
     private static final Log LOG = LogFactory.getLog(CatalogImpl.class);
 
     @Id
-    @GeneratedValue(generator= "CatalogId")
+    @GeneratedValue(generator = "CatalogId")
     @GenericGenerator(
-        name="CatalogId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CatalogImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.site.domain.CatalogImpl")
-        }
-    )
+            name = "CatalogId",
+            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CatalogImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.site.domain.CatalogImpl")
+            })
     @Column(name = "CATALOG_ID")
     protected Long id;
 
     @Column(name = "NAME")
-    @AdminPresentation(friendlyName = "Catalog_Name", gridOrder = 1, order=1, prominent = true)
+    @AdminPresentation(friendlyName = "Catalog_Name", gridOrder = 1, order = 1, prominent = true, requiredOverride = RequiredOverride.REQUIRED, translatable = true)
     protected String name;
 
     @OneToMany(targetEntity = SiteCatalogXrefImpl.class, mappedBy = "catalog", orphanRemoval = true)
-    @Cascade(value={org.hibernate.annotations.CascadeType.MERGE, org.hibernate.annotations.CascadeType.PERSIST})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cascade(value = { org.hibernate.annotations.CascadeType.MERGE, org.hibernate.annotations.CascadeType.PERSIST })
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
     @BatchSize(size = 50)
     protected List<SiteCatalogXref> siteXrefs = new ArrayList<SiteCatalogXref>();
 
@@ -96,7 +98,7 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
 
     @Embedded
     protected ArchiveStatus archiveStatus = new ArchiveStatus();
-    
+
     @Override
     public Long getId() {
         return id;
@@ -109,7 +111,7 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
 
     @Override
     public String getName() {
-        return name;
+        return DynamicTranslationProvider.getValue(this, "name", name);
     }
 
     @Override
@@ -143,7 +145,7 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
     }
 
     public void checkCloneable(Catalog catalog) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = catalog.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = catalog.getClass().getMethod("clone", new Class[] {});
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !catalog.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");
@@ -196,10 +198,10 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
     @Override
     public boolean isActive() {
         if (LOG.isDebugEnabled()) {
-            if ('Y'==getArchived()) {
+            if ('Y' == getArchived()) {
                 LOG.debug("catalog, " + id + ", inactive due to archived status");
             }
         }
-        return 'Y'!=getArchived();
+        return 'Y' != getArchived();
     }
 }


### PR DESCRIPTION
This pull request would add the translation capability to the Catalog' s "name" field.
It closes issue #1496 

The originating QA issue was https://github.com/BroadleafCommerce/QA/issues/707, which itself derived from another QA issue requiring this field and another one.