### PR TITLE
Make SystemProperty retrieval more efficient

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/config/service/SystemPropertiesServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/service/SystemPropertiesServiceImpl.java
@@ -91,7 +91,7 @@ public class SystemPropertiesServiceImpl implements SystemPropertiesService{
         }
 
         if (result != null) {
-            return result;
+            return result.equals(NULL_RESPONSE)?null:result;
         }
 
         SystemProperty property = systemPropertiesDao.readSystemPropertyByName(name);

--- a/common/src/main/java/org/broadleafcommerce/common/config/service/SystemPropertiesServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/service/SystemPropertiesServiceImpl.java
@@ -47,6 +47,8 @@ import javax.annotation.Resource;
 @Service("blSystemPropertiesService")
 public class SystemPropertiesServiceImpl implements SystemPropertiesService{
 
+    private static final String NULL_RESPONSE = "*NULL_RESPONSE*";
+
     protected Cache systemPropertyCache;
 
     @Resource(name="blSystemPropertiesDao")
@@ -103,10 +105,11 @@ public class SystemPropertiesServiceImpl implements SystemPropertiesService{
             }
         }
 
-        if (result != null) {
-            addPropertyToCache(name, result);
+        if (result == null) {
+            result = NULL_RESPONSE;
         }
-        return result;
+        addPropertyToCache(name, result);
+        return result.equals(NULL_RESPONSE)?null:result;
     }
 
     protected void addPropertyToCache(String propertyName, String propertyValue) {


### PR DESCRIPTION
BroadleafCommerce/QA#2924

In SystemPropertyServiceImpl, there is a top-level cache that holds the results of checking both the database and the Spring property manager. Currently, if a property is requested that is neither in the database or property manager, the "null" result is not cached. This results in each repeated request for the same property having to go through the search process again. However, this is a relatively low impact because the database search has its own cache that holds null responses, so at least this repeated search is not causing repeated real network calls to the database. On the other hand, there is some measurable expense involved with calling the Spring property manager to resolve the property. Therefore, a small performance gain will be realized by including null responses in the top-level cache in SystemPropertyServiceImpl.

A side benefit of this change will be a reduction in cache misses registered by ehcache on the two mentioned caches. This will be less confusing from a diagnostic standpoint.