### PR TITLE
Added "has details" concept to ListGridRecordIcon to denote icons with a more detailed message

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridRecord.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridRecord.java
@@ -212,13 +212,15 @@ public class ListGridRecord {
 
             return new ListGridRecordIcon()
                 .withCssClass("icon-exclamation-sign")
-                    .withMessage(msgToUser);
+                .withMessage(msgToUser)
+                .withHasDetails(true);
         }
 
         if (getIsDirty()) {
             return new ListGridRecordIcon()
                 .withCssClass("icon-pencil")
-                .withMessage(BLCMessageUtils.getMessage("listgrid.record.edited"));
+                .withMessage(BLCMessageUtils.getMessage("listgrid.record.edited"))
+                .withHasDetails(false);
         }
         
         return null;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridRecordIcon.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridRecordIcon.java
@@ -29,6 +29,7 @@ public class ListGridRecordIcon {
     
     protected String cssClass;
     protected String message;
+    protected Boolean hasDetails;
     
     public ListGridRecordIcon withCssClass(String cssClass) {
         setCssClass(cssClass);
@@ -37,6 +38,11 @@ public class ListGridRecordIcon {
 
     public ListGridRecordIcon withMessage(String message) {
         setMessage(message);
+        return this;
+    }
+    
+    public ListGridRecordIcon withHasDetails(Boolean hasDetails) {
+        setHasDetails(hasDetails);
         return this;
     }
 
@@ -56,4 +62,11 @@ public class ListGridRecordIcon {
         this.message = message;
     }
     
+    public Boolean getHasDetails() {
+        return hasDetails;
+    }
+    
+    public void setHasDetails(Boolean hasDetails) {
+        this.hasDetails = hasDetails;
+    }
 }


### PR DESCRIPTION
Addresses BroadleafCommerce/QA#456

Adds the concept of a ListGridRecordIcon having details to be looked up. This can be interpreted on a case by case basis, but was created to be used by BroadleafCommerce/Enterprise@149c29c3614a3e387f4f0a20dec3bbcdd2e70495.