### PR TITLE
Add extension functionality to modify the URL paths for a StaticAsset

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
@@ -22,11 +22,13 @@ package org.broadleafcommerce.cms.file.service;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.cms.field.type.StorageType;
+import org.broadleafcommerce.cms.file.StaticAssetMultiTenantExtensionManager;
 import org.broadleafcommerce.cms.file.dao.StaticAssetDao;
 import org.broadleafcommerce.cms.file.domain.ImageStaticAsset;
 import org.broadleafcommerce.cms.file.domain.ImageStaticAssetImpl;
 import org.broadleafcommerce.cms.file.domain.StaticAsset;
 import org.broadleafcommerce.cms.file.domain.StaticAssetImpl;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.file.service.StaticAssetPathService;
 import org.broadleafcommerce.common.util.TransactionUtils;
 import org.broadleafcommerce.openadmin.server.service.artifact.image.ImageArtifactProcessor;
@@ -75,6 +77,10 @@ public class StaticAssetServiceImpl implements StaticAssetService {
     
     @Resource(name = "blStaticAssetPathService")
     protected StaticAssetPathService staticAssetPathService;
+
+    @Resource(name = "blStaticAssetMultiTenantExtensionManager")
+    protected StaticAssetMultiTenantExtensionManager staticAssetExtensionManager;
+
 
     private final Random random = new Random();
     private final String FILE_NAME_CHARS = "0123456789abcdef";
@@ -187,25 +193,34 @@ public class StaticAssetServiceImpl implements StaticAssetService {
         }
 
         String fullUrl = buildAssetURL(properties, fileName);
+        StringBuilder urlBuilder = new StringBuilder();
+        urlBuilder.append(fullUrl);
+        ExtensionResultStatusType resultStatusType = staticAssetExtensionManager.getProxy().modifyDuplicateAssetURL(urlBuilder);
+        fullUrl = urlBuilder.toString();
         StaticAsset newAsset = staticAssetDao.readStaticAssetByFullUrl(fullUrl);
-        int count = 0;
-        while (newAsset != null) {
-            count++;
-            //removing the default count 1, from fullUrl for count logic
-            if (fullUrl.contains("-1")) {
-                fullUrl = fullUrl.replace("-1", "");
+        // If no ExtensionManager modified the URL to handle duplicates, then go ahead and run default
+        // logic for handling duplicate files.
+        if(resultStatusType != ExtensionResultStatusType.HANDLED){
+            int count = 0;
+            while (newAsset != null) {
                 count++;
+                //removing the default count 1, from fullUrl for count logic
+                if (fullUrl.contains("-1")) {
+                    fullUrl = fullUrl.replace("-1", "");
+                    count++;
+                }
+                //try the new format first, then the old
+                newAsset = staticAssetDao.readStaticAssetByFullUrl(getCountUrl(fullUrl, count, false));
+                if (newAsset == null) {
+                    newAsset = staticAssetDao.readStaticAssetByFullUrl(getCountUrl(fullUrl, count, true));
+                }
             }
-            //try the new format first, then the old
-            newAsset = staticAssetDao.readStaticAssetByFullUrl(getCountUrl(fullUrl, count, false));
-            if (newAsset == null) {
-                newAsset = staticAssetDao.readStaticAssetByFullUrl(getCountUrl(fullUrl, count, true));
+
+            if (count > 0) {
+                fullUrl = getCountUrl(fullUrl, count, false);
             }
         }
 
-        if (count > 0) {
-            fullUrl = getCountUrl(fullUrl, count, false);
-        }
 
         try {
             ImageMetadata metadata = imageArtifactProcessor.getImageMetadata(inputStream);

--- a/common/src/main/java/org/broadleafcommerce/common/file/service/BroadleafStaticAssetExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/file/service/BroadleafStaticAssetExtensionHandler.java
@@ -25,10 +25,19 @@ import org.broadleafcommerce.common.site.domain.Site;
 import org.springframework.ui.Model;
 
 /**
+ * 
  * @author Chris Kittrell (ckittrell)
  */
 public interface BroadleafStaticAssetExtensionHandler extends ExtensionHandler {
 
     public ExtensionResultStatusType removeShareOptionsForMTStandardSite(Model model, Site currentSite);
+
+    /**
+     * Provide an extension point to modify the url for a StaticAsset in the case
+     * where multiple assets have the same url.
+     * @param urlBuilder
+     * @return
+     */
+    public ExtensionResultStatusType modifyDuplicateAssetURL(StringBuilder urlBuilder);
 
 }


### PR DESCRIPTION
Add extension functionality to modify the URL paths for a `StaticAsset`

- Address Broadleafcommerce/QA#710
- The `StaticAssetService` will now utilize ExtensionHandlers to manage how duplicate `StaticAssets` are created. 