### PR TITLE
Fix an issue where sometimes related list grid column headers do not display

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
@@ -317,8 +317,14 @@
                 var nextHeader = $($columnHeaders[index+1])[0];
                 var $nextHeaderText = $(nextHeader).find('.listgrid-title span');
 
-                $currentHeaderText.outerWidth($(currentHeader).outerWidth() - CONTROL_WIDTH);
-                $nextHeaderText.outerWidth($(nextHeader).outerWidth() - CONTROL_WIDTH);
+                var newCurrentHeaderWidth = ($(currentHeader).outerWidth() - CONTROL_WIDTH);
+                var newNextHeaderWidth = ($(nextHeader).outerWidth() - CONTROL_WIDTH);
+
+                newCurrentHeaderWidth = newCurrentHeaderWidth > MIN_WIDTH ? newCurrentHeaderWidth : MIN_WIDTH;
+                newNextHeaderWidth = newNextHeaderWidth > MIN_WIDTH ? newNextHeaderWidth : MIN_WIDTH;
+
+                $currentHeaderText.outerWidth(newCurrentHeaderWidth);
+                $nextHeaderText.outerWidth(newNextHeaderWidth);
             });
         },
         


### PR DESCRIPTION
Initializing Listgrid Titles in Admin didn't check for MIN_WIDTH on page load, only on resize. So too thin of columns had no titles displayed until adjusting the resizer. Added in the check.