### PR TITLE
Defined a specific width for the remove row query builder icon

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-query-builder.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-query-builder.css
@@ -377,6 +377,7 @@
     right: 16px;
     top: 15px;
     z-index: 10;
+    width: 20px;
 }
 
 .query-builder-filters-container .query-builder .rule-container .rule-value-container {


### PR DESCRIPTION
This makes sure that the clickable region is only the size of the “X”. Fixes BroadleafCommerce/QA#2951