### PR TITLE
Provide mechanism to skip validation for MVEL strings in FieldData

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/FieldData.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/FieldData.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.web.rulebuilder.dto;
 
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -51,6 +52,7 @@ public class FieldData {
     }
 
     public static class Builder {
+
         protected String fieldLabel = null;
         protected String fieldName = null;
         protected String operators = null;
@@ -63,7 +65,8 @@ public class FieldData {
             return new FieldData(this);
         }
 
-        public Builder() {}
+        public Builder() {
+        }
 
         public Builder label(String fieldLabel) {
             this.fieldLabel = fieldLabel;
@@ -94,10 +97,10 @@ public class FieldData {
             this.secondaryFieldType = fieldType;
             return this;
         }
-        
+
         public Builder skipValidation(boolean skipValidation) {
-        	this.skipValidation = skipValidation;
-        	return this;
+            this.skipValidation = skipValidation;
+            return this;
         }
     }
 
@@ -125,13 +128,12 @@ public class FieldData {
         return secondaryFieldType;
     }
 
-	public boolean getSkipValidation() {
-		return skipValidation;
-	}
+    public boolean getSkipValidation() {
+        return skipValidation;
+    }
 
-	public void setSkipValidation(boolean skipValidation) {
-		this.skipValidation = skipValidation;
-	}
-    
-    
+    public void setSkipValidation(boolean skipValidation) {
+        this.skipValidation = skipValidation;
+    }
+
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/FieldData.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/FieldData.java
@@ -38,6 +38,7 @@ public class FieldData {
     protected String options;
     protected SupportedFieldType fieldType;
     protected SupportedFieldType secondaryFieldType;
+    protected boolean skipValidation;
 
     private FieldData(Builder builder) {
         this.fieldLabel = builder.fieldLabel;
@@ -46,6 +47,7 @@ public class FieldData {
         this.options = builder.options;
         this.fieldType = builder.fieldType;
         this.secondaryFieldType = builder.secondaryFieldType;
+        this.skipValidation = builder.skipValidation;
     }
 
     public static class Builder {
@@ -55,6 +57,7 @@ public class FieldData {
         protected String options = null;
         protected SupportedFieldType fieldType = null;
         protected SupportedFieldType secondaryFieldType = null;
+        protected boolean skipValidation;
 
         public FieldData build() {
             return new FieldData(this);
@@ -91,6 +94,11 @@ public class FieldData {
             this.secondaryFieldType = fieldType;
             return this;
         }
+        
+        public Builder skipValidation(boolean skipValidation) {
+        	this.skipValidation = skipValidation;
+        	return this;
+        }
     }
 
     public String getFieldLabel() {
@@ -116,4 +124,14 @@ public class FieldData {
     public SupportedFieldType getSecondaryFieldType() {
         return secondaryFieldType;
     }
+
+	public boolean getSkipValidation() {
+		return skipValidation;
+	}
+
+	public void setSkipValidation(boolean skipValidation) {
+		this.skipValidation = skipValidation;
+	}
+    
+    
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/service/AbstractRuleBuilderFieldService.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/service/AbstractRuleBuilderFieldService.java
@@ -174,22 +174,24 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
             }
 
             private void testFieldName(FieldData fieldData) throws ClassNotFoundException {
-                if (!StringUtils.isEmpty(fieldData.getFieldName()) && dynamicEntityDao != null) {
-                    Class<?>[] dtos = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(Class.forName(getDtoClassName()));
-                    if (ArrayUtils.isEmpty(dtos)) {
-                        dtos = new Class<?>[]{Class.forName(getDtoClassName())};
-                    }
-                    Field field = null;
-                    for (Class<?> dto : dtos) {
-                        field = dynamicEntityDao.getFieldManager().getField(dto, fieldData.getFieldName());
-                        if (field != null) {
-                            break;
-                        }
-                    }
-                    if (field == null) {
-                        throw new IllegalArgumentException("Unable to find the field declared in FieldData (" + fieldData.getFieldName() + ") on the target class (" + getDtoClassName() + "), or any registered entity class that derives from it.");
-                    }
-                }
+            	if (! fieldData.getSkipValidation()) {
+	                if (!StringUtils.isEmpty(fieldData.getFieldName()) && dynamicEntityDao != null) {
+	                    Class<?>[] dtos = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(Class.forName(getDtoClassName()));
+	                    if (ArrayUtils.isEmpty(dtos)) {
+	                        dtos = new Class<?>[]{Class.forName(getDtoClassName())};
+	                    }
+	                    Field field = null;
+	                    for (Class<?> dto : dtos) {
+	                        field = dynamicEntityDao.getFieldManager().getField(dto, fieldData.getFieldName());
+	                        if (field != null) {
+	                            break;
+	                        }
+	                    }
+	                    if (field == null) {
+	                        throw new IllegalArgumentException("Unable to find the field declared in FieldData (" + fieldData.getFieldName() + ") on the target class (" + getDtoClassName() + "), or any registered entity class that derives from it.");
+	                    }
+	                }
+            	}
             }
         });
         this.fields = proxyFields;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/service/AbstractRuleBuilderFieldService.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/service/AbstractRuleBuilderFieldService.java
@@ -17,6 +17,7 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.openadmin.web.rulebuilder.service;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -77,14 +78,14 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
         for (FieldData field : getFields()) {
             FieldDTO fieldDTO = new FieldDTO();
             fieldDTO.setLabel(field.getFieldLabel());
-            
+
             //translate the label to display
             String label = field.getFieldLabel();
             BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
             MessageSource messages = context.getMessageSource();
             label = messages.getMessage(label, null, label, context.getJavaLocale());
             fieldDTO.setLabel(label);
-            
+
             fieldDTO.setName(field.getFieldName());
             fieldDTO.setOperators(field.getOperators());
             fieldDTO.setOptions(field.getOptions());
@@ -99,7 +100,7 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
         SupportedFieldType type = null;
         if (fieldName != null) {
             for (FieldData field : getFields()) {
-                if (fieldName.equals(field.getFieldName())){
+                if (fieldName.equals(field.getFieldName())) {
                     return field.getFieldType();
                 }
             }
@@ -112,7 +113,7 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
         SupportedFieldType type = null;
         if (fieldName != null) {
             for (FieldData field : getFields()) {
-                if (fieldName.equals(field.getFieldName())){
+                if (fieldName.equals(field.getFieldName())) {
                     return field.getSecondaryFieldType();
                 }
             }
@@ -155,7 +156,8 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
     @Override
     @SuppressWarnings("unchecked")
     public void setFields(final List<FieldData> fields) {
-        List<FieldData> proxyFields = (List<FieldData>) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{List.class}, new InvocationHandler() {
+        List<FieldData> proxyFields = (List<FieldData>) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] { List.class }, new InvocationHandler() {
+
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 if (method.getName().equals("add")) {
@@ -174,24 +176,24 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
             }
 
             private void testFieldName(FieldData fieldData) throws ClassNotFoundException {
-            	if (! fieldData.getSkipValidation()) {
-	                if (!StringUtils.isEmpty(fieldData.getFieldName()) && dynamicEntityDao != null) {
-	                    Class<?>[] dtos = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(Class.forName(getDtoClassName()));
-	                    if (ArrayUtils.isEmpty(dtos)) {
-	                        dtos = new Class<?>[]{Class.forName(getDtoClassName())};
-	                    }
-	                    Field field = null;
-	                    for (Class<?> dto : dtos) {
-	                        field = dynamicEntityDao.getFieldManager().getField(dto, fieldData.getFieldName());
-	                        if (field != null) {
-	                            break;
-	                        }
-	                    }
-	                    if (field == null) {
-	                        throw new IllegalArgumentException("Unable to find the field declared in FieldData (" + fieldData.getFieldName() + ") on the target class (" + getDtoClassName() + "), or any registered entity class that derives from it.");
-	                    }
-	                }
-            	}
+                if (!fieldData.getSkipValidation()) {
+                    if (!StringUtils.isEmpty(fieldData.getFieldName()) && dynamicEntityDao != null) {
+                        Class<?>[] dtos = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(Class.forName(getDtoClassName()));
+                        if (ArrayUtils.isEmpty(dtos)) {
+                            dtos = new Class<?>[] { Class.forName(getDtoClassName()) };
+                        }
+                        Field field = null;
+                        for (Class<?> dto : dtos) {
+                            field = dynamicEntityDao.getFieldManager().getField(dto, fieldData.getFieldName());
+                            if (field != null) {
+                                break;
+                            }
+                        }
+                        if (field == null) {
+                            throw new IllegalArgumentException("Unable to find the field declared in FieldData (" + fieldData.getFieldName() + ") on the target class (" + getDtoClassName() + "), or any registered entity class that derives from it.");
+                        }
+                    }
+                }
             }
         });
         this.fields = proxyFields;
@@ -223,7 +225,7 @@ public abstract class AbstractRuleBuilderFieldService implements RuleBuilderFiel
             PersistenceManager persistenceManager = PersistenceManagerFactory.getPersistenceManager(TargetModeType.SANDBOX);
             dynamicEntityDao = persistenceManager.getDynamicEntityDao();
             setFields(new ArrayList<FieldData>());
-            
+
             // This cannot be null during startup as we do not want to remove the null safety checks in a multi-tenant env.
             boolean contextWasNull = false;
             if (BroadleafRequestContext.getBroadleafRequestContext() == null) {

--- a/common/src/main/java/org/broadleafcommerce/common/RequestDTOImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/RequestDTOImpl.java
@@ -19,13 +19,15 @@
  */
 package org.broadleafcommerce.common;
 
-import org.apache.commons.lang3.StringUtils;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.springframework.web.context.request.WebRequest;
-
 import java.io.Serializable;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.springframework.web.context.request.WebRequest;
 
 /**
  * Created by bpolster.
@@ -42,7 +44,7 @@ public class RequestDTOImpl implements RequestDTO, Serializable {
     private String fullUrlWithQueryString;
 
     @AdminPresentation(friendlyName = "RequestDTOImpl_Is_Secure")
-    private Boolean secure;
+    private Boolean secure;        
 
     public RequestDTOImpl(HttpServletRequest request) {
         requestURI = request.getRequestURI();
@@ -100,6 +102,14 @@ public class RequestDTOImpl implements RequestDTO, Serializable {
 
     public void setRequestURI(String requestURI) {
         this.requestURI = requestURI;
+    }
+        
+    public Map<String,Object> getProperties() {
+    	if (BroadleafRequestContext.getBroadleafRequestContext() != null) {
+    		return BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties();
+    	} else {
+    		return null;    		
+    	}
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/RequestDTOImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/RequestDTOImpl.java
@@ -17,17 +17,18 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.common;
-
-import java.io.Serializable;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.springframework.web.context.request.WebRequest;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Created by bpolster.
@@ -39,12 +40,11 @@ public class RequestDTOImpl implements RequestDTO, Serializable {
     @AdminPresentation(friendlyName = "RequestDTOImpl_Request_URI")
     private String requestURI;
 
-
     @AdminPresentation(friendlyName = "RequestDTOImpl_Full_Url")
     private String fullUrlWithQueryString;
 
     @AdminPresentation(friendlyName = "RequestDTOImpl_Is_Secure")
-    private Boolean secure;        
+    private Boolean secure;
 
     public RequestDTOImpl(HttpServletRequest request) {
         requestURI = request.getRequestURI();
@@ -103,13 +103,13 @@ public class RequestDTOImpl implements RequestDTO, Serializable {
     public void setRequestURI(String requestURI) {
         this.requestURI = requestURI;
     }
-        
-    public Map<String,Object> getProperties() {
-    	if (BroadleafRequestContext.getBroadleafRequestContext() != null) {
-    		return BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties();
-    	} else {
-    		return null;    		
-    	}
+
+    public Map<String, Object> getProperties() {
+        if (BroadleafRequestContext.getBroadleafRequestContext() != null) {
+            return BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties();
+        } else {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Provide support for MVEL expressions used by FieldData (rules) to utilize expressions that are not just field.property style expressions.    This commit allows a FieldData to set a "skipValidation" property which will avoid the strict check that is intended to catch typos in custom FieldData objects.

This pull-request also provides a small enhancement to RequestDTO which will allow the property map on BroadleafRequestContext to be used.

BroadleafCommerce/QA#738