### PR TITLE
Add back the Zookeeper transitive dependency for Solr cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -951,11 +951,6 @@
                         <groupId>com.fasterxml.jackson</groupId>
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
-                    <!-- security vulnerability in version 3.4.6. We explicity include version 3.4.9 elsewhere -->
-                    <exclusion>
-                        <groupId>org.apache.zookeeper</groupId>
-                        <artifactId>zookeeper</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
5.2.0-GA had an incorrect exclusion on the zookeeper dependency from Solrj. This was originally designed to guarantee an override of the zookeeper version, but it ended up completely removing the transitive dependency altogether. The outcome was that if you were using Solr Cloud you would have to specify the Zookeeper version manually.

If you are on 5.2.0-GA and have already specified the Zookeeper dependency in your project, updating to 5.2.1-GA will allow you to remove the dependency.