### PR TITLE
UpdateExecutor can create a parameterized query with an IN clause that has no params, causing a SQLException

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/UpdateExecutor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/UpdateExecutor.java
@@ -125,6 +125,9 @@ public class UpdateExecutor {
             } else {
                 arraySize = 800;
                 test -= arraySize;
+                if (test == 0) {
+                    eof = true;
+                }
             }
             Long[] temp = new Long[arraySize];
             System.arraycopy(all, pos, temp, 0, arraySize);


### PR DESCRIPTION
BroadleafCommerce/QA#772

UpdateExecutor attempts to break up queries with large quantities of IN clause params into multiple queries to avoid a sql exception related to exceeding the max number of IN clause params on several database platforms.

A bug was discovered where, if the number of params equaled a multiplier of 800, one trailing query with no params in the IN clause was issued. This creates invalid sql and the database will throw an error.