### PR TITLE
Add null checks in Category and Product handler mappings

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/CategoryHandlerMapping.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/CategoryHandlerMapping.java
@@ -96,19 +96,24 @@ public class CategoryHandlerMapping extends BLCAbstractHandlerMapping {
     }
 
     protected Category findCategoryUsingIdParam(BroadleafRequestContext context) throws ServletRequestBindingException {
-        Long categoryId = ServletRequestUtils.getLongParameter(context.getRequest(), "categoryId");
-        if (categoryId != null) {
-            Category category = catalogService.findCategoryById(categoryId);
-            if (category != null && LOG.isDebugEnabled()) {
-                LOG.debug("Obtained the category using ID=" + categoryId);
+        if (context.getRequest() != null) {
+            Long categoryId = ServletRequestUtils.getLongParameter(context.getRequest(), "categoryId");
+            if (categoryId != null) {
+                Category category = catalogService.findCategoryById(categoryId);
+                if (category != null && LOG.isDebugEnabled()) {
+                    LOG.debug("Obtained the category using ID=" + categoryId);
+                }
+                return category;
             }
-            return category;
         }
         return null;
     }
 
     protected Category findCategoryUsingUrl(BroadleafRequestContext context)
             throws ServletRequestBindingException, UnsupportedEncodingException {
+        if (context.getRequestURIWithoutContext() == null) {
+            return null;
+        }
         String requestUri = URLDecoder.decode(context.getRequestURIWithoutContext(), charEncoding);
         Category category = catalogService.findCategoryByURI(requestUri);
         if (category != null && LOG.isDebugEnabled()) {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/ProductHandlerMapping.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/ProductHandlerMapping.java
@@ -92,19 +92,24 @@ public class ProductHandlerMapping extends BLCAbstractHandlerMapping {
     }
 
     protected Product findProductUsingIdParam(BroadleafRequestContext context) throws ServletRequestBindingException {
-        Long productId = ServletRequestUtils.getLongParameter(context.getRequest(), "productId");
-        if (productId != null) {
-            Product product = catalogService.findProductById(productId);
-            if (product != null && LOG.isDebugEnabled()) {
-                LOG.debug("Obtained the product using id=" + productId);
+        if (context.getRequest() != null) {
+            Long productId = ServletRequestUtils.getLongParameter(context.getRequest(), "productId");
+            if (productId != null) {
+                Product product = catalogService.findProductById(productId);
+                if (product != null && LOG.isDebugEnabled()) {
+                    LOG.debug("Obtained the product using id=" + productId);
+                }
+                return product;
             }
-            return product;
         }
         return null;
     }
 
     protected Product findProductUsingUrl(BroadleafRequestContext context)
             throws ServletRequestBindingException, UnsupportedEncodingException {
+        if (context.getRequestURIWithoutContext() == null) {
+            return null;
+        }
         String requestUri = URLDecoder.decode(context.getRequestURIWithoutContext(), charEncoding);
         Product product = catalogService.findProductByURI(requestUri);
         if (product != null && LOG.isDebugEnabled()) {


### PR DESCRIPTION
This pull requests addresses an issue when defining `ResourceHandlerRegistry` handlers.  For example, the following will cause an NPE when you try to hit `/manifest.json`, because the context that is passed in contains nulls.

The `ResourceHandlerRegistry` checks for matches after all other handler mapping have run, so it will need to make it through both the `CategoryHandlerMapping` and the `ProductHandlerMapping` without errors to resolve correctly.

```
    @Override
    public void addResourceHandlers(ResourceHandlerRegistry registry) {
        registry.addResourceHandler("/favicon.ico")
                .addResourceLocations("WEB-INF/favicon.ico");
        registry.addResourceHandler("/manifest.json")
                .addResourceLocations("classpath:/manifest.json");
    }
```

