### PR TITLE
Added reply-to support in email

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
@@ -37,6 +37,7 @@ public class EmailInfo implements Serializable {
     private String emailTemplate;
     private String subject;
     private String fromAddress;
+    private String replyTo;
     private String messageBody;
     private String encoding = "UTF8";
     private List<Attachment> attachments = new ArrayList<Attachment>();
@@ -84,6 +85,22 @@ public class EmailInfo implements Serializable {
      */
     public void setSubject(String subject) {
         this.subject = subject;
+    }
+
+    /**
+     *
+     * @return the reply to address
+     */
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    /**
+     *
+     * @param replyTo the reply to address to set
+     */
+    public void setReplyTo(String replyTo) {
+        this.replyTo = replyTo;
     }
 
     /**
@@ -158,6 +175,7 @@ public class EmailInfo implements Serializable {
         info.setEmailTemplate(emailTemplate);
         info.setEmailType(emailType);
         info.setFromAddress(fromAddress);
+        info.setReplyTo(replyTo);
         info.setMessageBody(messageBody);
         info.setSendAsyncPriority(sendAsyncPriority);
         info.setSendEmailReliableAsync(sendEmailReliableAsync);

--- a/common/src/main/java/org/broadleafcommerce/common/email/service/message/MessageCreator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/message/MessageCreator.java
@@ -60,6 +60,9 @@ public abstract class MessageCreator {
                 message.setTo(emailUser.getEmailAddress());
                 message.setFrom(info.getFromAddress());
                 message.setSubject(info.getSubject());
+                if (info.getReplyTo() != null && !info.getReplyTo().isEmpty()) {
+                    message.setReplyTo(info.getReplyTo());
+                }
                 if (emailUser.getBCCAddresses() != null && emailUser.getBCCAddresses().length > 0) {
                     message.setBcc(emailUser.getBCCAddresses());
                 }

--- a/integration/src/test/java/org/broadleafcommerce/common/email/service/EmailTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/email/service/EmailTest.java
@@ -55,6 +55,7 @@ public class EmailTest extends BaseTest {
     public void testSynchronousEmail() throws Exception {
         EmailInfo info = new EmailInfo();
         info.setFromAddress("me@test.com");
+        info.setReplyTo("reply@test.com");
         info.setSubject("test");
         info.setEmailTemplate("org/broadleafcommerce/common/email/service/template/default.vm");
         info.setSendEmailReliableAsync("false");


### PR DESCRIPTION
It would be useful for us to be able to customize the reply-to address when sending emails. This patch allows that to happen.