### PR TITLE
Fix selectize queries to check data-hydrate if no results

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -584,6 +584,18 @@
                                         }
                                     }
                                 });
+
+                                if ( ! queryData["name"] ) {
+                                    var data = $selectize.$input.attr("data-hydrate");
+                                    var dataHydrate = BLCAdmin.stringToArray(data);
+                                    for (var k = 0; k < dataHydrate.length; k++) {
+                                        var item = dataHydrate[k];
+                                        if ($selectize.getOption(item).length === 0) {
+                                            $selectize.addOption({id: item, label: item});
+                                        }
+                                    }
+                                }
+
                                 callback(data);
                             });
                         } else {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -585,7 +585,10 @@
                                     }
                                 });
 
-                                if ( ! queryData["name"] ) {
+                                // On load, selectize returns a page of 50-100 results back
+                                // If the name you are searching for is not in this page, the field will be blank
+                                // So if the name is blank, we add options from the data-hydrate
+                                if (!queryData["name"]) {
                                     var data = $selectize.$input.attr("data-hydrate");
                                     var dataHydrate = BLCAdmin.stringToArray(data);
                                     for (var k = 0; k < dataHydrate.length; k++) {


### PR DESCRIPTION
As is, Selectize returns only a page of results. Anything past this cannot be found. So we now add an option from the data-hydrate field of the selectize if the query is empty.