### PR TITLE
Fixed an error caused by performing an unchecked cast

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CategorySiteMapGenerator.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CategorySiteMapGenerator.java
@@ -61,13 +61,14 @@ public class CategorySiteMapGenerator implements SiteMapGenerator {
     @Override
     public void addSiteMapEntries(SiteMapGeneratorConfiguration smgc, SiteMapBuilder siteMapBuilder) {
 
-        CategorySiteMapGeneratorConfiguration categorySMGC = (CategorySiteMapGeneratorConfiguration) smgc;
+        if (smgc instanceof CategorySiteMapGeneratorConfiguration) {
+            CategorySiteMapGeneratorConfiguration categorySMGC = (CategorySiteMapGeneratorConfiguration) smgc;
 
-        // Recursively construct the category SiteMap URLs
-        Long rootCategoryId = categorySMGC.getRootCategory().getId();
-        Category rootCategory = categoryDao.readCategoryById(rootCategoryId);
-        addCategorySiteMapEntries(rootCategory, 0, categorySMGC, siteMapBuilder);
-        
+            // Recursively construct the category SiteMap URLs
+            Long rootCategoryId = categorySMGC.getRootCategory().getId();
+            Category rootCategory = categoryDao.readCategoryById(rootCategoryId);
+            addCategorySiteMapEntries(rootCategory, 0, categorySMGC, siteMapBuilder);
+        }
     }
 
     protected void addCategorySiteMapEntries(Category parentCategory, int currentDepth, CategorySiteMapGeneratorConfiguration categorySMGC, SiteMapBuilder siteMapBuilder) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CategorySiteMapGenerator.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CategorySiteMapGenerator.java
@@ -61,7 +61,7 @@ public class CategorySiteMapGenerator implements SiteMapGenerator {
     @Override
     public void addSiteMapEntries(SiteMapGeneratorConfiguration smgc, SiteMapBuilder siteMapBuilder) {
 
-        if (smgc instanceof CategorySiteMapGeneratorConfiguration) {
+        if (CategorySiteMapGeneratorConfiguration.class.isAssignableFrom(smgc.getClass())) {
             CategorySiteMapGeneratorConfiguration categorySMGC = (CategorySiteMapGeneratorConfiguration) smgc;
 
             // Recursively construct the category SiteMap URLs


### PR DESCRIPTION
Fixed an error caused by explicitly casting a `SiteMapGeneratorConfiguration` to a `CategorySiteMapGeneratorConfiguration`