### PR TITLE
Check for a changed BigDecimal value fails due to handling of numerical scale

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/FieldPersistenceProviderAdapter.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/FieldPersistenceProviderAdapter.java
@@ -78,7 +78,14 @@ public class FieldPersistenceProviderAdapter extends AbstractFieldPersistencePro
                 value = ((String) value).trim();
             }
             if (value instanceof BigDecimal) {
-                checkValue = ((BigDecimal) checkValue).setScale(((BigDecimal) value).scale(), RoundingMode.HALF_UP);
+                BigDecimal origValue = (BigDecimal) value;
+                BigDecimal newValue = (BigDecimal) checkValue;
+                //set the scale of one of the BigDecimal values to the larger of the two scales
+                if (newValue.scale() < origValue.scale()) {
+                    checkValue = newValue.setScale(origValue.scale(), RoundingMode.UNNECESSARY);
+                } else if (origValue.scale() < newValue.scale()) {
+                    value = origValue.setScale(newValue.scale(), RoundingMode.UNNECESSARY);
+                }
             }
             dirty = value == null || !value.equals(checkValue);
         }


### PR DESCRIPTION
Changing the BigDecimal dirty check to accommodate for BigDecimals with different scales.  The change is to use the larger scale of the two BigDecimals prior to doing the comparison.  Note that this issue was found when using an Oracle JDBC driver.  The driver does not assume any scale from the database.

Addresses BroadleafCommerce/QA#775