### PR TITLE
Add ability to remove the primary media from a Product.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
@@ -1594,6 +1594,11 @@ button.show-asset-selector {
 	bottom: 4px;
 }
 
+button.asset-clear {
+    vertical-align: text-bottom;
+    bottom: 4px;
+}
+
 div.uploadMessage {
 	display: none;
 }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
@@ -156,7 +156,29 @@ $(document).ready(function() {
     	});
     	
 		return false;
-    });    
+    });
+
+    /**
+     *
+     */
+    $('body').on('click', 'button.asset-clear', function(event) {
+        var imagePlaceHolderSrc = "/admin/img/admin/placeholder-60x60.gif"
+
+        var mediaItem =  $('.mediaItem');
+        var image = $('.thumbnail');
+        image.removeClass();
+        image.addClass('placeholder-image');
+        image.attr("src", imagePlaceHolderSrc);
+
+        if (mediaItem.length > 0) {
+            var mediaJson = {};
+            mediaJson.url = "";
+            mediaItem.val(JSON.stringify(mediaJson));
+        }
+        return false;
+    });
+
+
     
     // When we detect that a user has selected a file from his file system, we will trigger an event
     $('body').on('change', 'input.ajaxUploadFile[type="file"]', function() {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/media.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/media.html
@@ -14,14 +14,16 @@
     <span th:unless="*{fields['__${field.name}__'].media != null and !#strings.isEmpty(fields['__${field.name}__'].media.url)}">
         <img class="thumbnail placeholder-image" th:src="@{/img/admin/placeholder-60x60.gif}" />
     </span>
-
+    <button class="asset-clear tiny radius secondary button hover-cursor"
+            type="button" th:inline="text"
+            th:utext="#{Clear}">
+    </button>
     <button class="show-asset-selector tiny radius secondary button hover-cursor"
         type="button" th:inline="text"
         th:if="${overrideAssetSectionKey}"
         th:attr="data-select-url=@{${'/'+overrideAssetSectionKey+ '/' + assetAssociationId + '/chooseAsset'}}">
         <i class="icon-camera"></i>&nbsp;[[#{Select_Upload_Image}]]
     </button>
-
     <button class="show-asset-selector tiny radius secondary button hover-cursor"
         type="button" th:inline="text"
         th:unless="${overrideAssetSectionKey}"

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/media.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/media.html
@@ -15,8 +15,8 @@
         <img class="thumbnail placeholder-image" th:src="@{/img/admin/placeholder-60x60.gif}" />
     </span>
     <button class="asset-clear tiny radius secondary button hover-cursor"
-            type="button" th:inline="text"
-            th:utext="#{Clear}">
+            type="button" th:inline="text">
+        <i class="icon-remove"></i>&nbsp;[[#{Clear}]]
     </button>
     <button class="show-asset-selector tiny radius secondary button hover-cursor"
         type="button" th:inline="text"


### PR DESCRIPTION
- Addresses BroadleafCommerce/BroadleafCommerce#1228
- Addresses BroadleafCommerce/QA#256

<h2>Problem</h2>
There is no way to remove the "primary media" once it has been set for a `Product`

<h2> Knowledge use to arrive to solution </h2>
- The "primary media" is a `SkuMediaXref`
- Logic already exist to remove/alter a `SkuMediaXref` linked to a product

<h2> Solution </h2>
Add a button for the media field that sets the value of the input field and replaces the current image/thumbnail with a placeholder image. 