### PR TITLE
Fixed issue with product filtering not working on selectize lookups

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
@@ -35,6 +35,7 @@ import org.broadleafcommerce.openadmin.dto.ClassTree;
 import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.broadleafcommerce.openadmin.dto.FilterAndSortCriteria;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.dto.SectionCrumb;
 import org.broadleafcommerce.openadmin.server.domain.PersistencePackageRequest;
@@ -76,7 +77,9 @@ import javax.servlet.http.HttpServletResponse;
 public class AdminProductController extends AdminBasicEntityController {
     
     public static final String SECTION_KEY = "product";
-    
+    public static final String DEFAULT_SKU_NAME = "defaultSku.name";
+    public static final String SELECTIZE_NAME_PROPERTY = "name";
+
     @Resource(name = "blCatalogService")
     protected CatalogService catalogService;
     
@@ -252,10 +255,18 @@ public class AdminProductController extends AdminBasicEntityController {
         String sectionClassName = getClassNameForSection(sectionKey);
         List<SectionCrumb> crumbs = getSectionCrumbs(request, null, null);
         PersistencePackageRequest ppr = getSectionPersistencePackageRequest(sectionClassName, requestParams, crumbs, pathVars)
-                .withFilterAndSortCriteria(getCriteria(requestParams))
                 .withStartIndex(getStartIndex(requestParams))
                 .withMaxIndex(getMaxIndex(requestParams))
                 .withCustomCriteria(getCustomCriteria(requestParams));
+
+        FilterAndSortCriteria[] fascs = getCriteria(requestParams);
+        for(FilterAndSortCriteria fasc : fascs) {
+            if (SELECTIZE_NAME_PROPERTY.equals(fasc.getPropertyId())) {
+                fasc.setPropertyId(DEFAULT_SKU_NAME);
+                break;
+            }
+        }
+        ppr.withFilterAndSortCriteria(fascs);
 
         ClassMetadata cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
         DynamicResultSet drs =  service.getRecords(ppr).getDynamicResultSet();

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -544,7 +544,7 @@
                         var dataHydrate = BLCAdmin.stringToArray(data);
                         for (var k = 0; k < dataHydrate.length; k++) {
                             var item = dataHydrate[k];
-                            if ($selectize.getOption(item).length === 0 && allowAdd) {
+                            if ($selectize.getOption(item).length === 0) {
                                 $selectize.addOption({id: item, label: item});
                             }
                             if (!isNaN(item)) {


### PR DESCRIPTION
This pull request fixes an issue with selectize lookups not targeting the correct property when looking up a product.  Selectize defaults to looking for `"name"`, product has a custom implementation that should look for `"defaultSku.name"`.

This also includes a fix for previously selected items not showing up on initial page load.  The issue was that the previously selected item was not in the initial 50 record load and wouldn't be added to the input.  The script was incorrectly skipping these items.