### PR TITLE
Exclude commons-fileupload from solr-core dependency for security purposes

### DIFF
--- a/core/broadleaf-framework/pom.xml
+++ b/core/broadleaf-framework/pom.xml
@@ -124,6 +124,10 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-hdfs</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Addresses BroadleafCommerce/QA#2920