### PR TITLE
Prevent loss of modal form data by way of errant clicks 

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/bootstrap.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/bootstrap.js
@@ -165,13 +165,20 @@
           this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
             .appendTo(document.body)
 
-          this.$backdrop.click(function() {
-              BLCAdmin.hideCurrentModal();
-          }
-            //this.options.backdrop == 'static' ?
-              //$.proxy(this.$element[0].focus, this.$element[0])
-            //: $.proxy(this.hide, this)
-          )
+            /*
+             * default behavior for modals will be that the only way to escape them
+             * is to click "escape" key or press the close button. To change this,
+             * simply uncomment or change the code below what handles what happens
+             * to modals once the user clicks a space on the backdrop
+             */
+
+          //  this.$backdrop.click(function() {
+          //          BLCAdmin.hideCurrentModal();
+          //      }
+          //  //this.options.backdrop == 'static' ?
+          //    //$.proxy(this.$element[0].focus, this.$element[0])
+          //  //: $.proxy(this.hide, this)
+          //)
 
           if (doAnimate) this.$backdrop[0].offsetWidth // force reflow
 


### PR DESCRIPTION
<h2>Problem</h2>
 Any clicks outside of the modal will cause the modal to close; the user then loses all data entered into the modal and is forced to start entering data all over again. 

<h2>Solution</h2>
By default, make sure the only way for a modal to close is by hitting `esc` key or by pressing the "close" button. 

Address BroadleafCommerce/QA#760