### PR TITLE
Make the `requiredFlag` field visible by default in admin application.

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -114,7 +114,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected Boolean textAreaFlag = false;
     
     @Column(name = "REQUIRED_FLAG")
-    protected Boolean requiredFlag = false;
+    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000,gridOrder = 4000,defaultValue = "false")
+    protected Boolean requiredFlag;
 
     @ManyToOne(targetEntity = DataDrivenEnumerationImpl.class)
     @JoinColumn(name = "ENUM_ID")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -114,8 +114,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected Boolean textAreaFlag = false;
     
     @Column(name = "REQUIRED_FLAG")
-    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000,gridOrder = 4000,defaultValue = "false")
-    protected Boolean requiredFlag;
+    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000,gridOrder = 4000, defaultValue = "false")
+    protected Boolean requiredFlag = false;
 
     @ManyToOne(targetEntity = DataDrivenEnumerationImpl.class)
     @JoinColumn(name = "ENUM_ID")

--- a/admin/broadleaf-contentmanagement-module/src/main/resources/messages/GeneratedMessagesEntityCMS.properties
+++ b/admin/broadleaf-contentmanagement-module/src/main/resources/messages/GeneratedMessagesEntityCMS.properties
@@ -94,7 +94,7 @@ PageItemCriteriaImpl_basePageItemCriteria=Page Item Criteria
 FieldDefinitionImpl_friendlyName=Friendly Name
 FieldDefinitionImpl_fieldType=Field Type
 FieldDefinitionImpl_fieldOrder=Field Order
-
+FieldDefinitionImpl_requiredFlag=Required Field
 StructuredContentImpl_Rules_Tab=Rules
 StructuredContentImpl_Rules=Rules
 PageImpl_Rules_Tab=Rules


### PR DESCRIPTION
This pull request address BroadleafCommerce/QA#516

The commit does not necessarily "fix" the issue of when a user tries to preview or save a page with data not compatible with a HTML template. The goal of this commit it to provide better "out-of-box" transparency on how to create a PageType that enforces some structural rules that Pages of the PageType must follow. 