### PR TITLE
fix product bundle out of stock

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/AbstractInventoryServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/AbstractInventoryServiceExtensionHandler.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.core.inventory.service;
 import org.broadleafcommerce.common.extension.AbstractExtensionHandler;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.core.catalog.domain.Sku;
 
 import java.util.Collection;
@@ -45,6 +46,11 @@ public abstract class AbstractInventoryServiceExtensionHandler extends AbstractE
 
     @Override
     public ExtensionResultStatusType reconcileChangeOrderInventory(Map<Sku, Integer> decrementSkuQuantities, Map<Sku, Integer> incrementSkuQuantities, Map<String, Object> context) throws InventoryUnavailableException {
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+
+    @Override
+    public ExtensionResultStatusType isProductBundleAvailable(Product product, int quantity, ExtensionResultHolder<Boolean> holder) {
         return ExtensionResultStatusType.NOT_HANDLED;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceExtensionHandler.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.core.inventory.service;
 import org.broadleafcommerce.common.extension.ExtensionHandler;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.checkout.service.workflow.DecrementInventoryActivity;
 import org.broadleafcommerce.core.order.service.workflow.CheckAvailabilityActivity;
@@ -75,5 +76,12 @@ public interface InventoryServiceExtensionHandler extends ExtensionHandler {
      * @throws InventoryUnavailableException
      */
     public ExtensionResultStatusType reconcileChangeOrderInventory(Map<Sku, Integer> decrementSkuQuantities, Map<Sku, Integer> incrementSkuQuantities, Map<String, Object> context) throws InventoryUnavailableException;
-    
+
+    /**
+     * Usually invoked via the AdvancedProduct to determine the availability of product bundle.
+     * @param product contains Product
+     * @param quantity
+     * @param holder
+     */
+    ExtensionResultStatusType isProductBundleAvailable(Product product, int quantity, ExtensionResultHolder<Boolean> holder);
 }


### PR DESCRIPTION
BroadleafCommerce/QA#2882
Extension point to check product bundle availability. `isProductBundleAvailable(Product product, int quantity, ExtensionResultHolder<Boolean> holder)` would be implemented in Advanced Product module.