### PR TITLE
Creates a DirectCopyTransformer version that conditionally executes based on a Spring property

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/OptionalDirectCopyClassTransformer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/OptionalDirectCopyClassTransformer.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.jpa.copy;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+
+/**
+ * Based on a Spring property value resolving to a boolean, this ClassTransformer will optionally perform
+ * bytecode transformations.
+ *
+ * @author Jeff Fischer
+ */
+public class OptionalDirectCopyClassTransformer extends DirectCopyClassTransformer implements BeanFactoryAware {
+
+    protected String propertyName;
+    protected ConfigurableBeanFactory beanFactory;
+
+    public OptionalDirectCopyClassTransformer(String moduleName) {
+        super(moduleName);
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = (ConfigurableBeanFactory) beanFactory;
+    }
+
+    /**
+     * Will return null if the Spring property value defined in {@link #propertyName} resolves to false, or if
+     * an exception occurs while trying to determine the value for the property.
+     *
+     * @param loader
+     * @param className
+     * @param classBeingRedefined
+     * @param protectionDomain
+     * @param classfileBuffer
+     * @return
+     * @throws IllegalClassFormatException
+     */
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+            ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+
+        Boolean shouldProceed;
+        try {
+            String value = beanFactory.resolveEmbeddedValue("${" + propertyName + ":false}");
+            shouldProceed = Boolean.parseBoolean(value);
+        } catch (Exception e) {
+            shouldProceed = false;
+        }
+        if (!shouldProceed) {
+            return null;
+        }
+
+        return super.transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public void setPropertyName(String propertyName) {
+        this.propertyName = propertyName;
+    }
+}


### PR DESCRIPTION
Fixes #1515
BroadleafCommerce/QA#454

It is sometimes advantageous to conditionally perform class transformation of domain classes based on a property. This would be primarily used during a patch release lifecycle where there is an expectation of no alteration to database schema (i.e. the release should be "drop-in"). However, it is still advantageous for specific implementations, that are willing to absorb the schema adjustments immediately, to consume the fix. They may still do so by setting a property defined as part of the issue resolution, which would engage the class transformation and subsequent schema changes.
