### PR TITLE
QA#764 - Add property to not return the default value for a translated field if that value is not in the same language.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/DynamicTranslationProvider.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/DynamicTranslationProvider.java
@@ -50,6 +50,8 @@ public class DynamicTranslationProvider {
             
             if (StringUtils.isNotBlank(translatedValue)) {
                 valueToReturn = translatedValue;
+            } else {
+                valueToReturn = translationService.getDefaultTranslationValue(obj, field, locale, defaultValue);
             }
         }
             

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationService.java
@@ -130,4 +130,23 @@ public interface TranslationService {
      */
     Cache getCache();
 
+    /**
+     * Intended for use with the {@link DynamicTranslationProvider} to determine the default value when a 
+     * translation was not provided.
+     * 
+     * The default implementation of this method relies on a system property "returnBlankTranslationForNotDefaultLocale". 
+     * If this is true, the system will return blank if the language of the defaultLocale does not match the language
+     * of the passed in locale.
+     * 
+     * For example, consider the "longDescription" property and the system default locale is "en".   If this method is 
+     * called for a locale of "en_CA", the requestedDefaultValue will be returned.   If the method is called with a value
+     * of "fr_CA", blank will be returned.
+     *  
+     * @param entity
+     * @param property
+     * @param locale
+     * @param requestedDefaultValue
+     * @return
+     */
+    String getDefaultTranslationValue(Object entity, String property, Locale locale, String requestedDefaultValue);
 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -427,11 +427,8 @@ public class TranslationServiceImpl implements TranslationService {
     public String getDefaultTranslationValue(Object entity, String property, Locale locale,
             String requestedDefaultValue) {
 
-        if (returnBlankTranslationForNotDefaultLocale) {
-            if (localeMatchesDefaultLocale(locale)) {
-            } else if (!propertyInDefaultLocaleExceptionList(entity, property)) {
-                return "";
-            }
+        if (returnBlankTranslationForNotDefaultLocale && !localeMatchesDefaultLocale(locale) && !propertyInDefaultLocaleExceptionList(entity, property)) {
+            return "";
         }
 
         return requestedDefaultValue;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -38,12 +38,15 @@ import org.broadleafcommerce.common.i18n.dao.TranslationDao;
 import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
 import org.broadleafcommerce.common.i18n.domain.Translation;
 import org.broadleafcommerce.common.i18n.domain.TranslationImpl;
+import org.broadleafcommerce.common.locale.service.LocaleService;
+import org.broadleafcommerce.common.locale.util.LocaleUtil;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -75,6 +78,15 @@ public class TranslationServiceImpl implements TranslationService {
 
     @Value("${translation.thresholdForFullCache:1000}")
     protected int thresholdForFullCache;
+
+    @Value("${returnBlankTranslationForNotDefaultLocale:false}")
+    protected boolean returnBlankTranslationForNotDefaultLocale;
+
+    @Resource(name = "blTranslationExceptionProperties")
+    protected List<String> translationExceptionProperties = new ArrayList<String>();
+
+    @Resource(name = "blLocaleService")
+    protected LocaleService localeService;
 
     @Resource(name="blGenericEntityDao")
     protected GenericEntityDao genericEntityDao;
@@ -410,6 +422,57 @@ public class TranslationServiceImpl implements TranslationService {
             // don't cache when not in a SandBox
             return -1;
         }
+    }
+
+    public String getDefaultTranslationValue(Object entity, String property, Locale locale,
+            String requestedDefaultValue) {
+
+        if (returnBlankTranslationForNotDefaultLocale) {
+            if (localeMatchesDefaultLocale(locale)) {
+            } else if (!propertyInDefaultLocaleExceptionList(entity, property)) {
+                return "";
+            }
+        }
+
+        return requestedDefaultValue;
+    }
+
+    /**
+     * Returns true if the passed in entity / property combination is in the defaultLocaleExceptionList
+     * 
+     * The default implementation checks the "translationExceptionProperties" list to see if the
+     * property matches one of the regularExpressions in that list.
+     * 
+     * Implementors are expected to override this method for implementation specific needs. 
+     * 
+     * @param entity
+     * @param property
+     * @return
+     */
+    protected boolean propertyInDefaultLocaleExceptionList(Object entity, String property) {
+        TranslatedEntity entityType = getEntityType(entity);
+        if (entityType != null && entityType.getFriendlyType() != null) {
+            for (String exceptionProperty : translationExceptionProperties) {
+                if (property.matches(exceptionProperty)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the passed in locale's language matches the Broadleaf default locale.
+     * @param locale
+     * @return
+     */
+    protected boolean localeMatchesDefaultLocale(Locale locale) {
+        String defaultLanguage = LocaleUtil.findLanguageCode(localeService.findDefaultLocale());
+
+        if (defaultLanguage != null && locale != null) {
+            return defaultLanguage.equals(locale.getLanguage());
+        }
+        return false;
     }
 
 }

--- a/common/src/main/resources/bl-common-applicationContext.xml
+++ b/common/src/main/resources/bl-common-applicationContext.xml
@@ -377,4 +377,12 @@
             </map>
         </property>
     </bean>
+    
+    <bean id="blTranslationExceptionProperties" class="org.springframework.beans.factory.config.ListFactoryBean" >
+        <property name="sourceList">
+            <list>
+                <value>pageTemplate.*</value>
+            </list>
+        </property>
+    </bean>    
 </beans>


### PR DESCRIPTION
Instead, return blank.   The new property to drive this behavior is named "returnBlankTranslationForNotDefaultLocale".

This ticket also provides an overridable method in TranslationServiceImpl to exclude some fields from this logic.     In particular, the CMS lookup fields (which start with pageTemplate) needed to be excluded for the home page to render in heat-clinic.     This is because all page template fields currently go through translation provider (even fields like ID) which are not even translatable.

Relates to BroadleafCommerce/QA#764

## Testing 
- Set  "returnBlankTranslationForNotDefaultLocale" to true.
- Update the DB so that a language does not have an out of box field (for example, removing the french longDescription entries provides a good test.
- View the home page in english and french.
- With the property set, you should not see any longDescriptions for the products for which the 

For example, see the first 2 products below which had the longDescription removed from the translation table.    Note that with the above property set to "false" (the default), the english translation would show.   (see screenshot 2).

![screen shot 2015-07-22 at 1 33 14 am](https://cloud.githubusercontent.com/assets/1189191/8819384/a6a30970-3011-11e5-8b6b-494aee15b7b5.png)

Also, of note is that the TranslationServiceImpl provides a way to exclude some fields from this behavior.    This can be done by adding items to the `blTranslationExceptionProperties` which by default is set to the following.

```
    <bean id="blTranslationExceptionProperties" class="org.springframework.beans.factory.config.ListFactoryBean" >
        <property name="sourceList">
            <list>
                <value>pageTemplate.*</value>
            </list>
        </property>
    </bean>    
```

> The list is a list of regular expressions.   If they match the property being translated then that property will default to the direct value regardless of the `returnBlankTranslationForNotDefaultLocale` property.

> The `pageTemplate.*` regular expression is required for anyone using foreign key lookups from the BLC CMS and therefore is included by default.   Other items can be added to the `blTranslationExceptionProperties` List component.

> Also of note, the methods added to TranslationServiceImpl provide for the ability for implementations to override if the out of box solution is not sufficient.     Prior to this commit, there was no ability to override as business logic was contained in the static method of `DynamicTranslationProvider`.

