### PR TITLE
Add a listener to resize images and asset grid on load for each image…

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -356,6 +356,12 @@ $(document).ready(function() {
                     BLCAdmin.assetGrid.initialize($assetGrid);
 
                     $(this).find('.asset-grid-container').replaceWith($assetGrid);
+
+                    // We never know when the last image loads, so resize on EVERY image load
+                    $(this).find('.asset-grid-container .asset-item img').on('load', function(e) {
+                        var $container = $(this).parents('.asset-grid-container');
+                        BLCAdmin.assetGrid.paginate.updateGridSize($container);
+                    })
                 });
 
                 hideTabSpinner($tab, $tabBody);


### PR DESCRIPTION
This, combined with [Enterprise PR 945](https://github.com/BroadleafCommerce/Enterprise/pull/945), should fix the assetGrid's sizing both on load and on window resizing.