### PR TITLE
Changed Offer Name to be a translatable property

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -121,7 +121,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     @Index(name="OFFER_NAME_INDEX", columnNames={"OFFER_NAME"})
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Name",
         group = GroupName.Description, order = FieldOrder.Name,
-        prominent = true, gridOrder = 1,
+        prominent = true, gridOrder = 1, translatable = true,
         defaultValue = "New Offer")
     protected String name;
 


### PR DESCRIPTION
Offer Name is often shown on the cart page.  It should be a translatable field.
Fixes https://github.com/BroadleafCommerce/QA/issues/2954