### PR TITLE
In the My Changes list grid, when having enough changes to warrant a scrollbar, attempting to select on the bottom changes causes scroll-up and no selection.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
@@ -924,6 +924,9 @@
                 scrollEasing: "linear",
                 scrollInertia: 500,
                 mouseWheelPixels: trHeight,
+                advanced:{
+                    autoScrollOnFocus: false,
+                },
                 callbacks: {
                     onScroll: function() {
                         var singleGrid = BLCAdmin.listGrid.getListGridCount($) == 1;


### PR DESCRIPTION
BroadleafCommerce/QA#2678
fix scroll up on the bottom checkbox click