### PR TITLE
Resize assets on asset grid on each image load

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -356,6 +356,12 @@ $(document).ready(function() {
                     BLCAdmin.assetGrid.initialize($assetGrid);
 
                     $(this).find('.asset-grid-container').replaceWith($assetGrid);
+
+                    // We never know when the last image loads, so resize on EVERY image load
+                    $(this).find('.asset-grid-container .asset-item img').on('load', function(e) {
+                        var $container = $(this).parents('.asset-grid-container');
+                        BLCAdmin.assetGrid.paginate.updateGridSize($container);
+                    })
                 });
 
                 hideTabSpinner($tab, $tabBody);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -584,6 +584,18 @@
                                         }
                                     }
                                 });
+
+                                if ( ! queryData["name"] ) {
+                                    var data = $selectize.$input.attr("data-hydrate");
+                                    var dataHydrate = BLCAdmin.stringToArray(data);
+                                    for (var k = 0; k < dataHydrate.length; k++) {
+                                        var item = dataHydrate[k];
+                                        if ($selectize.getOption(item).length === 0) {
+                                            $selectize.addOption({id: item, label: item});
+                                        }
+                                    }
+                                }
+
                                 callback(data);
                             });
                         } else {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -585,7 +585,10 @@
                                     }
                                 });
 
-                                if ( ! queryData["name"] ) {
+                                // On load, selectize returns a page of 50-100 results back
+                                // If the name you are searching for is not in this page, the field will be blank
+                                // So if the name is blank, we add options from the data-hydrate
+                                if (!queryData["name"]) {
                                     var data = $selectize.$input.attr("data-hydrate");
                                     var dataHydrate = BLCAdmin.stringToArray(data);
                                     for (var k = 0; k < dataHydrate.length; k++) {


### PR DESCRIPTION
Add a listener to resize the assetGrid whenever an asset image loads, so we match everything to the maximumHeight of all images. This is so, on the last image load, we scale everything appropriately.