### PR TITLE
Do not only add friendly admin permissions to the Spring Security Authorities, add all of them

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminSecurityHelper.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminSecurityHelper.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.server.security.service;
+
+import org.broadleafcommerce.openadmin.server.security.domain.AdminPermission;
+import org.springframework.security.core.GrantedAuthority;
+import java.util.Collection;
+
+/**
+ * @author Philip Baggett (pbaggett)
+ */
+public interface AdminSecurityHelper {
+
+    /**
+     * Adds the hierarchy of each admin permission to the collection of granted authorities.
+     *
+     * @param grantedAuthorities the collection that authorities will be added to
+     * @param adminPermissions the collection of permissions who's hierarchies will be put into grantedAuthorities
+     */
+    void addAllPermissionsToAuthorities(Collection<GrantedAuthority> grantedAuthorities, Collection<AdminPermission> adminPermissions);
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminSecurityHelperImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminSecurityHelperImpl.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.server.security.service;
+
+import org.broadleafcommerce.openadmin.server.security.domain.AdminPermission;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import java.util.Collection;
+
+/**
+ * @author Philip Baggett (pbaggett)
+ */
+@Component("blAdminSecurityHelper")
+public class AdminSecurityHelperImpl implements AdminSecurityHelper {
+
+    @Override
+    public void addAllPermissionsToAuthorities(Collection<GrantedAuthority> grantedAuthorities, Collection<AdminPermission> adminPermissions) {
+        for (AdminPermission permission : adminPermissions) {
+            if(permission.isFriendly()) {
+                for (AdminPermission childPermission : permission.getAllChildPermissions()) {
+                    grantedAuthorities.add(new SimpleGrantedAuthority(childPermission.getName()));
+                }
+            } else {
+                grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+            }
+        }
+    }
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminUserDetailsServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminUserDetailsServiceImpl.java
@@ -17,21 +17,17 @@
  */
 package org.broadleafcommerce.openadmin.server.security.service;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.Resource;
-
-import org.broadleafcommerce.openadmin.server.security.domain.AdminPermission;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminRole;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.GrantedAuthorityImpl;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Resource;
 
 /**
  * @author Jeff Fischer
@@ -40,6 +36,9 @@ public class AdminUserDetailsServiceImpl implements UserDetailsService {
 
     @Resource(name="blAdminSecurityService")
     protected AdminSecurityService adminSecurityService;
+
+    @Resource(name="blAdminSecurityHelper")
+    protected AdminSecurityHelper adminSecurityHelper;
     
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
@@ -50,25 +49,9 @@ public class AdminUserDetailsServiceImpl implements UserDetailsService {
 
         List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
         for (AdminRole role : adminUser.getAllRoles()) {
-            for (AdminPermission permission : role.getAllPermissions()) {
-                if(permission.isFriendly()) {
-                    for (AdminPermission childPermission : permission.getAllChildPermissions()) {
-                        authorities.add(new SimpleGrantedAuthority(childPermission.getName()));
-                    }
-                } else {
-                    authorities.add(new SimpleGrantedAuthority(permission.getName()));
-                }
-            }
+            adminSecurityHelper.addAllPermissionsToAuthorities(authorities, role.getAllPermissions());
         }
-        for (AdminPermission permission : adminUser.getAllPermissions()) {
-            if(permission.isFriendly()) {
-                for (AdminPermission childPermission : permission.getAllChildPermissions()) {
-                    authorities.add(new SimpleGrantedAuthority(childPermission.getName()));
-                }
-            } else {
-                authorities.add(new SimpleGrantedAuthority(permission.getName()));
-            }
-        }
+        adminSecurityHelper.addAllPermissionsToAuthorities(authorities, adminUser.getAllPermissions());
         for (String perm : AdminSecurityService.DEFAULT_PERMISSIONS) {
             authorities.add(new GrantedAuthorityImpl(perm));
         }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminUserProvisioningServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/AdminUserProvisioningServiceImpl.java
@@ -19,7 +19,6 @@ package org.broadleafcommerce.openadmin.server.security.service;
 
 import org.apache.commons.lang.StringUtils;
 import org.broadleafcommerce.common.security.BroadleafExternalAuthenticationUserDetails;
-import org.broadleafcommerce.openadmin.server.security.domain.AdminPermission;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminRole;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUserImpl;
@@ -27,12 +26,10 @@ import org.broadleafcommerce.openadmin.server.security.external.AdminExternalLog
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Resource;
 
 /**
@@ -50,6 +47,9 @@ public class AdminUserProvisioningServiceImpl implements AdminUserProvisioningSe
 
     @Resource(name = "blAdminExternalLoginExtensionManager")
     protected AdminExternalLoginUserExtensionManager adminExternalLoginExtensionManager;
+
+    @Resource(name="blAdminSecurityHelper")
+    protected AdminSecurityHelper adminSecurityHelper;
 
     protected Map<String, String[]> roleNameSubstitutions;
 
@@ -85,18 +85,7 @@ public class AdminUserProvisioningServiceImpl implements AdminUserProvisioningSe
             for (AdminRole role : adminRoles) {
                 if (newRoles.contains(role.getName())) {
                     grantedRoles.add(role);
-                    Set<AdminPermission> permissions = role.getAllPermissions();
-                    if (permissions != null && !permissions.isEmpty()) {
-                        for (AdminPermission permission : permissions) {
-                            if (permission.isFriendly()) {
-                                for (AdminPermission childPermission : permission.getAllChildPermissions()) {
-                                    newAuthorities.add(new SimpleGrantedAuthority(childPermission.getName()));
-                                }
-                            } else {
-                                newAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
-                            }
-                        }
-                    }
+                    adminSecurityHelper.addAllPermissionsToAuthorities(newAuthorities, role.getAllPermissions());
                 }
             }
         }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
@@ -210,7 +210,7 @@ public class CustomerServiceImpl implements CustomerService {
         HashMap<String, Object> vars = new HashMap<String, Object>();
         vars.put("customer", retCustomer);
         
-        emailService.sendTemplateEmail(customer.getEmailAddress(), getRegistrationEmailInfo(), vars);        
+        sendEmail(customer.getEmailAddress(), getRegistrationEmailInfo(), vars);
         notifyPostRegisterListeners(retCustomer);
         return retCustomer;
     }
@@ -500,7 +500,7 @@ public class CustomerServiceImpl implements CustomerService {
             if (activeUsernames.size() > 0) {
                 HashMap<String, Object> vars = new HashMap<String, Object>();
                 vars.put("userNames", activeUsernames);
-                emailService.sendTemplateEmail(emailAddress, getForgotUsernameEmailInfo(), vars);
+                sendEmail(emailAddress, getForgotUsernameEmailInfo(), vars);
             } else {
                 // send inactive username found email.
                 response.addErrorCode("inactiveUser");
@@ -552,7 +552,7 @@ public class CustomerServiceImpl implements CustomerService {
                 }
             }
             vars.put("resetPasswordUrl", resetPasswordUrl); 
-            emailService.sendTemplateEmail(customer.getEmailAddress(), getForgotPasswordEmailInfo(), vars);
+            sendEmail(customer.getEmailAddress(), getForgotPasswordEmailInfo(), vars);
         }
         return response;
     }
@@ -685,6 +685,10 @@ public class CustomerServiceImpl implements CustomerService {
         long tokenSaveTimeInMillis = fpst.getCreateDate().getTime();
         long minutesSinceSave = (currentTimeInMillis - tokenSaveTimeInMillis)/60000;
         return minutesSinceSave > tokenExpiredMinutes;
+    }
+
+    protected void sendEmail(String emailAddress, EmailInfo emailInfo, Map<String, Object> props) {
+        emailService.sendTemplateEmail(emailAddress, emailInfo, props);
     }
 
     public int getTokenExpiredMinutes() {


### PR DESCRIPTION
### This is old code that should be tested before merging. Also, evaluate the logic in `addAllPermissionsToAuthorities` as mentioned below.

Refactored the admin user authorities logic into a single location, reducing duplicated code and providing a single point to update the logic. Arguably, `addAllPermissionsToAuthorities` should also be updated to add friendly permissions themselves, whereas now it will only add child permissions of a friendly permission.

`CustomerService` can now be easily extended to customize the `sendEmail` method.