### PR TITLE
If an exception was thrown in a workflow rollback handler, it is not possible to see what the exception was

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/workflow/SequenceProcessor.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/workflow/SequenceProcessor.java
@@ -94,10 +94,10 @@ public class SequenceProcessor extends BaseProcessor {
                                 errorHandler.handleError(context, th);
                             }
                         } catch (RuntimeException e) {
-                            LOG.error("An exception was caught while attempting to handle an activity generated exception", th);
+                            LOG.error("An exception was caught while attempting to handle an activity generated exception", e);
                             throw e;
                         } catch (WorkflowException e) {
-                            LOG.error("An exception was caught while attempting to handle an activity generated exception", th);
+                            LOG.error("An exception was caught while attempting to handle an activity generated exception", e);
                             throw e;
                         }
                     }


### PR DESCRIPTION
In `SequenceProcessor` the exception being logged is the original `Activity` exception instead of the exception that was thrown by the `RollbackHandler`.

Fixes BroadleafCommerce/QA#754.