### PR TITLE
Fixed issue where adding inventory to a sku would cause an error when trying to add said sku to the cart

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -767,22 +767,25 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
             property.setIsDirty(true);
         }
 
-        //remove the current list of product option values from the Sku
-        if (adminInstance.getProductOptionValueXrefs().size() > 0) {
-            Iterator<SkuProductOptionValueXref> iterator = adminInstance.getProductOptionValueXrefs().iterator();
-            while (iterator.hasNext()) {
-                dynamicEntityDao.remove(iterator.next());
+        // Only process associations if product option value changes came in via the form
+        if (CollectionUtils.isNotEmpty(productOptionValueIds)) {
+            //remove the current list of product option values from the Sku
+            if (adminInstance.getProductOptionValueXrefs().size() > 0) {
+                Iterator<SkuProductOptionValueXref> iterator = adminInstance.getProductOptionValueXrefs().iterator();
+                while (iterator.hasNext()) {
+                    dynamicEntityDao.remove(iterator.next());
+                }
+                dynamicEntityDao.merge(adminInstance);
             }
-            dynamicEntityDao.merge(adminInstance);
-        }
 
-        //Associate the product option values from the form with the Sku
-        for (Long id : productOptionValueIds) {
-            //Simply find the changed ProductOptionValues directly - seems to work better with sandboxing code
-            ProductOptionValue pov = (ProductOptionValue) dynamicEntityDao.find(ProductOptionValueImpl.class, id);
-            SkuProductOptionValueXref xref = new SkuProductOptionValueXrefImpl(adminInstance, pov);
-            xref = dynamicEntityDao.merge(xref);
-            adminInstance.getProductOptionValueXrefs().add(xref);
+            //Associate the product option values from the form with the Sku
+            for (Long id : productOptionValueIds) {
+                //Simply find the changed ProductOptionValues directly - seems to work better with sandboxing code
+                ProductOptionValue pov = (ProductOptionValue) dynamicEntityDao.find(ProductOptionValueImpl.class, id);
+                SkuProductOptionValueXref xref = new SkuProductOptionValueXrefImpl(adminInstance, pov);
+                xref = dynamicEntityDao.merge(xref);
+                adminInstance.getProductOptionValueXrefs().add(xref);
+            }
         }
     }
 


### PR DESCRIPTION
BroadleafCommerce/QA#2923 

- Prevent the association of product options if no changes came in via the form

When updating a sku we disassociate the product options from the sku and reassign them based on what was submitted via the form. When saving a sku via the `Manage Inventory` section, there is no `Product Information` which was causing the product options to be disassociated but never reassigned. When adding to cart, it would now fail since the product options were no longer associated to any sku.