### PR TITLE
Missing parent's pages from ajax dynamicform call 

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -407,6 +407,11 @@ $(document).ready(function() {
                     var $dynamicContainer = $("div.dynamic-form-container[data-dynamicpropertyname='" + trigger[1] + "']");
                     var url = $dynamicContainer.data('currenturl') + '?propertyTypeId=' + fields['id'];
                     
+                    if ($('div.dynamic-form-container').attr("data-dynamicpropertyname")=="pageTemplate"){
+                    	var pagesId = "&pagesId="+$("input#id").val();
+                        url = url + pagesId;
+                    }
+                    
                     BLC.ajax({
                         url : url,
                         type : "GET"


### PR DESCRIPTION
When we click lookup button in Page to choose Page Template and select a row in modal window, we encounter error message like below.

"Unable to perform inspect for entity: org.broadleafcommerce.cms.page.domain.PageTemplate"

it is cause of request parameter for parent's page is missing when ajax dynamicform call.

It seems to need to some change code.

related to below.
open_admin_style.js.admin.components.listGrid.js
