### PR TITLE
multitenant site defaults

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/SiteDefaultsDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/SiteDefaultsDTO.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * broadleaf-multitenant-singleschema
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.common;
+
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
+import org.broadleafcommerce.common.locale.domain.Locale;
+
+/**
+ * A DTO for transmitting some default values from a selected Site (because it is done through an extension handler and those don't return values, so 
+ * these have to be passed by reference inside a method call)
+ * @author gdiaz
+ *
+ */
+public class SiteDefaultsDTO {
+
+    protected BroadleafCurrency defaultCurrency;
+
+    protected Locale defaultLocale;
+
+    public BroadleafCurrency getDefaultCurrency() {
+        return defaultCurrency;
+    }
+
+    public void setDefaultCurrency(BroadleafCurrency defaultCurrency) {
+        this.defaultCurrency = defaultCurrency;
+    }
+
+    public Locale getDefaultLocale() {
+        return defaultLocale;
+    }
+
+    public void setDefaultLocale(Locale defaultLocale) {
+        this.defaultLocale = defaultLocale;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafCurrencyResolverImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafCurrencyResolverImpl.java
@@ -17,10 +17,12 @@
  * limitations under the License.
  * #L%
  */
+
 package org.broadleafcommerce.common.web;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.SiteDefaultsDTO;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.currency.domain.BroadleafRequestedCurrencyDto;
 import org.broadleafcommerce.common.currency.service.BroadleafCurrencyService;
@@ -59,6 +61,9 @@ public class BroadleafCurrencyResolverImpl implements BroadleafCurrencyResolver 
     @Resource(name = "blCurrencyService")
     private BroadleafCurrencyService broadleafCurrencyService;
 
+    @Resource(name = "blSiteDefaultsExtensionManager")
+    private SiteDefaultsExtensionManager siteDefaultsExtensionManager;
+
     /**
      * Responsible for returning the currency to use for the current request.
      */
@@ -96,6 +101,13 @@ public class BroadleafCurrencyResolverImpl implements BroadleafCurrencyResolver 
             }
         }
 
+        // 4.5) Check the a runtime-weaved extension manager, with access to Enterprise MutiTenant site
+        SiteDefaultsDTO siteDefaultsDTO = new SiteDefaultsDTO();
+        siteDefaultsExtensionManager.getProxy().retrieveDefautls(siteDefaultsDTO);
+        if (siteDefaultsDTO.getDefaultCurrency() != null) {
+            desiredCurrency = siteDefaultsDTO.getDefaultCurrency();
+        }
+
         // 5) Lookup default currency from DB
         BroadleafCurrency defaultCurrency = broadleafCurrencyService.findDefaultBroadleafCurrency();
         if (desiredCurrency == null) {
@@ -113,7 +125,4 @@ public class BroadleafCurrencyResolverImpl implements BroadleafCurrencyResolver 
         BroadleafRequestedCurrencyDto dto = new BroadleafRequestedCurrencyDto(currencyToUse, desiredCurrency);
         return dto;
     }
-
-
-
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafCurrencyResolverImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafCurrencyResolverImpl.java
@@ -103,7 +103,7 @@ public class BroadleafCurrencyResolverImpl implements BroadleafCurrencyResolver 
 
         // 4.5) Check the a runtime-weaved extension manager, with access to Enterprise MutiTenant site
         SiteDefaultsDTO siteDefaultsDTO = new SiteDefaultsDTO();
-        siteDefaultsExtensionManager.getProxy().retrieveDefautls(siteDefaultsDTO);
+        siteDefaultsExtensionManager.getProxy().retrieveDefaults(siteDefaultsDTO);
         if (siteDefaultsDTO.getDefaultCurrency() != null) {
             desiredCurrency = siteDefaultsDTO.getDefaultCurrency();
         }

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafLocaleResolverImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafLocaleResolverImpl.java
@@ -105,7 +105,7 @@ public class BroadleafLocaleResolverImpl implements BroadleafLocaleResolver {
 
         //  Fourth, use the a runtime-weaved extension manager, with access to Enterprise MutiTenant site
         SiteDefaultsDTO siteDefaultsDTO = new SiteDefaultsDTO();
-        siteDefaultsExtensionManager.getProxy().retrieveDefautls(siteDefaultsDTO);
+        siteDefaultsExtensionManager.getProxy().retrieveDefaults(siteDefaultsDTO);
 
         Locale managedLocale = siteDefaultsDTO.getDefaultLocale(); //not good to repeatedly call the DTO. 
         if (managedLocale != null) {

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsAbstractHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsAbstractHandler.java
@@ -27,7 +27,7 @@ import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 public class SiteDefaultsAbstractHandler extends AbstractExtensionHandler implements SiteDefaultsResolver {
 
     @Override
-    public ExtensionResultStatusType retrieveDefautls(SiteDefaultsDTO defautlsDTO) {
+    public ExtensionResultStatusType retrieveDefaults(SiteDefaultsDTO defautlsDTO) {
         return ExtensionResultStatusType.NOT_HANDLED;
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsAbstractHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsAbstractHandler.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * broadleaf-multitenant-singleschema
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.common.web;
+
+import org.broadleafcommerce.common.SiteDefaultsDTO;
+import org.broadleafcommerce.common.extension.AbstractExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+
+public class SiteDefaultsAbstractHandler extends AbstractExtensionHandler implements SiteDefaultsResolver {
+
+    @Override
+    public ExtensionResultStatusType retrieveDefautls(SiteDefaultsDTO defautlsDTO) {
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsExtensionManager.java
@@ -27,10 +27,10 @@ import org.springframework.stereotype.Service;
  * @author gonzalo díaz
  */
 @Service("blSiteDefaultsExtensionManager")
-public class SiteDefaultsExtensionManager extends ExtensionManager<SiteDefaultsAbstractHandler> {
+public class SiteDefaultsExtensionManager extends ExtensionManager<SiteDefaultsResolver> {
 
     public SiteDefaultsExtensionManager() {
-        super(SiteDefaultsAbstractHandler.class);
+        super(SiteDefaultsResolver.class);
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsExtensionManager.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.common.web;
+
+import org.broadleafcommerce.common.extension.ExtensionManager;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author gonzalo díaz
+ */
+@Service("blSiteDefaultsExtensionManager")
+public class SiteDefaultsExtensionManager extends ExtensionManager<SiteDefaultsAbstractHandler> {
+
+    public SiteDefaultsExtensionManager() {
+        super(SiteDefaultsAbstractHandler.class);
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * broadleaf-multitenant-singleschema
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.broadleafcommerce.common.web;
+
+import org.broadleafcommerce.common.SiteDefaultsDTO;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+
+/**
+ * interface that defines what generic behavior I want from any particular EM implementation
+ * (in this case, retrieve default information from a site)
+ * @author gdiaz
+ *
+ */
+public interface SiteDefaultsResolver {
+
+    public ExtensionResultStatusType retrieveDefautls(SiteDefaultsDTO defautlsDTO);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
@@ -21,6 +21,7 @@
 package org.broadleafcommerce.common.web;
 
 import org.broadleafcommerce.common.SiteDefaultsDTO;
+import org.broadleafcommerce.common.extension.ExtensionHandler;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 
 /**
@@ -29,7 +30,7 @@ import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
  * @author gdiaz
  *
  */
-public interface SiteDefaultsResolver {
+public interface SiteDefaultsResolver extends ExtensionHandler {
 
     public ExtensionResultStatusType retrieveDefautls(SiteDefaultsDTO defautlsDTO);
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/SiteDefaultsResolver.java
@@ -32,6 +32,6 @@ import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
  */
 public interface SiteDefaultsResolver extends ExtensionHandler {
 
-    public ExtensionResultStatusType retrieveDefautls(SiteDefaultsDTO defautlsDTO);
+    public ExtensionResultStatusType retrieveDefaults(SiteDefaultsDTO defautlsDTO);
 
 }


### PR DESCRIPTION
This pull request allows to make use of a new extension manager that retrieves site defaults, allowing for multi-tenant capabilities. Specifically, this PR covers the core, non-enterprise part of those handler implementations.

The originating QA issue is BroadleafCommerce/QA#753