### PR TITLE
Reworked the check for masterFieldGroup method

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/FieldGroup.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/FieldGroup.java
@@ -162,8 +162,12 @@ public class FieldGroup {
         if (getTitle() != null && getTitle().toLowerCase().contains("master")) {
             return true;
         }
+        return false;
+    }
+
+    public boolean containsFieldData() {
         for (Field field : fields) {
-            if (field.isMasterField() && field.getValue() != null) {
+            if (field.getValue() != null) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request removes the dependency of fields needing to be specified as **master**. Only `FieldGroups` will need this distinction. This change will enable the use of a flag that will be introduced for this issue: https://github.com/BroadleafCommerce/QA/issues/671. 

Also added a convenience method to check if a `FieldGroup` contains field data.

Source issue can be found here: https://github.com/BroadleafCommerce/QA/issues/750