### PR TITLE
Enhance TranslationService to support multiple retrieval strategies

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
@@ -4,15 +4,17 @@
  * %%
  * Copyright (C) 2009 - 2017 Broadleaf Commerce
  * %%
- * NOTICE:  All information contained herein is, and remains
- * the property of Broadleaf Commerce, LLC
- * The intellectual and technical concepts contained
- * herein are proprietary to Broadleaf Commerce, LLC
- * and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Broadleaf Commerce, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * #L%
  */
 package org.broadleafcommerce.common.cache;

--- a/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
@@ -50,4 +50,9 @@ public class DefaultOverridePreCacheServiceImpl implements OverridePreCacheServi
     public void groomCacheByTargetEntity(String entityType, Serializable id) {
         //do nothing
     }
+
+    @Override
+    public void refreshCache() {
+        //do nothing
+    }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
@@ -44,6 +44,11 @@ public class DefaultOverridePreCacheServiceImpl implements OverridePreCacheServi
     }
 
     @Override
+    public boolean isActiveIsolatedSiteForType(Long siteId, String entityType) {
+        return false;
+    }
+
+    @Override
     public void groomCacheBySiteOverride(String entityType, Long cloneId, boolean isRemove) {
         //do nothing
     }

--- a/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Enterprise
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained
+ * herein are proprietary to Broadleaf Commerce, LLC
+ * and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Broadleaf Commerce, LLC.
+ * #L%
+ */
+package org.broadleafcommerce.common.cache;
+
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+import org.springframework.stereotype.Service;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Jeff Fischer
+ */
+@Service("blOverridePreCacheService")
+public class DefaultOverridePreCacheServiceImpl implements OverridePreCacheService {
+
+    @Override
+    public List<StandardCacheItem> findElements(String... cacheKeys) {
+        return null;
+    }
+
+    @Override
+    public boolean isActiveForType(String type) {
+        return false;
+    }
+
+    @Override
+    public void groomCacheBySiteOverride(String entityType, Long cloneId, boolean isRemove) {
+        //do nothing
+    }
+
+    @Override
+    public void groomCacheByTargetEntity(String entityType, Serializable id) {
+        //do nothing
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/DefaultOverridePreCacheServiceImpl.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
+ * Default implementation of {@link OverridePreCacheService}. Simply contains no-ops methods.
+ *
  * @author Jeff Fischer
  */
 @Service("blOverridePreCacheService")

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
@@ -4,15 +4,17 @@
  * %%
  * Copyright (C) 2009 - 2017 Broadleaf Commerce
  * %%
- * NOTICE:  All information contained herein is, and remains
- * the property of Broadleaf Commerce, LLC
- * The intellectual and technical concepts contained
- * herein are proprietary to Broadleaf Commerce, LLC
- * and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Broadleaf Commerce, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * #L%
  */
 package org.broadleafcommerce.common.cache;

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
@@ -22,12 +22,27 @@ package org.broadleafcommerce.common.cache;
 import org.broadleafcommerce.common.extension.StandardCacheItem;
 
 /**
+ * Performs cache item initialization for a specific entity type.
+ *
  * @author Jeff Fischer
  */
 public interface OverridePreCacheInitializer {
 
+    /**
+     * Whether or not this initializer is qualified to work on the given entity type
+     *
+     * @param type
+     * @return
+     */
     boolean isOverrideQualified(Class<?> type);
 
+    /**
+     * Perform any initialization tasks (e.g. exercising a lazy collection) and returns
+     * a StandardCacheItem instance.
+     *
+     * @param entity
+     * @return
+     */
     StandardCacheItem initializeOverride(Object entity);
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheInitializer.java
@@ -1,0 +1,31 @@
+/*
+ * #%L
+ * broadleaf-multitenant-singleschema
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained
+ * herein are proprietary to Broadleaf Commerce, LLC
+ * and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Broadleaf Commerce, LLC.
+ * #L%
+ */
+package org.broadleafcommerce.common.cache;
+
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface OverridePreCacheInitializer {
+
+    boolean isOverrideQualified(Class<?> type);
+
+    StandardCacheItem initializeOverride(Object entity);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
@@ -43,6 +43,17 @@ public interface OverridePreCacheService {
     List<StandardCacheItem> findElements(String... cacheKeys);
 
     /**
+     * Assuming the passed in site is a standard site, determine whether or not the standard site has any
+     * isolated values (i.e. not inherited) for the given type. This information is generally useful when making
+     * optimized query determinations for whether or not the standard site should be included in the query.
+     *
+     * @param siteId
+     * @param entityType
+     * @return
+     */
+    boolean isActiveIsolatedSiteForType(Long siteId, String entityType);
+
+    /**
      * Whether or not the cache is active for the specified type
      *
      * @param type the entity type to check

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
@@ -4,15 +4,17 @@
  * %%
  * Copyright (C) 2009 - 2017 Broadleaf Commerce
  * %%
- * NOTICE:  All information contained herein is, and remains
- * the property of Broadleaf Commerce, LLC
- * The intellectual and technical concepts contained
- * herein are proprietary to Broadleaf Commerce, LLC
- * and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Broadleaf Commerce, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * #L%
  */
 package org.broadleafcommerce.common.cache;

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * broadleaf-multitenant-singleschema
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Broadleaf Commerce, LLC
+ * The intellectual and technical concepts contained
+ * herein are proprietary to Broadleaf Commerce, LLC
+ * and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Broadleaf Commerce, LLC.
+ * #L%
+ */
+package org.broadleafcommerce.common.cache;
+
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface OverridePreCacheService {
+
+    List<StandardCacheItem> findElements(String... cacheKeys);
+
+    boolean isActiveForType(String type);
+
+    void groomCacheBySiteOverride(String entityType, Long cloneId, boolean isRemove);
+
+    void groomCacheByTargetEntity(final String entityType, final Serializable id);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
@@ -37,4 +37,6 @@ public interface OverridePreCacheService {
 
     void groomCacheByTargetEntity(final String entityType, final Serializable id);
 
+    void refreshCache();
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/OverridePreCacheService.java
@@ -25,18 +25,51 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
+ * Describes a service capable of maintaining a cache of standard site level overrides. This cache spans multiple
+ * entity types. This is a multitenant concept. An override declaration and the actual overridden entity
+ * are generally two different things. This cache is responsible for reviewing a list of overrides declarations and caching the
+ * referenced overridden entities.
+ *
  * @author Jeff Fischer
  */
 public interface OverridePreCacheService {
 
+    /**
+     * Find any cached items matching the passed keys
+     *
+     * @param cacheKeys the keys to check
+     * @return
+     */
     List<StandardCacheItem> findElements(String... cacheKeys);
 
+    /**
+     * Whether or not the cache is active for the specified type
+     *
+     * @param type the entity type to check
+     * @return
+     */
     boolean isActiveForType(String type);
 
+    /**
+     * Add or remove from the cache based on an override declaration.
+     *
+     * @param entityType
+     * @param cloneId
+     * @param isRemove
+     */
     void groomCacheBySiteOverride(String entityType, Long cloneId, boolean isRemove);
 
-    void groomCacheByTargetEntity(final String entityType, final Serializable id);
+    /**
+     * Update an overridden entity value in the cache
+     *
+     * @param entityType
+     * @param id
+     */
+    void groomCacheByTargetEntity(String entityType, Serializable id);
 
+    /**
+     * Refresh the entire cache structure. Presumably, this will clear and rebuild the structure.
+     */
     void refreshCache();
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/ItemStatus.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/ItemStatus.java
@@ -23,5 +23,5 @@ package org.broadleafcommerce.common.extension;
  * @author Jeff Fischer
  */
 public enum ItemStatus {
-    DELETED,NORMAL
+    DELETED,NORMAL,NONE
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/ResultType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/ResultType.java
@@ -27,5 +27,5 @@ package org.broadleafcommerce.common.extension;
  * @author Jeff Fischer
  */
 public enum ResultType {
-    STANDARD,STANDARD_CACHE,TEMPLATE,TEMPLATE_CACHE,IGNORE
+    STANDARD,STANDARD_CACHE,TEMPLATE,TEMPLATE_CACHE,IGNORE,IGNORE_CATALOG_ONLY
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/ResultType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/ResultType.java
@@ -27,5 +27,5 @@ package org.broadleafcommerce.common.extension;
  * @author Jeff Fischer
  */
 public enum ResultType {
-    STANDARD,STANDARD_CACHE,TEMPLATE,TEMPLATE_CACHE,IGNORE,IGNORE_CATALOG_ONLY
+    STANDARD,STANDARD_CACHE,TEMPLATE,TEMPLATE_CACHE,IGNORE, CATALOG_ONLY
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
@@ -178,4 +178,13 @@ public interface SparselyPopulatedQueryExtensionHandler extends ExtensionHandler
      */
     ExtensionResultStatusType isValidState(ExtensionResultHolder<Boolean> response);
 
+    /**
+     * Get a common id for an object that is consistent for a standard site (whether or not the test object is overridden in the standard site)
+     *
+     * @param testObject the object whose id is normalized
+     * @param response the container for the normalized id
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType getNormalizedId(Object testObject, ExtensionResultHolder<Long> response);
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
@@ -21,6 +21,7 @@ package org.broadleafcommerce.common.extension;
 
 import java.util.List;
 
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Order;
@@ -58,6 +59,32 @@ public interface SparselyPopulatedQueryExtensionHandler extends ExtensionHandler
      * @return the status of the extension operation
      */
     ExtensionResultStatusType refineRetrieve(Class<?> type, ResultType resultType, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Predicate> restrictions);
+
+    /**
+     * Add additional restrictions to the fetch query. Uses parameters, rather than embedding values directly in the query. This is more
+     * efficient from a Hibernate statement cache and database prepared statement cache perspective. Use in conjunction with
+     * {@link #refineQuery(Class, ResultType, TypedQuery)} to pass the actual parameter values before retrieving the query
+     * results.
+     *
+     * @param type the class type for the query
+     * @param resultType pass a ResultType of IGNORE to explicitly ignore refineRetrieve, even if the multitenant module is loaded
+     * @param builder
+     * @param criteria
+     * @param root
+     * @param restrictions any additional JPA criteria restrictions should be added here
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType refineParameterRetrieve(Class<?> type, ResultType resultType, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Predicate> restrictions);
+
+    /**
+     * Finish the query - possibly setting parameters
+     *
+     * @param type the class type for the query
+     * @param resultType pass a ResultType of IGNORE to explicitly ignore refineQuery, even if the multitenant module is loaded
+     * @param query the final Query instance to embellish
+     * @return
+     */
+    ExtensionResultStatusType refineQuery(Class<?> type, ResultType resultType, TypedQuery query);
 
     /**
      * Perform any setup operations. This is usually done before executing the query and can serve to prepare the BroadleafRequestContext (if applicable).

--- a/common/src/main/java/org/broadleafcommerce/common/extension/StandardCacheItem.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/StandardCacheItem.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
  */
 public class StandardCacheItem implements Serializable {
 
+    private String key;
     private Object cacheItem;
     private ItemStatus itemStatus;
 
@@ -48,4 +49,11 @@ public class StandardCacheItem implements Serializable {
         this.itemStatus = itemStatus;
     }
 
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
@@ -21,6 +21,7 @@ package org.broadleafcommerce.common.extension;
 
 import java.util.List;
 
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Order;
@@ -33,7 +34,18 @@ import javax.persistence.criteria.Root;
 public interface TemplateOnlyQueryExtensionHandler extends ExtensionHandler {
 
     /**
-     * Add additional restrictions to the fetch query
+     * Finish the query - possibly setting parameters
+     *
+     * @param type the class type for the query
+     * @param testObject supporting implementations may use this object to test for possible catalog query optimizations. This value can be null, in which case it is ignored.
+     * @param query the final Query instance to embellish
+     * @return
+     */
+    ExtensionResultStatusType refineQuery(Class<?> type, Object testObject, TypedQuery query);
+
+    /**
+     * Add additional restrictions to the fetch query. Use in conjunction with {@link #refineQuery(Class, Object, TypedQuery)} to set
+     * actual parameter values before retrieving results.
      *
      * @param type the class type for the query
      * @param testObject supporting implementations may use this object to test for possible catalog query optimizations. This value can be null, in which case it is ignored.
@@ -43,7 +55,7 @@ public interface TemplateOnlyQueryExtensionHandler extends ExtensionHandler {
      * @param restrictions any additional JPA criteria restrictions should be added here
      * @return the status of the extension operation
      */
-    ExtensionResultStatusType refineRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder,
+    ExtensionResultStatusType refineParameterRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder,
                                              CriteriaQuery criteria, Root root, List<Predicate> restrictions);
 
     /**

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
@@ -19,6 +19,8 @@
  */
 package org.broadleafcommerce.common.extension;
 
+import org.broadleafcommerce.common.i18n.service.SparseTranslationOverrideStrategy;
+
 import java.util.List;
 
 import javax.persistence.TypedQuery;
@@ -29,6 +31,11 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 /**
+ * Extension handler (generally for DAO usage) that allows contribution to a query (presumably from another module). The intent
+ * of this handler is to manipulate a query to not include standard site catalogs (template only). This is useful in some
+ * caching situations where it is advantageous to only look at template catalog values. {@link SparseTranslationOverrideStrategy}
+ * is an example use case. This is generally used in multitenant scenarios.
+ *
  * @author Jeff Fischer
  */
 public interface TemplateOnlyQueryExtensionHandler extends ExtensionHandler {

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.extension;
+
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface TemplateOnlyQueryExtensionHandler extends ExtensionHandler {
+
+    /**
+     * Add additional restrictions to the fetch query
+     *
+     * @param type the class type for the query
+     * @param testObject supporting implementations may use this object to test for possible catalog query optimizations. This value can be null, in which case it is ignored.
+     * @param builder
+     * @param criteria
+     * @param root
+     * @param restrictions any additional JPA criteria restrictions should be added here
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType refineRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder,
+                                             CriteriaQuery criteria, Root root, List<Predicate> restrictions);
+
+    /**
+     * Perform any setup operations. This is usually done before executing the query and can serve to prepare the BroadleafRequestContext (if applicable).
+     *
+     * @param type the class type for the query
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType setup(Class<?> type);
+
+    /**
+     * Perform any breakdown operations. This is usually done after executing the query and can serve to reset the BroadleafRequestContext (if applicable)
+     *
+     * @param type the class type for the query
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType breakdown(Class<?> type);
+
+    /**
+     * Add sorting to the fetch query
+     *
+     * @param type the class type for the query
+     * @param builder
+     * @param criteria
+     * @param root
+     * @param sorts any additional JPA order expressions should be added here
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType refineOrder(Class<?> type, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Order> sorts);
+
+    /**
+     * Determine if the current thread is in a valid state for sparse cache handling
+     *
+     * @param response
+     * @return
+     */
+    ExtensionResultStatusType isValidState(ExtensionResultHolder<Boolean> response);
+
+    ExtensionResultStatusType buildStatus(Object entity, ExtensionResultHolder<ItemStatus> response);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionHandler.java
@@ -103,4 +103,19 @@ public interface TemplateOnlyQueryExtensionHandler extends ExtensionHandler {
 
     ExtensionResultStatusType buildStatus(Object entity, ExtensionResultHolder<ItemStatus> response);
 
+    /**
+     * Validate and filter the results. This can be interesting when you have restricted the query with a test object and
+     * need to confirm the validity of the results. A nuanced example of this would be translations associated with a profile
+     * entity (e.g. StructuredContent). If you filter by the StructuredContent, you will be filtering translations by owning
+     * site. However, the resulting translations are not profile entities and will not available necessarily to the requesting
+     * site. As a result, we filter here and check the translations based on catalog visibility (Translations are dual
+     * discriminated). This is primarily to handle edge cases and will generally have no impact on the results.
+     *
+     * @param type
+     * @param testObject
+     * @param results
+     * @return
+     */
+    ExtensionResultStatusType filterResults(Class<?> type, Object testObject, List results);
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
@@ -19,19 +19,11 @@
  */
 package org.broadleafcommerce.common.extension;
 
-import org.broadleafcommerce.common.extension.ExtensionHandler;
-import org.broadleafcommerce.common.extension.ExtensionManager;
-import org.broadleafcommerce.common.extension.ExtensionManagerOperation;
-import org.broadleafcommerce.common.extension.ExtensionResultHolder;
-import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
-import org.broadleafcommerce.common.extension.ItemStatus;
-import org.broadleafcommerce.common.extension.ResultType;
-import org.broadleafcommerce.common.extension.SparselyPopulatedQueryExtensionHandler;
-import org.broadleafcommerce.common.extension.TemplateOnlyQueryExtensionHandler;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Order;
@@ -49,10 +41,17 @@ import javax.persistence.criteria.Root;
 @Service("blTemplateOnlyQueryExtensionManager")
 public class TemplateOnlyQueryExtensionManager extends ExtensionManager<TemplateOnlyQueryExtensionHandler> implements TemplateOnlyQueryExtensionHandler {
 
-    public static final ExtensionManagerOperation refineRetrieve = new ExtensionManagerOperation() {
+    public static final ExtensionManagerOperation refineParameterRetrieve = new ExtensionManagerOperation() {
         @Override
         public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
-            return ((TemplateOnlyQueryExtensionHandler) handler).refineRetrieve((Class<?>) params[0], params[1], (CriteriaBuilder) params[2], (CriteriaQuery) params[3], (Root) params[4], (List<Predicate>) params[5]);
+            return ((TemplateOnlyQueryExtensionHandler) handler).refineParameterRetrieve((Class<?>) params[0], params[1], (CriteriaBuilder) params[2], (CriteriaQuery) params[3], (Root) params[4], (List<Predicate>) params[5]);
+        }
+    };
+
+    public static final ExtensionManagerOperation refineQuery = new ExtensionManagerOperation() {
+            @Override
+            public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).refineQuery((Class<?>) params[0], params[1], (TypedQuery) params[2]);
         }
     };
 
@@ -96,8 +95,13 @@ public class TemplateOnlyQueryExtensionManager extends ExtensionManager<Template
     }
 
     @Override
-    public ExtensionResultStatusType refineRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Predicate> restrictions) {
-        return execute(refineRetrieve, type, testObject, builder, criteria, root, restrictions);
+    public ExtensionResultStatusType refineParameterRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Predicate> restrictions) {
+        return execute(refineParameterRetrieve, type, testObject, builder, criteria, root, restrictions);
+    }
+
+    @Override
+    public ExtensionResultStatusType refineQuery(Class<?> type, Object testObject, TypedQuery query) {
+        return execute(refineQuery, type, testObject, query);
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
@@ -90,6 +90,13 @@ public class TemplateOnlyQueryExtensionManager extends ExtensionManager<Template
         }
     };
 
+    public static final ExtensionManagerOperation filterResults = new ExtensionManagerOperation() {
+            @Override
+            public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).filterResults((Class<?>) params[0], params[1], (List) params[2]);
+        }
+    };
+
     public TemplateOnlyQueryExtensionManager() {
         super(TemplateOnlyQueryExtensionHandler.class);
     }
@@ -132,5 +139,10 @@ public class TemplateOnlyQueryExtensionManager extends ExtensionManager<Template
     @Override
     public ExtensionResultStatusType buildStatus(Object entity, ExtensionResultHolder<ItemStatus> response) {
         return execute(buildStatus, entity, response);
+    }
+
+    @Override
+    public ExtensionResultStatusType filterResults(Class<?> type, Object testObject, List results) {
+        return execute(filterResults, type, testObject, results);
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/TemplateOnlyQueryExtensionManager.java
@@ -1,0 +1,132 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionManager;
+import org.broadleafcommerce.common.extension.ExtensionManagerOperation;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.extension.ItemStatus;
+import org.broadleafcommerce.common.extension.ResultType;
+import org.broadleafcommerce.common.extension.SparselyPopulatedQueryExtensionHandler;
+import org.broadleafcommerce.common.extension.TemplateOnlyQueryExtensionHandler;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+
+/**
+ * Provides specialized filter and restriction behavior for template-related (MT concept) queries. This is only meaningful
+ * in a multi-tenant installation.
+ *
+ * @see TemplateOnlyQueryExtensionHandler
+ * @author Jeff Fischer
+ */
+@Service("blTemplateOnlyQueryExtensionManager")
+public class TemplateOnlyQueryExtensionManager extends ExtensionManager<TemplateOnlyQueryExtensionHandler> implements TemplateOnlyQueryExtensionHandler {
+
+    public static final ExtensionManagerOperation refineRetrieve = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).refineRetrieve((Class<?>) params[0], params[1], (CriteriaBuilder) params[2], (CriteriaQuery) params[3], (Root) params[4], (List<Predicate>) params[5]);
+        }
+    };
+
+    public static final ExtensionManagerOperation setup = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).setup((Class<?>) params[0]);
+        }
+    };
+
+    public static final ExtensionManagerOperation breakdown = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).breakdown((Class<?>) params[0]);
+        }
+    };
+
+    public static final ExtensionManagerOperation refineOrder = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).refineOrder((Class<?>) params[0], (CriteriaBuilder) params[1], (CriteriaQuery) params[2], (Root) params[3], (List<Order>) params[4]);
+        }
+    };
+
+    public static final ExtensionManagerOperation isValidState = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).isValidState((ExtensionResultHolder<Boolean>) params[0]);
+        }
+    };
+
+    public static final ExtensionManagerOperation buildStatus = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((TemplateOnlyQueryExtensionHandler) handler).buildStatus(params[0], (ExtensionResultHolder<ItemStatus>) params[1]);
+        }
+    };
+
+    public TemplateOnlyQueryExtensionManager() {
+        super(TemplateOnlyQueryExtensionHandler.class);
+    }
+
+    @Override
+    public ExtensionResultStatusType refineRetrieve(Class<?> type, Object testObject, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Predicate> restrictions) {
+        return execute(refineRetrieve, type, testObject, builder, criteria, root, restrictions);
+    }
+
+    @Override
+    public ExtensionResultStatusType setup(Class<?> type) {
+        return execute(setup, type);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public ExtensionResultStatusType breakdown(Class<?> type) {
+        return execute(breakdown, type);
+    }
+
+    @Override
+    public ExtensionResultStatusType refineOrder(Class<?> type, CriteriaBuilder builder, CriteriaQuery criteria, Root root, List<Order> sorts) {
+        return execute(refineOrder, type, builder, criteria, root, sorts);
+    }
+
+    @Override
+    public ExtensionResultStatusType isValidState(ExtensionResultHolder<Boolean> response) {
+        return execute(isValidState, response);
+    }
+
+    @Override
+    public ExtensionResultStatusType buildStatus(Object entity, ExtensionResultHolder<ItemStatus> response) {
+        return execute(buildStatus, entity, response);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
@@ -184,11 +184,14 @@ public class TranslationDaoImpl implements TranslationDao {
         try {
             if (extensionManager != null) {
                 extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Long> query = em.createQuery(criteria);
+            if (extensionManager != null) {
+                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+            }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             return query.getSingleResult();
         } finally {
@@ -216,11 +219,14 @@ public class TranslationDaoImpl implements TranslationDao {
         try {
             if (extensionManager != null) {
                 extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Translation> query = em.createQuery(criteria);
+            if (extensionManager != null) {
+                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+            }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             return query.getResultList();
         } finally {
@@ -255,11 +261,14 @@ public class TranslationDaoImpl implements TranslationDao {
         try {
             if (extensionManager != null) {
                 extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Translation> query = em.createQuery(criteria);
+            if (extensionManager != null) {
+                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+            }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             List<Translation> translations = query.getResultList();
 

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
@@ -264,7 +264,11 @@ public class TranslationDaoImpl implements TranslationDao {
             List<Translation> translations = query.getResultList();
 
             if (!translations.isEmpty()) {
-                return findBestTranslation(localeCountryCode, translations);
+                if (!localeCode.equals(localeCountryCode)) {
+                    return findBestTranslation(localeCountryCode, translations);
+                } else {
+                    return findSpecificTranslation(localeCountryCode, translations);
+                }
             } else {
                 return null;
             }
@@ -299,6 +303,15 @@ public class TranslationDaoImpl implements TranslationDao {
             }
         }
         return translations.get(0);
+    }
+
+    protected Translation findSpecificTranslation(String localeCountryCode, List<Translation> translations) {
+        for (Translation translation : translations) {
+            if (translation.getLocaleCode().equals(localeCountryCode)) {
+                return translation;
+            }
+        }
+        return null;
     }
 
     public DynamicDaoHelper getDynamicDaoHelper() {

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/LocalePair.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/LocalePair.java
@@ -22,6 +22,8 @@ package org.broadleafcommerce.common.i18n.service;
 import org.broadleafcommerce.common.extension.StandardCacheItem;
 
 /**
+ * Represents a cached translation pair.
+ *
  * @author Jeff Fischer
  */
 public class LocalePair {
@@ -29,6 +31,11 @@ public class LocalePair {
     StandardCacheItem specificItem = null;
     StandardCacheItem generalItem = null;
 
+    /**
+     * Retrieve the language and country specific translation.
+     *
+     * @return
+     */
     public StandardCacheItem getSpecificItem() {
         return specificItem;
     }
@@ -37,6 +44,11 @@ public class LocalePair {
         this.specificItem = specificItem;
     }
 
+    /**
+     * Retrieve the language only translation.
+     *
+     * @return
+     */
     public StandardCacheItem getGeneralItem() {
         return generalItem;
     }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/LocalePair.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/LocalePair.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.i18n.service;
+
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+
+/**
+ * @author Jeff Fischer
+ */
+public class LocalePair {
+
+    StandardCacheItem specificItem = null;
+    StandardCacheItem generalItem = null;
+
+    public StandardCacheItem getSpecificItem() {
+        return specificItem;
+    }
+
+    public void setSpecificItem(StandardCacheItem specificItem) {
+        this.specificItem = specificItem;
+    }
+
+    public StandardCacheItem getGeneralItem() {
+        return generalItem;
+    }
+
+    public void setGeneralItem(StandardCacheItem generalItem) {
+        this.generalItem = generalItem;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -165,7 +165,7 @@ public class SparseTranslationOverrideStrategy implements TranslationOverrideStr
         return PRECACHED_SPARSE_OVERRIDE_ORDER;
     }
 
-    protected List<Translation> getTemplateTranslations(final TranslatedEntity entityType, final String entityId, final String property, final String localeCode) {
+    protected List<Translation> getTemplateTranslations(TranslatedEntity entityType, String entityId, String property, String localeCode) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<Translation> criteria = builder.createQuery(Translation.class);
         Root<TranslationImpl> root = criteria.from(TranslationImpl.class);

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -52,6 +52,28 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 /**
+ * A retrieval and caching strategy for translations. Primarily supports multitenant scenarios with the following characteristics:
+ * <ul>
+ *     <li>A very large template translation catalog</li>
+ *     <li>A small number of standard site overrides</li>
+ *     <li>Small or large quantity of individual standard sites</li>
+ * </ul>
+ * Since the large catalog can be costly for the threshold count bounding inherent to {@link ThresholdCacheTranslationOverrideStrategy},
+ * this strategy opts for completely caching overrides and minimizing template queries. The highest template query optimization
+ * is achieved in conjunction with the 'precached.sparse.override.template.search.restrict.catalog' property set to true (false by
+ * default). See com.broadleafcommerce.tenant.service.extension.MultiTenantTemplateOnlyQueryExtensionHandler for more information,
+ * since this setting assumes the translated entity is in the same catalog as the {@link Translation} instance, which may
+ * not be true for all installations.
+ * </p>
+ * Hybrid configurations are also possible for small to medium size template translation catalogs where the threshold
+ * count bounding queries are not a concern and complete (or partial) caching of the template catalog can be achieved. However,
+ * such a strategy may provide little to no benefit over the out-of-the-box {@link ThresholdCacheTranslationOverrideStrategy}.
+ * See the {@link #templateEnabled} property for more information.
+ * </p>
+ * This strategy is disabled by default. Please see the javadoc for com.broadleafcommerce.tenant.service.cache.SparseOverridePreCacheServiceImpl (MultiTenant only)
+ * for more information on how to enable this strategy via configuration of that service.
+ *
+ * @see ThresholdCacheTranslationOverrideStrategy
  * @author Jeff Fischer
  */
 @Component("blSparseTranslationOverrideStrategy")
@@ -187,7 +209,7 @@ public class SparseTranslationOverrideStrategy implements TranslationOverrideStr
     }
 
     @Override
-    public boolean validateTemplateKey(String standardCacheKey, String templateCacheKey) {
+    public boolean validateTemplateProcessing(String standardCacheKey, String templateCacheKey) {
         return true;
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -311,7 +311,11 @@ public class SparseTranslationOverrideStrategy implements TranslationOverrideStr
                 extensionManager.refineQuery(TranslationImpl.class, testObject, query);
             }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
-            return query.getResultList();
+            List response = query.getResultList();
+            if (extensionManager != null) {
+                extensionManager.filterResults(TranslationImpl.class, testObject, response);
+            }
+            return response;
         } finally {
             extensionManager.breakdown(TranslationImpl.class);
         }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -4,15 +4,17 @@
  * %%
  * Copyright (C) 2009 - 2017 Broadleaf Commerce
  * %%
- * NOTICE:  All information contained herein is, and remains
- * the property of Broadleaf Commerce, LLC
- * The intellectual and technical concepts contained
- * herein are proprietary to Broadleaf Commerce, LLC
- * and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Broadleaf Commerce, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * #L%
  */
 package org.broadleafcommerce.common.i18n.service;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -38,13 +38,18 @@ import org.broadleafcommerce.common.util.dao.DynamicDaoHelper;
 import org.broadleafcommerce.common.util.dao.DynamicDaoHelperImpl;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.hibernate.SessionFactory;
+import org.hibernate.ejb.HibernateEntityManager;
 import org.hibernate.ejb.QueryHints;
 import org.hibernate.ejb.criteria.CriteriaBuilderImpl;
+import org.hibernate.type.LongType;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
@@ -295,7 +300,13 @@ public class SparseTranslationOverrideStrategy implements TranslationOverrideStr
                     SessionFactory sessionFactory = ((CriteriaBuilderImpl) em.getCriteriaBuilder()).getEntityManagerFactory().getSessionFactory();
                     Class<?>[] entities = helper.getAllPolymorphicEntitiesFromCeiling(type, sessionFactory, true, true);
                     //This should already be in level 1 cache and this should not cause a hit to the database.
-                    testObject = em.find(entities[entities.length - 1], Long.parseLong(entityId));
+                    Map<String, Object> idMetadata = helper.getIdMetadata(entities[entities.length - 1], (HibernateEntityManager) em);
+                    Type idType = (Type) idMetadata.get("type");
+                    if (idType instanceof StringType) {
+                        testObject = em.find(entities[entities.length - 1], entityId);
+                    } else if (idType instanceof LongType) {
+                        testObject = em.find(entities[entities.length - 1], Long.parseLong(entityId));
+                    }
                 } catch (ClassNotFoundException e) {
                     throw ExceptionHelper.refineException(e);
                 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/SparseTranslationOverrideStrategy.java
@@ -187,6 +187,11 @@ public class SparseTranslationOverrideStrategy implements TranslationOverrideStr
     }
 
     @Override
+    public boolean validateTemplateKey(String standardCacheKey, String templateCacheKey) {
+        return true;
+    }
+
+    @Override
     public int getOrder() {
         return PRECACHED_SPARSE_OVERRIDE_ORDER;
     }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
@@ -41,8 +41,20 @@ import java.util.Map;
 import javax.annotation.Resource;
 
 /**
- * Default strategy. Should run last and will always return a result.
+ * Default {@link TranslationOverrideStrategy}. Should run last and will always return a result. Primarily supports multitenant
+ * scenarios with the following characteristics:
+  * <ul>
+  *     <li>Small to medium template translation catalog</li>
+  *     <li>Small to medium number of standard site overrides</li>
+  *     <li>Small or large quantity of individual standard sites</li>
+  * </ul>
+ * This strategy tries to efficiently cache all standard site overries and/or all template catalog translations. This is the
+ * highest efficiency settings, as all translations are cached on the app tier. However, if the override or template catalog
+ * member count exceeds the threshold, the strategy falls back to on demand queries that are cached as they occur. See
+ * {@link TranslationSupport#getThresholdForFullCache()} and {@link TranslationSupport#getTemplateThresholdForFullCache()}
+ * for more information on these properties and how to set their values.
  *
+ * @see SparseTranslationOverrideStrategy
  * @author Jeff Fischer
  */
 @Component("blThresholdCacheTranslationOverrideStrategy")
@@ -149,7 +161,7 @@ public class ThresholdCacheTranslationOverrideStrategy implements TranslationOve
     }
 
     @Override
-    public boolean validateTemplateKey(String standardCacheKey, String templateCacheKey) {
+    public boolean validateTemplateProcessing(String standardCacheKey, String templateCacheKey) {
         return !standardCacheKey.equals(templateCacheKey);
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
@@ -1,0 +1,163 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.i18n.service;
+
+import net.sf.ehcache.Element;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.broadleafcommerce.common.cache.CacheStatType;
+import org.broadleafcommerce.common.cache.StatisticsService;
+import org.broadleafcommerce.common.extension.ItemStatus;
+import org.broadleafcommerce.common.extension.ResultType;
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+import org.broadleafcommerce.common.i18n.dao.TranslationDao;
+import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
+import org.broadleafcommerce.common.i18n.domain.Translation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+/**
+ * Default strategy. Should run last and will always return a result.
+ *
+ * @author Jeff Fischer
+ */
+@Component("blThresholdCacheTranslationOverrideStrategy")
+@Lazy
+public class ThresholdCacheTranslationOverrideStrategy implements TranslationOverrideStrategy {
+
+    @Resource(name="blStatisticsService")
+    protected StatisticsService statisticsService;
+
+    @Resource(name = "blTranslationDao")
+    protected TranslationDao dao;
+
+    @Autowired
+    protected TranslationSupport translationSupport;
+
+    @Override
+    public LocalePair getLocaleBasedOverride(String property, TranslatedEntity entityType, String entityId,
+                                             String localeCode, String localeCountryCode, String basicCacheKey) {
+        String specificPropertyKey = property + "_" + localeCountryCode;
+        String generalPropertyKey = property + "_" + localeCode;
+        Element cacheResult = translationSupport.getCache().get(basicCacheKey);
+        Element result = null;
+        LocalePair response = new LocalePair();
+        if (cacheResult == null) {
+            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), false);
+            if (dao.countTranslationEntries(entityType, ResultType.STANDARD_CACHE) < translationSupport.getThresholdForFullCache()) {
+                Map<String, Map<String, StandardCacheItem>> propertyTranslationMap = new HashMap<String, Map<String, StandardCacheItem>>();
+                List<StandardCacheItem> convertedList = dao.readConvertedTranslationEntries(entityType, ResultType.STANDARD_CACHE);
+                if (!CollectionUtils.isEmpty(convertedList)) {
+                    for (StandardCacheItem standardCache : convertedList) {
+                        Translation translation = (Translation) standardCache.getCacheItem();
+                        String key = translation.getFieldName() + "_" + translation.getLocaleCode();
+                        if (!propertyTranslationMap.containsKey(key)) {
+                            propertyTranslationMap.put(key, new HashMap<String, StandardCacheItem>());
+                        }
+                        propertyTranslationMap.get(key).put(translation.getEntityId(), standardCache);
+                    }
+                }
+                Element newElement = new Element(basicCacheKey, propertyTranslationMap);
+                translationSupport.getCache().put(newElement);
+                result = newElement;
+            } else {
+                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.IGNORE);
+                if (translation != null) {
+                    buildSingleItemResponse(response, translation);
+                    return response;
+                }
+            }
+        } else {
+            result = cacheResult;
+            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), true);
+        }
+        if (result != null) {
+            Map<String, Map<String, StandardCacheItem>> propertyTranslationMap = (Map<String, Map<String, StandardCacheItem>>) result.getObjectValue();
+            // Check For a Specific Standard Site Match (language and country)
+            StandardCacheItem specificTranslation = translationSupport.lookupTranslationFromMap(specificPropertyKey, propertyTranslationMap, entityId);
+            // Check For a General Match (language and country)
+            StandardCacheItem generalTranslation = translationSupport.lookupTranslationFromMap(generalPropertyKey, propertyTranslationMap, entityId);
+            response.setSpecificItem(specificTranslation);
+            response.setGeneralItem(generalTranslation);
+        }
+        return response;
+    }
+
+    @Override
+    public LocalePair getLocaleBasedTemplateValue(String templateCacheKey, String property, TranslatedEntity entityType,
+                                                  String entityId, String localeCode, String localeCountryCode, String specificPropertyKey, String generalPropertyKey) {
+        Element cacheResult = translationSupport.getCache().get(templateCacheKey);
+        LocalePair response = new LocalePair();
+        if (cacheResult == null) {
+            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), false);
+            if (dao.countTranslationEntries(entityType, ResultType.TEMPLATE_CACHE) < translationSupport.getThresholdForFullCache()) {
+                Map<String, Map<String, Translation>> propertyTranslationMap = new HashMap<String, Map<String, Translation>>();
+                List<Translation> translationList = dao.readAllTranslationEntries(entityType, ResultType.TEMPLATE_CACHE);
+                if (!CollectionUtils.isEmpty(translationList)) {
+                    for (Translation translation : translationList) {
+                        String key = translation.getFieldName() + "_" + translation.getLocaleCode();
+                        if (!propertyTranslationMap.containsKey(key)) {
+                            propertyTranslationMap.put(key, new HashMap<String, Translation>());
+                        }
+                        propertyTranslationMap.get(key).put(translation.getEntityId(), translation);
+                    }
+                }
+                translationSupport.getCache().put(new Element(templateCacheKey, propertyTranslationMap));
+                Translation translation = translationSupport.findBestTemplateTranslation(specificPropertyKey, generalPropertyKey, propertyTranslationMap, entityId);
+                if (translation != null) {
+                    buildSingleItemResponse(response, translation);
+                }
+            } else {
+                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.TEMPLATE);
+                if (translation != null) {
+                    buildSingleItemResponse(response, translation);
+                }
+            }
+        } else {
+            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), true);
+            Map<String, Map<String, Translation>> propertyTranslationMap = (Map<String, Map<String, Translation>>) cacheResult.getObjectValue();
+            Translation bestTranslation = translationSupport.findBestTemplateTranslation(specificPropertyKey, generalPropertyKey, propertyTranslationMap, entityId);
+            if (bestTranslation != null) {
+                buildSingleItemResponse(response, bestTranslation);
+            }
+        }
+        return response;
+    }
+
+    @Override
+    public int getOrder() {
+            return 0;
+        }
+
+    protected void buildSingleItemResponse(LocalePair response, Translation translation) {
+        StandardCacheItem cacheItem = new StandardCacheItem();
+        cacheItem.setItemStatus(ItemStatus.NORMAL);
+        cacheItem.setCacheItem(translation);
+        response.setSpecificItem(cacheItem);
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
@@ -114,7 +114,7 @@ public class ThresholdCacheTranslationOverrideStrategy implements TranslationOve
         LocalePair response = new LocalePair();
         if (cacheResult == null) {
             statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), false);
-            if (dao.countTranslationEntries(entityType, ResultType.TEMPLATE_CACHE) < translationSupport.getThresholdForFullCache()) {
+            if (dao.countTranslationEntries(entityType, ResultType.TEMPLATE_CACHE) < translationSupport.getTemplateThresholdForFullCache()) {
                 Map<String, Map<String, Translation>> propertyTranslationMap = new HashMap<String, Map<String, Translation>>();
                 List<Translation> translationList = dao.readAllTranslationEntries(entityType, ResultType.TEMPLATE_CACHE);
                 if (!CollectionUtils.isEmpty(translationList)) {
@@ -146,6 +146,11 @@ public class ThresholdCacheTranslationOverrideStrategy implements TranslationOve
             }
         }
         return response;
+    }
+
+    @Override
+    public boolean validateTemplateKey(String standardCacheKey, String templateCacheKey) {
+        return !standardCacheKey.equals(templateCacheKey);
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
@@ -86,9 +86,9 @@ public class ThresholdCacheTranslationOverrideStrategy implements TranslationOve
                 result = newElement;
             } else {
                 //Translation is dual discriminated by site and catalog, which can make it impossible to find results under normal
-                //circumstances because the two discriminators can cancel eachother out. We use the IGNORE_CATALOG_ONLY ResultType
+                //circumstances because the two discriminators can cancel eachother out. We use the CATALOG_ONLY ResultType
                 //to force the system to only honor the catalog discrimination during this call.
-                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.IGNORE_CATALOG_ONLY);
+                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.CATALOG_ONLY);
                 buildSingleItemResponse(response, translation);
                 return response;
             }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
@@ -33,4 +33,6 @@ public interface TranslationOverrideStrategy extends Ordered {
     LocalePair getLocaleBasedTemplateValue(String templateCacheKey, String property, TranslatedEntity entityType,
                                            String entityId, String localeCode, String localeCountryCode, String specificPropertyKey,
                                            String generalPropertyKey);
+
+    boolean validateTemplateKey(String standardCacheKey, String templateCacheKey);
 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
@@ -23,16 +23,51 @@ import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
 import org.springframework.core.Ordered;
 
 /**
+ * Provides translations at both the standard site catalog and template catalog level, whichever is appropriate. This is
+ * only meaningful in a multitenant scenario.
+ *
  * @author Jeff Fischer
  */
 public interface TranslationOverrideStrategy extends Ordered {
 
+    /**
+     * Retrieve the standard site override translation, if applicable
+     *
+     * @param property
+     * @param entityType
+     * @param entityId
+     * @param localeCode
+     * @param localeCountryCode
+     * @param basicCacheKey
+     * @return
+     */
     LocalePair getLocaleBasedOverride(String property, TranslatedEntity entityType, String entityId,
                                       String localeCode, String localeCountryCode, String basicCacheKey);
 
+    /**
+     * Retrieve the template level translation, if applicable
+     *
+     * @param templateCacheKey
+     * @param property
+     * @param entityType
+     * @param entityId
+     * @param localeCode
+     * @param localeCountryCode
+     * @param specificPropertyKey
+     * @param generalPropertyKey
+     * @return
+     */
     LocalePair getLocaleBasedTemplateValue(String templateCacheKey, String property, TranslatedEntity entityType,
                                            String entityId, String localeCode, String localeCountryCode, String specificPropertyKey,
                                            String generalPropertyKey);
 
-    boolean validateTemplateKey(String standardCacheKey, String templateCacheKey);
+    /**
+     * Whether or not a template version should be searched for. If false, then the system will return null for the
+     * translation, should an override not be found.
+     *
+     * @param standardCacheKey
+     * @param templateCacheKey
+     * @return
+     */
+    boolean validateTemplateProcessing(String standardCacheKey, String templateCacheKey);
 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationOverrideStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.i18n.service;
+
+import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
+import org.springframework.core.Ordered;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface TranslationOverrideStrategy extends Ordered {
+
+    LocalePair getLocaleBasedOverride(String property, TranslatedEntity entityType, String entityId,
+                                      String localeCode, String localeCountryCode, String basicCacheKey);
+
+    LocalePair getLocaleBasedTemplateValue(String templateCacheKey, String property, TranslatedEntity entityType,
+                                           String entityId, String localeCode, String localeCountryCode, String specificPropertyKey,
+                                           String generalPropertyKey);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -252,7 +252,9 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
         if (generalTranslation != null) {
             if (ItemStatus.DELETED.equals(generalTranslation.getItemStatus())) {
                 generalTranslationDeleted = true;
-                if (specificTranslationDeleted) {
+                //If the specific translation is override deleted as well, we're done
+                //If the general translation is override deleted and we've only got a general local code - we're done
+                if (specificTranslationDeleted || !localeCountryCode.contains("_")) {
                     return null;
                 }
             } else {
@@ -261,7 +263,9 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
                 } else {
                     response = (String) generalTranslation.getCacheItem();
                 }
-                if (specificTranslationDeleted) {
+                //If the specific translation is override deleted as well, we're done
+                //If the general translation is override and we've only got a general local code - we're done
+                if (specificTranslationDeleted || !localeCountryCode.contains("_")) {
                     return replaceEmptyWithNullResponse(response);
                 }
                 //We have a valid general override - don't check for general template value

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -20,7 +20,6 @@
 package org.broadleafcommerce.common.i18n.service;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,13 +27,10 @@ import java.util.Map.Entry;
 
 import javax.annotation.Resource;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.cache.CacheStatType;
 import org.broadleafcommerce.common.cache.StatisticsService;
-import org.broadleafcommerce.common.dao.GenericEntityDao;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ItemStatus;
 import org.broadleafcommerce.common.extension.ResultType;
@@ -53,11 +49,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
-
 
 @Service("blTranslationService")
-public class TranslationServiceImpl implements TranslationService {
+public class TranslationServiceImpl implements TranslationService, TranslationSupport {
 
     protected static final Log LOG = LogFactory.getLog(TranslationServiceImpl.class);
     private static final Translation DELETED_TRANSLATION = new TranslationImpl();
@@ -88,8 +82,8 @@ public class TranslationServiceImpl implements TranslationService {
     @Resource(name = "blLocaleService")
     protected LocaleService localeService;
 
-    @Resource(name="blGenericEntityDao")
-    protected GenericEntityDao genericEntityDao;
+    @Resource
+    protected List<TranslationOverrideStrategy> strategies;
     
     @Override
     @Transactional("blTransactionManager")
@@ -221,75 +215,53 @@ public class TranslationServiceImpl implements TranslationService {
 
     protected String getOverrideTranslatedValue(String property, TranslatedEntity entityType,
                                                 String entityId, String localeCode, String localeCountryCode) {
-        String specificPropertyKey = property + "_" + localeCountryCode;
-        String generalPropertyKey = property + "_" + localeCode;
-        String cacheKey = getCacheKey(ResultType.STANDARD, entityType);
-        Element cacheResult = getCache().get(cacheKey);
-        Element result = null;
-        String response = null;
-        if (cacheResult == null) {
-            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), false);
-            if (dao.countTranslationEntries(entityType, ResultType.STANDARD_CACHE) < getThresholdForFullCache()) {
-                Map<String, Map<String, StandardCacheItem>> propertyTranslationMap = new HashMap<String, Map<String, StandardCacheItem>>();
-                List<StandardCacheItem> convertedList = dao.readConvertedTranslationEntries(entityType, ResultType.STANDARD_CACHE);
-                if (!CollectionUtils.isEmpty(convertedList)) {
-                    for (StandardCacheItem standardCache : convertedList) {
-                        Translation translation = (Translation) standardCache.getCacheItem();
-                        String key = translation.getFieldName() + "_" + translation.getLocaleCode();
-                        if (!propertyTranslationMap.containsKey(key)) {
-                            propertyTranslationMap.put(key, new HashMap<String, StandardCacheItem>());
-                        }
-                        propertyTranslationMap.get(key).put(translation.getEntityId(), standardCache);
-                    }
-                }
-                Element newElement = new Element(cacheKey, propertyTranslationMap);
-                getCache().put(newElement);
-                result = newElement;
-            } else {
-                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.IGNORE);
-                if (translation != null) {
-                    response = translation.getTranslatedValue();
-                }
-            }
-        } else {
-            result = cacheResult;
-            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), true);
-        }
-
         boolean specificTranslationDeleted = false;
         boolean generalTranslationDeleted = false;
-
-        if (result != null) {
-            Map<String, Map<String, StandardCacheItem>> propertyTranslationMap =
-                    (Map<String, Map<String, StandardCacheItem>>) result.getObjectValue();
-
-            // Check For a Specific Standard Site Match (language and country)
-            StandardCacheItem specificTranslation =
-                    lookupTranslationFromMap(specificPropertyKey, propertyTranslationMap, entityId);
-            if (specificTranslation != null) {
-                if (ItemStatus.DELETED.equals(specificTranslation.getItemStatus())) {
-                    specificTranslationDeleted = true;
-                } else {
-                    response = ((Translation) specificTranslation.getCacheItem()).getTranslatedValue();
-                    return replaceEmptyWithNullResponse(response);
-                }
+        StandardCacheItem specificTranslation = null;
+        StandardCacheItem generalTranslation = null;
+        String specificPropertyKey = property + "_" + localeCountryCode;
+        String generalPropertyKey = property + "_" + localeCode;
+        String response;
+        String cacheKey = getCacheKey(ResultType.STANDARD, entityType);
+        LocalePair override = null;
+        for (TranslationOverrideStrategy strategy : strategies) {
+            override = strategy.getLocaleBasedOverride(property, entityType, entityId, localeCode, localeCountryCode, cacheKey);
+            if(override != null) {
+                specificTranslation = override.getSpecificItem();
+                generalTranslation = override.getGeneralItem();
+                break;
             }
-                
-            // Check For a General Match (language and country)
-            StandardCacheItem generalTranslation =
-                    lookupTranslationFromMap(generalPropertyKey, propertyTranslationMap, entityId);
-            if (generalTranslation != null) {
-                if (ItemStatus.DELETED.equals(generalTranslation.getItemStatus())) {
-                    generalTranslationDeleted = true;
-                    if (specificTranslationDeleted) {
-                        return null;
-                    }
+        }
+        if (override == null) {
+            throw new IllegalStateException("Expected at least one TranslationOverrideStrategy to return a valid value");
+        }
+
+        if (specificTranslation != null) {
+            if (ItemStatus.DELETED.equals(specificTranslation.getItemStatus())) {
+                specificTranslationDeleted = true;
+            } else {
+                if (specificTranslation.getCacheItem() instanceof Translation) {
+                    response = ((Translation) specificTranslation.getCacheItem()).getTranslatedValue();
+                } else {
+                    response = (String) specificTranslation.getCacheItem();
                 }
-            
+                return replaceEmptyWithNullResponse(response);
+            }
+        }
+
+        if (generalTranslation != null) {
+            if (ItemStatus.DELETED.equals(generalTranslation.getItemStatus())) {
+                generalTranslationDeleted = true;
                 if (specificTranslationDeleted) {
-                    response = ((Translation) generalTranslation.getCacheItem()).getTranslatedValue();
-                    return replaceEmptyWithNullResponse(response);
+                    return null;
                 }
+            } else {
+                if (generalTranslation.getCacheItem() instanceof Translation) {
+                    response = ((Translation) generalTranslation.getCacheItem()).getTranslatedValue();
+                } else {
+                    response = (String) generalTranslation.getCacheItem();
+                }
+                return replaceEmptyWithNullResponse(response);
             }
         }
 
@@ -302,10 +274,8 @@ public class TranslationServiceImpl implements TranslationService {
             generalPropertyKey = specificPropertyKey;
         }
 
-        response = getTemplateTranslatedValue(cacheKey, property, entityType, entityId, localeCode,
+        return getTemplateTranslatedValue(cacheKey, property, entityType, entityId, localeCode,
                     localeCountryCode, specificPropertyKey, generalPropertyKey);
-
-        return replaceEmptyWithNullResponse(response);
     }
 
     protected String replaceEmptyWithNullResponse(String response) {
@@ -319,51 +289,26 @@ public class TranslationServiceImpl implements TranslationService {
                         String entityId, String localeCode, String localeCountryCode, String specificPropertyKey, String generalPropertyKey) {
         String cacheKey = getCacheKey(ResultType.TEMPLATE, entityType);
         if (standardCacheKey.equals(cacheKey)) {
+            //short circuit immediately for non-MT scenarios
             return null;
         }
-        Element cacheResult = getCache().get(cacheKey);
-        if (cacheResult == null) {
-            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), false);
-            if (dao.countTranslationEntries(entityType, ResultType.TEMPLATE_CACHE) < getThresholdForFullCache()) {
-                Map<String, Map<String, Translation>> propertyTranslationMap = new HashMap<String, Map<String, Translation>>();
-                List<Translation> translationList = dao.readAllTranslationEntries(entityType, ResultType.TEMPLATE_CACHE);
-                if (!CollectionUtils.isEmpty(translationList)) {
-                    for (Translation translation : translationList) {
-                        String key = translation.getFieldName() + "_" + translation.getLocaleCode();
-                        if (!propertyTranslationMap.containsKey(key)) {
-                            propertyTranslationMap.put(key, new HashMap<String, Translation>());
-                        }
-                        propertyTranslationMap.get(key).put(translation.getEntityId(), translation);
-                    }
-                }
-                getCache().put(new Element(cacheKey, propertyTranslationMap));
-                Translation translation = findBestTemplateTranslation(specificPropertyKey, generalPropertyKey, propertyTranslationMap, entityId);
-                if (translation != null) {
-                    return translation.getTranslatedValue();
-                } else {
-                    return null;
-                }
-            } else {
-                Translation translation = dao.readTranslation(entityType, entityId, property, localeCode, localeCountryCode, ResultType.TEMPLATE);
-                if (translation != null) {
-                    return translation.getTranslatedValue();
-                } else {
-                    return null;
-                }
-            }
-        } else {
-            statisticsService.addCacheStat(CacheStatType.TRANSLATION_CACHE_HIT_RATE.toString(), true);
-            Map<String, Map<String, Translation>> propertyTranslationMap = (Map<String, Map<String, Translation>>) cacheResult.getObjectValue();
-            Translation bestTranslation = findBestTemplateTranslation(specificPropertyKey, generalPropertyKey, propertyTranslationMap, entityId);
-            if (bestTranslation != null) {
-                return bestTranslation.getTranslatedValue();
-            } else {
-                return null;
+        StandardCacheItem translation = null;
+        LocalePair override = null;
+        for (TranslationOverrideStrategy strategy : strategies) {
+            override = strategy.getLocaleBasedTemplateValue(cacheKey, property, entityType, entityId, localeCode, localeCountryCode, specificPropertyKey, generalPropertyKey);
+            if(override != null) {
+                translation = override.getSpecificItem();
+                break;
             }
         }
+        if (override == null) {
+            throw new IllegalStateException("Expected at least one TranslationOverrideStrategy to return a valid value");
+        }
+        return translation==null?null:replaceEmptyWithNullResponse(((Translation) translation.getCacheItem()).getTranslatedValue());
     }
 
-    protected StandardCacheItem lookupTranslationFromMap(String key,
+    @Override
+    public StandardCacheItem lookupTranslationFromMap(String key,
             Map<String, Map<String, StandardCacheItem>> propertyTranslationMap, String entityId) {
 
         StandardCacheItem cacheItem = null;
@@ -374,7 +319,8 @@ public class TranslationServiceImpl implements TranslationService {
         return cacheItem;
     }
 
-    protected Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId) {
+    @Override
+    public Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId) {
         Translation translation = null;
         if (propertyTranslationMap.containsKey(specificPropertyKey)) {
             Map<String, Translation> byEntity = propertyTranslationMap.get(specificPropertyKey);
@@ -426,7 +372,8 @@ public class TranslationServiceImpl implements TranslationService {
         return cacheKey;
     }
 
-    protected int getThresholdForFullCache() {
+    @Override
+    public int getThresholdForFullCache() {
         if (BroadleafRequestContext.getBroadleafRequestContext().isProductionSandBox()) {
             return thresholdForFullCache;
         } else {

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -70,9 +70,17 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
     @Resource(name="blTranslationServiceExtensionManager")
     protected TranslationServiceExtensionManager extensionManager;
 
+    /**
+     * The default is 1000. Use the 'translation.thresholdForFullCache' to change the value.
+     */
     @Value("${translation.thresholdForFullCache:1000}")
     protected int thresholdForFullCache;
 
+    /**
+     * The default is 1000. This property also uses 'translation.thresholdForFullCache' for
+     * backwards compatibility. If you wish to change this value, you'll need to extend
+     * TranslationServiceImpl and return a custom value for {@link TranslationSupport#getTemplateThresholdForFullCache()}
+     */
     @Value("${translation.thresholdForFullCache:1000}")
     protected int templateThresholdForFullCache;
 
@@ -309,7 +317,7 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
             override = strategy.getLocaleBasedTemplateValue(cacheKey, property, entityType, entityId, localeCode, localeCountryCode, specificPropertyKey, generalPropertyKey);
             if(override != null) {
                 translation = override.getSpecificItem();
-                if (!strategy.validateTemplateKey(standardCacheKey, cacheKey)) {
+                if (!strategy.validateTemplateProcessing(standardCacheKey, cacheKey)) {
                     return null;
                 }
                 break;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -221,7 +221,7 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
         StandardCacheItem generalTranslation = null;
         String specificPropertyKey = property + "_" + localeCountryCode;
         String generalPropertyKey = property + "_" + localeCode;
-        String response;
+        String response = null;
         String cacheKey = getCacheKey(ResultType.STANDARD, entityType);
         LocalePair override = null;
         for (TranslationOverrideStrategy strategy : strategies) {
@@ -261,7 +261,11 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
                 } else {
                     response = (String) generalTranslation.getCacheItem();
                 }
-                return replaceEmptyWithNullResponse(response);
+                if (specificTranslationDeleted) {
+                    return replaceEmptyWithNullResponse(response);
+                }
+                //We have a valid general override - don't check for general template value
+                generalTranslationDeleted = true;
             }
         }
 
@@ -274,8 +278,12 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
             generalPropertyKey = specificPropertyKey;
         }
 
-        return getTemplateTranslatedValue(cacheKey, property, entityType, entityId, localeCode,
+        String templateResponse = getTemplateTranslatedValue(cacheKey, property, entityType, entityId, localeCode,
                     localeCountryCode, specificPropertyKey, generalPropertyKey);
+        if (templateResponse != null) {
+            response = templateResponse;
+        }
+        return response;
     }
 
     protected String replaceEmptyWithNullResponse(String response) {

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -368,7 +368,8 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
         }
     }
 
-    protected String getCacheKey(ResultType resultType, TranslatedEntity entityType) {
+    @Override
+    public String getCacheKey(ResultType resultType, TranslatedEntity entityType) {
         String cacheKey = StringUtils.join(new String[] { entityType.getFriendlyType()}, "|");
         if (extensionManager != null) {
             ExtensionResultHolder<String> result = new ExtensionResultHolder<String>();
@@ -388,6 +389,11 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
             // don't cache when not in a SandBox
             return -1;
         }
+    }
+
+    @Override
+    public void setThresholdForFullCache(int thresholdForFullCache) {
+        this.thresholdForFullCache = thresholdForFullCache;
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
@@ -29,24 +29,67 @@ import org.broadleafcommerce.common.i18n.domain.Translation;
 import java.util.Map;
 
 /**
+ * {@link TranslationService} functionality, primarily in support of {@link TranslationOverrideStrategy} instances.
+ *
  * @author Jeff Fischer
  */
 public interface TranslationSupport {
 
+    /**
+     * Retrieve a cached translation from an individual property translation map retrieved from the cache.
+     *
+     * @param key
+     * @param propertyTranslationMap
+     * @param entityId
+     * @return
+     */
     StandardCacheItem lookupTranslationFromMap(String key, Map<String, Map<String, StandardCacheItem>> propertyTranslationMap, String entityId);
 
+    /**
+     * Retrieve the backing Ehcache Cache instance
+     *
+     * @return
+     */
     Cache getCache();
 
+    /**
+     * Retrieve the threshold under which the full list of standard site translation overrides are cached. See
+     * {@link TranslationServiceImpl#thresholdForFullCache} for more information on setting the value.
+     *
+     * @return
+     */
     int getThresholdForFullCache();
 
     void setThresholdForFullCache(int thresholdForFullCache);
 
+    /**
+     * Retrieve the threshold under which the full list of template catalog translations are cached. See
+     * {@link TranslationServiceImpl#templateThresholdForFullCache} for more information on setting the value.
+     *
+     * @return
+     */
     int getTemplateThresholdForFullCache();
 
     void setTemplateThresholdForFullCache(int templateThresholdForFullCache);
 
+    /**
+     * Find the most appropriate translation in the map. The most specific qualified translation will win.
+     *
+     * @param specificPropertyKey
+     * @param generalPropertyKey
+     * @param propertyTranslationMap
+     * @param entityId
+     * @return
+     */
     Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId);
 
+    /**
+     * Build a cache key
+     *
+     * @param resultType
+     * @param entityType
+     * @return
+     */
     String getCacheKey(ResultType resultType, TranslatedEntity entityType);
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.common.i18n.service;
+
+import net.sf.ehcache.Cache;
+
+import org.broadleafcommerce.common.extension.ResultType;
+import org.broadleafcommerce.common.extension.StandardCacheItem;
+import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
+import org.broadleafcommerce.common.i18n.domain.Translation;
+
+import java.util.Map;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface TranslationSupport {
+
+    StandardCacheItem lookupTranslationFromMap(String key, Map<String, Map<String, StandardCacheItem>> propertyTranslationMap, String entityId);
+
+    Cache getCache();
+
+    int getThresholdForFullCache();
+
+    Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
@@ -39,6 +39,10 @@ public interface TranslationSupport {
 
     int getThresholdForFullCache();
 
+    void setThresholdForFullCache(int thresholdForFullCache);
+
     Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId);
+
+    String getCacheKey(ResultType resultType, TranslatedEntity entityType);
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
@@ -41,6 +41,10 @@ public interface TranslationSupport {
 
     void setThresholdForFullCache(int thresholdForFullCache);
 
+    int getTemplateThresholdForFullCache();
+
+    void setTemplateThresholdForFullCache(int templateThresholdForFullCache);
+
     Translation findBestTemplateTranslation(String specificPropertyKey, String generalPropertyKey, Map<String, Map<String, Translation>> propertyTranslationMap, String entityId);
 
     String getCacheKey(ResultType resultType, TranslatedEntity entityType);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/dynamic/DefaultDynamicSkuPricingInvocationHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/dynamic/DefaultDynamicSkuPricingInvocationHandler.java
@@ -123,6 +123,10 @@ public class DefaultDynamicSkuPricingInvocationHandler implements InvocationHand
         }
     }
 
+    public Sku unwrap(){
+        return delegate;
+    }
+
     public void reset() {
         delegate = null;
         retailPrice = null;

--- a/integration/src/test/java/org/broadleafcommerce/test/translation/sitejvm/TranslationServiceTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/test/translation/sitejvm/TranslationServiceTest.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.test.translation.sitejvm;
+
+import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
+import org.broadleafcommerce.common.i18n.service.TranslationService;
+import org.broadleafcommerce.core.catalog.domain.Category;
+import org.broadleafcommerce.core.catalog.domain.CategoryImpl;
+import org.broadleafcommerce.core.catalog.service.CatalogService;
+import org.broadleafcommerce.test.BaseTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+
+import javax.annotation.Resource;
+
+/**
+ * Test basic core translation use cases. Confirms core is configured correctly and operational.
+ *
+ * @author Jeff Fischer
+ */
+public class TranslationServiceTest extends BaseTest {
+
+    @Resource
+    private TranslationService translationService;
+
+    @Resource
+    private CatalogService catalogService;
+
+    @Test(groups = {"testTranslation"})
+    @Transactional
+    public void testTranslation() throws Exception {
+        Category category = new CategoryImpl();
+        category.setName("Translation");
+        category = catalogService.saveCategory(category);
+
+        translationService.save(TranslatedEntity.CATEGORY.getType(), String.valueOf(category.getId()), "name", "es_MX", "es_MX");
+        translationService.save(TranslatedEntity.CATEGORY.getType(), String.valueOf(category.getId()), "name", "es", "es");
+
+        String specificTranslation = translationService.getTranslatedValue(category, "name", new Locale("es", "MX"));
+        Assert.assertEquals(specificTranslation, "es_MX");
+
+        String generalTranslation = translationService.getTranslatedValue(category, "name", Locale.forLanguageTag("es"));
+        Assert.assertEquals(generalTranslation, "es");
+
+        //test a second time to go through cache
+
+        specificTranslation = translationService.getTranslatedValue(category, "name", new Locale("es", "MX"));
+        Assert.assertEquals(specificTranslation, "es_MX");
+
+        generalTranslation = translationService.getTranslatedValue(category, "name", Locale.forLanguageTag("es"));
+        Assert.assertEquals(generalTranslation, "es");
+    }
+}


### PR DESCRIPTION
BroadleafCommerce/QA#2922

- Only impacts MultiTenant installations
- Support the current Threshold cache strategy
- Support a new sparse override cache strategy
- Support parameterized criteria for more efficient Hibernate and database caching of prepared statements