### PR TITLE
Framework changes to allow dynamic search facets

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RemoveFacetValuesLinkProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RemoveFacetValuesLinkProcessor.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.core.web.processor;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.search.domain.SearchCriteria;
 import org.broadleafcommerce.core.search.domain.SearchFacetDTO;
+import org.broadleafcommerce.core.web.service.SearchFacetDTOService;
 import org.broadleafcommerce.core.web.util.ProcessorUtils;
 import org.thymeleaf.Arguments;
 import org.thymeleaf.dom.Element;
@@ -32,6 +33,7 @@ import org.thymeleaf.standard.expression.StandardExpressions;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -42,6 +44,9 @@ import javax.servlet.http.HttpServletRequest;
  * @author apazzolini
  */
 public class RemoveFacetValuesLinkProcessor extends AbstractAttributeModifierAttrProcessor {
+    
+    @Resource(name = "blSearchFacetDTOService")
+    protected SearchFacetDTOService searchFacetDTOService;
 
     /**
      * Sets the name of this processor to be used in Thymeleaf template
@@ -70,7 +75,7 @@ public class RemoveFacetValuesLinkProcessor extends AbstractAttributeModifierAtt
                 .parseExpression(arguments.getConfiguration(), arguments, element.getAttributeValue(attributeName));
         SearchFacetDTO facet = (SearchFacetDTO) expression.execute(arguments.getConfiguration(), arguments);
         
-        String key = facet.getFacet().getField().getAbbreviation();
+        String key = searchFacetDTOService.getUrlKey(facet);
         params.remove(key);
         params.remove(SearchCriteria.PAGE_NUMBER);
         

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOService.java
@@ -81,4 +81,6 @@ public interface SearchFacetDTOService {
     public String getValue(SearchFacetResultDTO result);
 
 
+    public String getUrlKey(SearchFacetDTO result);
+
 }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOServiceImpl.java
@@ -115,4 +115,9 @@ public class SearchFacetDTOServiceImpl implements SearchFacetDTOService {
         return result.getValueKey();
     }
 
+    @Override
+    public String getUrlKey(SearchFacetDTO result) {
+        return result.getFacet().getField().getAbbreviation();
+    }
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
@@ -29,16 +29,28 @@ import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.core.search.domain.solr.FieldType;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
-import javax.persistence.Entity;
-import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -220,7 +232,13 @@ public class FieldImpl implements Field, Serializable, AdminMainEntity {
     public void setSearchConfigs(List<SearchConfig> searchConfigs) {
         throw new UnsupportedOperationException("The default Field implementation does not support search configs");
     }
-    
+
+    public static final Field getNoneField() {
+        Field noneField = new FieldImpl();
+        noneField.setAbbreviation("NONE");
+        return noneField;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
@@ -233,12 +233,6 @@ public class FieldImpl implements Field, Serializable, AdminMainEntity {
         throw new UnsupportedOperationException("The default Field implementation does not support search configs");
     }
 
-    public static final Field getNoneField() {
-        Field noneField = new FieldImpl();
-        noneField.setAbbreviation("NONE");
-        return noneField;
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetDTO.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetDTO.java
@@ -31,6 +31,7 @@ public class SearchFacetDTO {
     protected boolean showQuantity;
     protected List<SearchFacetResultDTO> facetValues = new ArrayList<SearchFacetResultDTO>();
     protected boolean active;
+    protected String abbreviation;
     
     public SearchFacet getFacet() {
         return facet;
@@ -62,6 +63,18 @@ public class SearchFacetDTO {
 
     public void setActive(boolean active) {
         this.active = active;
+    }
+    
+    public String getAbbreviation() {
+        if (abbreviation != null) {
+            return abbreviation;
+        }
+        
+        return this.getFacet().getField().getAbbreviation();
+    }
+
+    public void setAbbreviation(String abbreviation) {
+        this.abbreviation = abbreviation;
     }
     
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -86,7 +86,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable {
             groupOrder = 1000, prominent = true, translatable = true, gridOrder = 1000)
     protected String label;
 
-    @ManyToOne(optional=false, targetEntity = FieldImpl.class)
+    @ManyToOne(targetEntity = FieldImpl.class)
     @JoinColumn(name = "FIELD_ID")
     @AdminPresentation(friendlyName = "SearchFacetImpl_field", order = 2000, group = "SearchFacetImpl_description",
             prominent = true, gridOrder = 2000)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -86,7 +86,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable {
             groupOrder = 1000, prominent = true, translatable = true, gridOrder = 1000)
     protected String label;
 
-    @ManyToOne(targetEntity = FieldImpl.class)
+    @ManyToOne(optional=false, targetEntity = FieldImpl.class)
     @JoinColumn(name = "FIELD_ID")
     @AdminPresentation(friendlyName = "SearchFacetImpl_field", order = 2000, group = "SearchFacetImpl_description",
             prominent = true, gridOrder = 2000)


### PR DESCRIPTION
QA Issue: https://github.com/BroadleafCommerce/QA/issues/699

This pull request introduces the ability to set the abbreviation for a SearchFacetDTO, which is utilized in the https://github.com/BroadleafCommerce/EnterpriseSearch module.

I will add the extension manager to allow null Fields as part of a future update (probably with the admin functionality).