### PR TITLE
Use the `StaticAssetPathService` to properly resolve images

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/expression/AssetURLVariableExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/expression/AssetURLVariableExpression.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2015 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.web.expression;
+
+import org.broadleafcommerce.common.file.service.StaticAssetPathService;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+
+import javax.annotation.Resource;
+
+/**
+ * For HTML fields maintained in the admin, redactor allows the user to select images. These images need to be able to be served from a CDN.
+ * Goal is to be able to use this syntax in html pages.
+ * Example of trying to  resolve images in longDescription:
+ *
+ * <div th:utext="${#cms.fixUrl('__*{longDescription}__')}" id="description"></div>
+ *
+ * @author by reginaldccole
+ */
+public class AssetURLVariableExpression implements BroadleafVariableExpression {
+
+    @Resource(name="blStaticAssetPathService")
+    protected StaticAssetPathService staticAssetPathService;
+
+
+    @Override
+    public String getName() {
+        return "cms";
+    }
+
+
+    /**
+     * This method will resolve image urls located in HTML.
+     * @see StaticAssetPathService#convertAllAssetPathsInContent(String, boolean)
+     * @param content
+     * @return
+     */
+    public String fixUrl(String content){
+        boolean isSecure = false;
+        BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
+        if (brc != null) {
+             isSecure  = brc.getRequest().isSecure();
+        }
+        return staticAssetPathService.convertAllAssetPathsInContent(content,isSecure);
+    }
+
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafProductController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafProductController.java
@@ -73,15 +73,6 @@ public class BroadleafProductController extends BroadleafAbstractController impl
         ModelAndView model = new ModelAndView();
         Product product = (Product) request.getAttribute(ProductHandlerMapping.CURRENT_PRODUCT_ATTRIBUTE_NAME);
         assert(product != null);
-        String cmsPrefix = staticAssetPathService.getStaticAssetUrlPrefix();
-        String originalValue = product.getDefaultSku().getLongDescription();
-        if (StringUtils.isNotBlank(originalValue) && StringUtils.isNotBlank(cmsPrefix) && originalValue.contains(cmsPrefix)) {
-            //This may either be an ASSET_LOOKUP image path or an HTML block (with multiple <img>) or a plain STRING that contains the cmsPrefix.
-            //If there is an environment prefix configured (e.g. a CDN), then we must replace the cmsPrefix with this one.
-            String fldValue = staticAssetPathService.convertAllAssetPathsInContent(originalValue, request.isSecure());
-                product.setLongDescription(fldValue);
-
-        }
         model.addObject(MODEL_ATTRIBUTE_NAME, product);
         Set<Product> allProductsSet = new HashSet<Product>();
         allProductsSet.add(product);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafProductController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafProductController.java
@@ -22,6 +22,8 @@ package org.broadleafcommerce.core.web.controller.catalog;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.file.service.StaticAssetPathService;
+import org.broadleafcommerce.common.media.domain.Media;
 import org.broadleafcommerce.common.template.TemplateOverrideExtensionManager;
 import org.broadleafcommerce.common.template.TemplateType;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
@@ -36,6 +38,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Resource;
@@ -57,7 +60,11 @@ public class BroadleafProductController extends BroadleafAbstractController impl
     @Autowired(required = false)
     @Qualifier("blProductDeepLinkService")
     protected DeepLinkService<Product> deepLinkService;
-    
+
+    @Resource(name="blStaticAssetPathService")
+    protected StaticAssetPathService staticAssetPathService;
+
+
     @Resource(name = "blTemplateOverrideExtensionManager")
     protected TemplateOverrideExtensionManager templateOverrideManager;
 
@@ -66,7 +73,15 @@ public class BroadleafProductController extends BroadleafAbstractController impl
         ModelAndView model = new ModelAndView();
         Product product = (Product) request.getAttribute(ProductHandlerMapping.CURRENT_PRODUCT_ATTRIBUTE_NAME);
         assert(product != null);
-        
+        String cmsPrefix = staticAssetPathService.getStaticAssetUrlPrefix();
+        String originalValue = product.getDefaultSku().getLongDescription();
+        if (StringUtils.isNotBlank(originalValue) && StringUtils.isNotBlank(cmsPrefix) && originalValue.contains(cmsPrefix)) {
+            //This may either be an ASSET_LOOKUP image path or an HTML block (with multiple <img>) or a plain STRING that contains the cmsPrefix.
+            //If there is an environment prefix configured (e.g. a CDN), then we must replace the cmsPrefix with this one.
+            String fldValue = staticAssetPathService.convertAllAssetPathsInContent(originalValue, request.isSecure());
+                product.setLongDescription(fldValue);
+
+        }
         model.addObject(MODEL_ATTRIBUTE_NAME, product);
         Set<Product> allProductsSet = new HashSet<Product>();
         allProductsSet.add(product);

--- a/core/broadleaf-framework-web/src/main/resources/bl-framework-web-applicationContext.xml
+++ b/core/broadleaf-framework-web/src/main/resources/bl-framework-web-applicationContext.xml
@@ -111,6 +111,7 @@
     <bean id="blVariableExpressions" class="org.springframework.beans.factory.config.ListFactoryBean">
         <property name="sourceList">
             <list>
+                <bean class="org.broadleafcommerce.common.web.expression.AssetURLVariableExpression" />
                 <bean class="org.broadleafcommerce.common.web.expression.NullBroadleafVariableExpression" />
                 <bean class="org.broadleafcommerce.common.web.expression.BRCVariableExpression" />
                 <bean class="org.broadleafcommerce.common.web.expression.PropertiesVariableExpression" />


### PR DESCRIPTION
Addresses BroadleafCommerce/QA#470

<h3>Steps to reproduce problem:</h3>
1. set `asset.server.url.prefix=[some cdn] ` in  common-shared properties:
2. in admin application Catalog >> Products >> "Sudden Death sauce"
3. add an image in the description box. save,promote,and approve change
4. navigate to the product on the site
Result: If you check the `url` src of the image that is part of the description, you will see that the image was served from the application and not the CDN. 

<h3>Solution:</h3>
Use a Thymeleaf CMS expression parser that replaces cmsstatic with CDN urls. 

<h3>How to Test fix:</h3>
1. In product.html file; around line 36 where template tries to display the description on the page, 
 insert this line `  <div th:utext="${#cms.fixUrl('__*{longDescription}__')}" id="description"></div>`
2. set `asset.server.url.prefix=[some cdn] ` in  common-shared properties:
3. in admin application Catalog >> Products >> "Sudden Death sauce"
4. add an image in the description box. save,promote,and approve change
5. navigate to the product on the site
