### PR TITLE
Failed to Lookup another Page Template in page

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/PageTemplateCustomPersistenceHandler.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/PageTemplateCustomPersistenceHandler.java
@@ -123,12 +123,13 @@ public class PageTemplateCustomPersistenceHandler extends CustomPersistenceHandl
         List<PageTemplateFieldGroupXref> fieldGroupXrefs = null;
 
         List<FieldGroup> fieldGroups = new ArrayList<FieldGroup>();
-        if (template != null) {
-            fieldGroupXrefs = template.getFieldGroupXrefs();
-        }
-
+        
         if (page.getPageTemplate() != null) {
             fieldGroupXrefs = page.getPageTemplate().getFieldGroupXrefs();
+        }
+
+        if (template != null) {
+            fieldGroupXrefs = template.getFieldGroupXrefs();
         }
 
         if (fieldGroupXrefs != null) {


### PR DESCRIPTION
When we choose another page template by lookup, it returned always old template.
look 130 ~ 139 line.
Even template has requested by user's lookup, getFieldGroups always return page.getPageTemplate.
Thats why we got always same template.

It seems need to change two if statements order.
