### PR TITLE
Order History - Searching, Pagination, and Date Filtering

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -54,7 +54,7 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
         orders = orderHistoryService.getOrderHistory(request.getParameterMap(), modelAttributes, orders);
 
         for (Order order : orders) {
-            orderHistoryService.validateCustomerOwnedData(order);
+            validateCustomerOwnedData(order);
         }
 
         model.addAllAttributes(modelAttributes);
@@ -78,5 +78,9 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
 
     public String getOrderDetailsRedirectView() {
         return orderDetailsRedirectView;
+    }
+
+    protected void validateCustomerOwnedData(Order order) {
+        orderHistoryService.validateCustomerOwnedData(order);
     }
 }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -17,6 +17,13 @@
  */
 package org.broadleafcommerce.core.web.controller.account;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+
 import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.service.OrderService;
 import org.broadleafcommerce.core.order.service.type.OrderStatus;
@@ -24,12 +31,6 @@ import org.broadleafcommerce.core.web.service.OrderHistoryService;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ui.Model;
-
-import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class BroadleafOrderHistoryController extends AbstractAccountController {
 
@@ -47,9 +48,6 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     protected OrderService orderService;
 
     public String viewOrderHistory(HttpServletRequest request, Model model) {
-        if (CustomerState.getCustomer() == null) {
-            throw new SecurityException("Null customer tried to access order history");
-        }
         List<Order> orders = orderService.findOrdersForCustomer(CustomerState.getCustomer(), OrderStatus.SUBMITTED);
 
         Map<String, Object> modelAttributes = new HashMap<>();
@@ -65,7 +63,8 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     }
 
     public String viewOrderDetails(HttpServletRequest request, Model model, String orderNumber) {
-        orderHistoryService.viewOrderDetails(request, model, orderNumber);
+        Order order = orderHistoryService.getOrderDetails(orderNumber);
+        model.addAttribute("order", order);
         return isAjaxRequest(request) ? getOrderDetailsView() : getOrderDetailsRedirectView();
     }
 

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -21,6 +21,7 @@ import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;
 import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.domain.OrderItem;
 import org.broadleafcommerce.core.order.service.type.OrderStatus;
+import org.broadleafcommerce.core.search.domain.SearchResult;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,6 +50,7 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     protected static String orderHistoryDateStartParameter = "dateStart";
     protected static String orderHistoryDateEndParameter = "dateEnd";
     protected static String orderHistoryDateFilterParameter = "dateFilter";
+    protected static String orderHistoryResultParameter = "result";
     protected static DateFormat filterDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
     protected static int itemsPerPage = 10;
 
@@ -124,6 +126,7 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
             orders = matchingOrders;
         }
 
+        final int totalOrders = orders.size();
         if (!orders.isEmpty() && page > 0 && page <= orders.size() / itemsPerPage + 1) {
             orders = orders.subList((page - 1) * itemsPerPage, Math.min(orders.size(), page * itemsPerPage));
         }
@@ -133,6 +136,23 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
         model.addAttribute(orderHistoryDateStartParameter, dateStartParam);
         model.addAttribute(orderHistoryDateEndParameter, dateEndParam);
         model.addAttribute(orderHistoryPageParameter, page);
+
+        final List<Order> finalOrders = orders;
+        SearchResult result = new SearchResult() {
+            @Override
+            public Integer getStartResult() {
+                return itemsPerPage * (page - 1) + (finalOrders.isEmpty() ? 0 : 1);
+            }
+
+            @Override
+            public Integer getTotalPages() {
+                return totalOrders / itemsPerPage + 1;
+            }
+        };
+        result.setPage(page);
+        result.setPageSize(itemsPerPage);
+        result.setTotalResults(totalOrders);
+        model.addAttribute(orderHistoryResultParameter, result);
 
         model.addAttribute("orders", orders);
         return getOrderHistoryView();

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -42,6 +42,7 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     protected static String orderDetailsView = "account/partials/orderDetails";
     protected static String orderDetailsRedirectView = "account/partials/orderDetails";
     protected static String orderHistoryPageParameter = "page";
+    protected static String orderHistoryQueryParameter = "query";
     protected static String orderHistoryDateStartParameter = "dateStart";
     protected static String orderHistoryDateEndParameter = "dateEnd";
     protected static String orderHistoryDateFilterParameter = "dateFilter";
@@ -61,10 +62,12 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
 
         List<Order> orders;
 
+        //Date filtering
         String filterParameter = request.getParameter(orderHistoryDateFilterParameter);
+        String dateStartParam = request.getParameter(orderHistoryDateStartParameter);
+        String dateEndParam = request.getParameter(orderHistoryDateEndParameter);
         if (filterParameter != null) {
-            String dateStartParam = request.getParameter(orderHistoryDateStartParameter);
-            String dateEndParam = request.getParameter(orderHistoryDateEndParameter);
+
             if(dateStartParam == null || dateEndParam == null) {
                 throw new InvalidParameterException("Start and end date parameters were null");
             }
@@ -74,6 +77,9 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
             try {
                 Date startDate = filterDateFormat.parse(dateStartParam + " 00:00:00"); //Start of day
                 Date endDate = filterDateFormat.parse(dateEndParam + " 23:59:59"); //Last second of the day
+
+
+
                 orders = orderService.findOrdersForCustomersInDateRange(Collections.singletonList(CustomerState.getCustomer().getId()), startDate, endDate);
             } catch (ParseException p) {
                 throw new InvalidParameterException("The start/end date was specified in an invalid format");
@@ -82,8 +88,14 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
             orders = orderService.findOrdersForCustomer(CustomerState.getCustomer(), OrderStatus.SUBMITTED);
         }
 
+        model.addAttribute(orderHistoryDateFilterParameter, filterParameter);
+        model.addAttribute(orderHistoryQueryParameter, request.getParameter(orderHistoryQueryParameter));
+        model.addAttribute(orderHistoryDateStartParameter, dateStartParam);
+        model.addAttribute(orderHistoryDateEndParameter, dateEndParam);
+        model.addAttribute(orderHistoryPageParameter, page);
+
         if (!orders.isEmpty() && page > 0 && page <= orders.size() / itemsPerPage + 1) {
-            orders = orders.subList((page - 1) * 10, Math.min(orders.size(), page * 10));
+            orders = orders.subList((page - 1) * itemsPerPage, Math.min(orders.size(), page * itemsPerPage));
         }
 
         model.addAttribute("orders", orders);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -18,6 +18,8 @@
 package org.broadleafcommerce.core.web.controller.account;
 
 import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.service.OrderService;
+import org.broadleafcommerce.core.order.service.type.OrderStatus;
 import org.broadleafcommerce.core.web.service.OrderHistoryService;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,12 +43,17 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     @Resource(name = "blOrderHistoryService")
     protected OrderHistoryService orderHistoryService;
 
+    @Resource(name = "blOrderService")
+    protected OrderService orderService;
+
     public String viewOrderHistory(HttpServletRequest request, Model model) {
         if (CustomerState.getCustomer() == null) {
             throw new SecurityException("Null customer tried to access order history");
         }
+        List<Order> orders = orderService.findOrdersForCustomer(CustomerState.getCustomer(), OrderStatus.SUBMITTED);
+
         Map<String, Object> modelAttributes = new HashMap<>();
-        List<Order> orders = orderHistoryService.getOrderHistory(request.getParameterMap(), modelAttributes);
+        orders = orderHistoryService.getOrderHistory(request.getParameterMap(), modelAttributes, orders);
 
         for (Order order : orders) {
             orderHistoryService.validateCustomerOwnedData(order);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafOrderHistoryController.java
@@ -17,13 +17,6 @@
  */
 package org.broadleafcommerce.core.web.controller.account;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
-
 import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.service.OrderService;
 import org.broadleafcommerce.core.order.service.type.OrderStatus;
@@ -31,6 +24,11 @@ import org.broadleafcommerce.core.web.service.OrderHistoryService;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ui.Model;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 
 public class BroadleafOrderHistoryController extends AbstractAccountController {
 
@@ -50,20 +48,13 @@ public class BroadleafOrderHistoryController extends AbstractAccountController {
     public String viewOrderHistory(HttpServletRequest request, Model model) {
         List<Order> orders = orderService.findOrdersForCustomer(CustomerState.getCustomer(), OrderStatus.SUBMITTED);
 
-        Map<String, Object> modelAttributes = new HashMap<>();
-        orders = orderHistoryService.getOrderHistory(request.getParameterMap(), modelAttributes, orders);
-
-        for (Order order : orders) {
-            validateCustomerOwnedData(order);
-        }
-
-        model.addAllAttributes(modelAttributes);
         model.addAttribute("orders", orders);
         return getOrderHistoryView();
     }
 
     public String viewOrderDetails(HttpServletRequest request, Model model, String orderNumber) {
         Order order = orderHistoryService.getOrderDetails(orderNumber);
+
         model.addAttribute("order", order);
         return isAjaxRequest(request) ? getOrderDetailsView() : getOrderDetailsRedirectView();
     }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
@@ -17,12 +17,10 @@
  */
 package org.broadleafcommerce.core.web.service;
 
-import org.broadleafcommerce.core.order.domain.Order;
-import org.springframework.ui.Model;
-
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Map;
+
+import org.broadleafcommerce.core.order.domain.Order;
 
 /**
  * Service for retrieving filtered (by search query and date) order history
@@ -30,12 +28,30 @@ import java.util.Map;
  */
 public interface OrderHistoryService {
 
-    List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes);
-
+    /**
+     * Gets the orders that should be displayed after pagination, date filtering, and search filtering
+     * @param parameterMap the parameters from the web request
+     * @param modelAttributes a map that holds attributes that should be added to the model
+     * @param startingOrders the starting orders to filter from
+     * @return the filtered ordes from <code>startingOrders</code>
+     */
     List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes, List<Order> startingOrders);
 
+    /**
+     * Throws an exception if the customer tries to access an order they don't have access to
+     * @param order the order to check ownership of
+     */
     void validateCustomerOwnedData(Order order);
 
-    void viewOrderDetails(HttpServletRequest request, Model model, String orderNumber);
+    /**
+     * Loads a single order
+     * @param orderNumber the order number of the order to retrieve
+     */
+    Order getOrderDetails(String orderNumber);
 
+    /**
+     * Gets the number of items per page
+     * @return number of items per page
+     */
+    int getItemsPerPage();
 }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
@@ -18,7 +18,6 @@
 package org.broadleafcommerce.core.web.service;
 
 import org.broadleafcommerce.core.order.domain.Order;
-import org.broadleafcommerce.core.order.service.type.OrderStatus;
 import org.springframework.ui.Model;
 
 import javax.servlet.http.HttpServletRequest;
@@ -33,7 +32,7 @@ public interface OrderHistoryService {
 
     List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes);
 
-    List<Order> filterOrdersByStatus(List<Order> orders, List<OrderStatus> orderStatuses);
+    List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes, List<Order> startingOrders);
 
     void validateCustomerOwnedData(Order order);
 

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.service;
+
+import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.service.type.OrderStatus;
+import org.springframework.ui.Model;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for retrieving filtered (by search query and date) order history
+ * @author Jacob Mitash
+ */
+public interface OrderHistoryService {
+
+    List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes);
+
+    List<Order> filterOrdersByStatus(List<Order> orders, List<OrderStatus> orderStatuses);
+
+    void validateCustomerOwnedData(Order order);
+
+    void viewOrderDetails(HttpServletRequest request, Model model, String orderNumber);
+
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryService.java
@@ -17,41 +17,28 @@
  */
 package org.broadleafcommerce.core.web.service;
 
-import java.util.List;
-import java.util.Map;
-
 import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.web.core.CustomerState;
 
 /**
- * Service for retrieving filtered (by search query and date) order history
+ * Service for gathering previously completed orders
+ *
  * @author Jacob Mitash
  */
 public interface OrderHistoryService {
 
     /**
-     * Gets the orders that should be displayed after pagination, date filtering, and search filtering
-     * @param parameterMap the parameters from the web request
-     * @param modelAttributes a map that holds attributes that should be added to the model
-     * @param startingOrders the starting orders to filter from
-     * @return the filtered ordes from <code>startingOrders</code>
-     */
-    List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes, List<Order> startingOrders);
-
-    /**
-     * Throws an exception if the customer tries to access an order they don't have access to
-     * @param order the order to check ownership of
-     */
-    void validateCustomerOwnedData(Order order);
-
-    /**
-     * Loads a single order
-     * @param orderNumber the order number of the order to retrieve
+     * Gathers an {@link Order} based on the given {@param orderNumber} value
+     *
+     * If `validate.customer.owned.data` is true, then we must throw an exception to avoid giving the currently logged in
+     *  {@link Customer} access to an order that they do not own.
      */
     Order getOrderDetails(String orderNumber);
 
     /**
-     * Gets the number of items per page
-     * @return number of items per page
+     * If is validation is enabled via the `validate.customer.owned.data` property, a {@link SecurityException} should be thrown if the current customer
+     *  ({@link CustomerState#getCustomer()}) is not associated to the given {@param order}.
      */
-    int getItemsPerPage();
+    void validateCustomerOwnedData(Order order) throws SecurityException;
 }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
@@ -76,12 +76,18 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
         String dateEndParam = parameters.get(orderHistoryDateEndParameter);
 
         //Date filtering
-        if(startingOrders != null && isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
-            orders = filterDates(startingOrders, dateStartParam, dateEndParam);
-        } else if (startingOrders == null && isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
-            orders = findFilteredDates(dateStartParam, dateEndParam);
+        if(startingOrders != null) {
+            if(isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
+                orders = filterDates(startingOrders, dateStartParam, dateEndParam);
+            } else {
+                orders = startingOrders;
+            }
         } else {
-            orders = orderService.findOrdersForCustomer(CustomerState.getCustomer());
+            if (isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
+                orders = findFilteredDates(dateStartParam, dateEndParam);
+            } else {
+                orders = orderService.findOrdersForCustomer(CustomerState.getCustomer());
+            }
         }
 
         //Query filtering

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
@@ -1,0 +1,227 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.service;
+
+import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;
+import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.domain.OrderItem;
+import org.broadleafcommerce.core.order.service.OrderService;
+import org.broadleafcommerce.core.order.service.type.OrderStatus;
+import org.broadleafcommerce.core.search.domain.SearchResult;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.web.core.CustomerState;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.Model;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+import java.security.InvalidParameterException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/**
+ * @author Jacob Mitash
+ */
+@Service("blOrderHistoryService")
+public class OrderHistoryServiceImpl implements OrderHistoryService {
+
+    @Value("${validate.customer.owned.data:true}")
+    protected boolean validateCustomerOwnedData;
+
+    protected static String orderHistoryPageParameter = "page";
+    protected static String orderHistoryQueryParameter = "query";
+    protected static String orderHistoryDateStartParameter = "dateStart";
+    protected static String orderHistoryDateEndParameter = "dateEnd";
+    protected static String orderHistoryDateFilterParameter = "dateFilter";
+    protected static String orderHistoryResultParameter = "result";
+    protected static DateFormat filterDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+    protected static int itemsPerPage = 10;
+
+    @Resource(name = "blOrderService")
+    protected OrderService orderService;
+
+    @Override
+    public List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes) {
+        Map<String, String> parameters = singleValueParameterMap(parameterMap);
+
+        int page = getCurrentPage(parameters.get(orderHistoryPageParameter));
+
+        List<Order> orders;
+
+        String dateFilter = parameters.get(orderHistoryDateFilterParameter);
+        String query = parameters.get(orderHistoryQueryParameter);
+        String dateStartParam = parameters.get(orderHistoryDateStartParameter);
+        String dateEndParam = parameters.get(orderHistoryDateEndParameter);
+
+        //Date filtering
+        if (isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
+            orders = filterDates(dateStartParam, dateEndParam);
+        } else {
+            orders = orderService.findOrdersForCustomer(CustomerState.getCustomer());
+        }
+
+        //Query filtering
+        if (isSearch(query)) {
+            orders = filterSearch(orders, query);
+        }
+
+        final int totalOrders = orders.size();
+        if (!orders.isEmpty() && page > 0 && page <= orders.size() / itemsPerPage + 1) {
+            orders = orders.subList((page - 1) * itemsPerPage, Math.min(orders.size(), page * itemsPerPage));
+        }
+
+
+        //Build search result so pagination works
+        final List<Order> finalOrders = orders;
+        SearchResult result = new SearchResult() {
+            @Override
+            public Integer getStartResult() {
+                return itemsPerPage * (page - 1) + (finalOrders.isEmpty() ? 0 : 1);
+            }
+
+            @Override
+            public Integer getTotalPages() {
+                return totalOrders / itemsPerPage + 1;
+            }
+        };
+        result.setPage(page);
+        result.setPageSize(itemsPerPage);
+        result.setTotalResults(totalOrders);
+
+        //Keep the previously selected options and add result
+        modelAttributes.put(orderHistoryResultParameter, result);
+        modelAttributes.put(orderHistoryDateFilterParameter, dateFilter);
+        modelAttributes.put(orderHistoryQueryParameter, query);
+        modelAttributes.put(orderHistoryDateStartParameter, dateStartParam);
+        modelAttributes.put(orderHistoryDateEndParameter, dateEndParam);
+        modelAttributes.put(orderHistoryPageParameter, page);
+
+        return orders;
+    }
+
+    @Override
+    public List<Order> filterOrdersByStatus(List<Order> orders, List<OrderStatus> orderStatuses) {
+        List<Order> filteredOrders = new ArrayList<>(orders);
+        for(Iterator<Order> iterator = orders.iterator(); iterator.hasNext();) {
+            Order order = iterator.next();
+            validateCustomerOwnedData(order);
+            if(!orderStatuses.contains(order.getStatus())) {
+                iterator.remove();
+            }
+        }
+        return filteredOrders;
+    }
+
+    @Override
+    public void validateCustomerOwnedData(Order order) {
+        if (validateCustomerOwnedData) {
+            Customer activeCustomer = CustomerState.getCustomer();
+            if (activeCustomer != null && !(activeCustomer.equals(order.getCustomer()))) {
+                throw new SecurityException("The active customer does not own the object that they are trying to view, edit, or remove.");
+            } else if (activeCustomer == null && order.getCustomer() != null) {
+                throw new SecurityException("The active customer does not own the object that they are trying to view, edit, or remove.");
+            }
+        }
+    }
+
+    public void viewOrderDetails(HttpServletRequest request, Model model, String orderNumber) {
+        Order order = orderService.findOrderByOrderNumber(orderNumber);
+        if (order == null) {
+            throw new IllegalArgumentException("The orderNumber provided is not valid");
+        }
+
+        validateCustomerOwnedData(order);
+
+        model.addAttribute("order", order);
+    }
+
+    protected int getCurrentPage(String pageParameter) {
+        return pageParameter == null ? 1 : Integer.parseInt(pageParameter);
+    }
+
+    protected boolean isDateFiltered(String filterParam, String dateStartParam, String dateEndParam) {
+        if (filterParam != null) {
+            if (dateStartParam == null || dateEndParam == null) {
+                throw new InvalidParameterException("Start and end date parameters were null");
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    protected boolean isSearch(String query) {
+        return query != null && !query.trim().isEmpty();
+    }
+
+    protected List<Order> filterSearch(List<Order> originalOrders, String query) {
+        List<Order> matchingOrders = new ArrayList<>();
+        if (query.matches("[0-9]+")) {
+            //SKU or order ID
+            for (Order order : originalOrders) {
+                boolean match = order.getOrderNumber().equals(query);
+                if (!match) {
+                    for (DiscreteOrderItem orderItem : order.getDiscreteOrderItems()) {
+                        if (orderItem.getSku().getId().equals(Long.parseLong(query))) {
+                            match = true;
+                            break;
+                        }
+                    }
+                }
+                if (match) {
+                    matchingOrders.add(order);
+                }
+            }
+        } else {
+            //Product name
+            for (Order order : originalOrders) {
+                for (OrderItem orderItem : order.getOrderItems()) {
+                    if (orderItem.getName().toLowerCase().contains(query.toLowerCase())) {
+                        matchingOrders.add(order);
+                    }
+                }
+            }
+        }
+        return matchingOrders;
+    }
+
+    protected List<Order> filterDates(String dateStartParam, String dateEndParam) {
+        try {
+            Date startDate = filterDateFormat.parse(dateStartParam + " 00:00:00"); //Start of day
+            Date endDate = filterDateFormat.parse(dateEndParam + " 23:59:59"); //Last second of the day
+
+            return orderService.findOrdersForCustomersInDateRange(Collections.singletonList(CustomerState.getCustomer().getId()), startDate, endDate);
+        } catch (ParseException p) {
+            throw new InvalidParameterException("The start/end date was specified in an invalid format");
+        }
+    }
+
+    protected Map<String, String> singleValueParameterMap(Map<String, String[]> parameterMap) {
+        Map<String, String> singleValueMap = new HashMap<>();
+        for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().length > 0) {
+                singleValueMap.put(entry.getKey(), entry.getValue()[0]);
+            }
+        }
+        return singleValueMap;
+    }
+
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/OrderHistoryServiceImpl.java
@@ -17,25 +17,15 @@
  */
 package org.broadleafcommerce.core.web.service;
 
-import java.security.InvalidParameterException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import javax.annotation.Resource;
-
-import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;
 import org.broadleafcommerce.core.order.domain.Order;
-import org.broadleafcommerce.core.order.domain.OrderItem;
 import org.broadleafcommerce.core.order.service.OrderService;
-import org.broadleafcommerce.core.search.domain.SearchResult;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
 
 /**
  * @author Jacob Mitash
@@ -43,96 +33,13 @@ import org.springframework.stereotype.Service;
 @Service("blOrderHistoryService")
 public class OrderHistoryServiceImpl implements OrderHistoryService {
 
-    @Value("${validate.customer.owned.data:true}")
-    protected boolean validateCustomerOwnedData;
-
-    protected static String orderHistoryPageParameter = "page";
-    protected static String orderHistoryQueryParameter = "query";
-    protected static String orderHistoryDateStartParameter = "dateStart";
-    protected static String orderHistoryDateEndParameter = "dateEnd";
-    protected static String orderHistoryDateFilterParameter = "dateFilter";
-    protected static String orderHistoryResultParameter = "result";
-    protected static DateFormat filterDateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
-
-    protected final Environment environment;
+    public static final String ACTIVE_CUSTOMER_OWNERSHIP_ERROR_MESSAGE = "The active customer does not own the object that they are trying to view, edit, or remove.";
 
     @Resource(name = "blOrderService")
     protected OrderService orderService;
 
     @Autowired
-    public OrderHistoryServiceImpl(Environment environment) {
-        this.environment = environment;
-    }
-
-    @Override
-    public List<Order> getOrderHistory(Map<String, String[]> parameterMap, Map<String, Object> modelAttributes, List<Order> startingOrders) {
-        Map<String, String> parameters = singleValueParameterMap(parameterMap);
-
-        int page = getCurrentPage(parameters.get(orderHistoryPageParameter));
-
-        List<Order> orders;
-
-        String dateFilter = parameters.get(orderHistoryDateFilterParameter);
-        String query = parameters.get(orderHistoryQueryParameter);
-        String dateStartParam = parameters.get(orderHistoryDateStartParameter);
-        String dateEndParam = parameters.get(orderHistoryDateEndParameter);
-
-        //Date filtering
-        if(isDateFiltered(dateFilter, dateStartParam, dateEndParam)) {
-            orders = filterDates(startingOrders, dateStartParam, dateEndParam);
-        } else {
-            orders = startingOrders;
-        }
-
-        //Query filtering
-        if (isSearch(query)) {
-            orders = filterSearch(orders, query);
-        }
-
-        final int totalOrders = orders.size();
-        if (!orders.isEmpty() && page > 0 && page <= orders.size() / getItemsPerPage() + 1) {
-            orders = orders.subList((page - 1) * getItemsPerPage(), Math.min(orders.size(), page * getItemsPerPage()));
-        }
-
-        //Build search result so pagination works
-        final List<Order> finalOrders = orders;
-        SearchResult result = new SearchResult() {
-            @Override
-            public Integer getStartResult() {
-                return getItemsPerPage() * (page - 1) + (finalOrders.isEmpty() ? 0 : 1);
-            }
-
-            @Override
-            public Integer getTotalPages() {
-                return totalOrders / getItemsPerPage() + 1;
-            }
-        };
-        result.setPage(page);
-        result.setPageSize(getItemsPerPage());
-        result.setTotalResults(totalOrders);
-
-        //Keep the previously selected options and add result
-        modelAttributes.put(orderHistoryResultParameter, result);
-        modelAttributes.put(orderHistoryDateFilterParameter, dateFilter);
-        modelAttributes.put(orderHistoryQueryParameter, query);
-        modelAttributes.put(orderHistoryDateStartParameter, dateStartParam);
-        modelAttributes.put(orderHistoryDateEndParameter, dateEndParam);
-        modelAttributes.put(orderHistoryPageParameter, page);
-
-        return orders;
-    }
-
-    @Override
-    public void validateCustomerOwnedData(Order order) {
-        if (validateCustomerOwnedData) {
-            Customer activeCustomer = CustomerState.getCustomer();
-            if (activeCustomer != null && !(activeCustomer.equals(order.getCustomer()))) {
-                throw new SecurityException("The active customer does not own the object that they are trying to view, edit, or remove.");
-            } else if (activeCustomer == null && order.getCustomer() != null) {
-                throw new SecurityException("The active customer does not own the object that they are trying to view, edit, or remove.");
-            }
-        }
-    }
+    protected Environment env;
 
     @Override
     public Order getOrderDetails(String orderNumber) {
@@ -147,141 +54,19 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
     }
 
     @Override
-    public int getItemsPerPage() {
-        String itemsPerPage = environment.getProperty("web.defaultPageSize", "15");
-        try {
-            return Integer.parseInt(itemsPerPage);
-        } catch (NumberFormatException e) {
-            throw new InvalidParameterException("web.defaultPageSize could not be parsed as an integer '" + itemsPerPage + "'");
-        }
-    }
-
-    /**
-     * Gets the current page number
-     * @param pageParameter the "page" parameter from the request
-     * @return the current page
-     */
-    protected int getCurrentPage(String pageParameter) {
-        return pageParameter == null ? 1 : Integer.parseInt(pageParameter);
-    }
-
-    /**
-     * Tells whether the results should be filtered by date
-     * @param filterParam the string from the "filter date" checkbox
-     * @param dateStartParam the starting date
-     * @param dateEndParam the ending date
-     * @return
-     */
-    protected boolean isDateFiltered(String filterParam, String dateStartParam, String dateEndParam) {
-        if (filterParam != null) {
-            if (dateStartParam == null || dateEndParam == null) {
-                throw new InvalidParameterException("Start and end date parameters were null");
-            }
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Tells if the request is a search
-     * @param query The query string
-     * @return true if the query is a search, false otherwise
-     */
-    protected boolean isSearch(String query) {
-        return query != null && !query.trim().isEmpty();
-    }
-
-    /**
-     * Filters the <code>originalOrders</code> to match the <code>query</code>
-     * TODO: Solr order searching
-     * @param originalOrders the orders to filter
-     * @param query the query to filter by- either a SKU, Order number, or partial product name
-     * @return a subset of the orders
-     */
-    protected List<Order> filterSearch(List<Order> originalOrders, String query) {
-        List<Order> matchingOrders = new ArrayList<>();
-        if (query.matches("[0-9]+")) {
-            //SKU or order ID
-            for (Order order : originalOrders) {
-                boolean match = order.getOrderNumber().equals(query);
-                if (!match) {
-                    for (DiscreteOrderItem orderItem : order.getDiscreteOrderItems()) {
-                        if (orderItem.getSku().getId().equals(Long.parseLong(query))) {
-                            match = true;
-                            break;
-                        }
-                    }
-                }
-                if (match) {
-                    matchingOrders.add(order);
-                }
-            }
-        } else {
-            //Product name
-            for (Order order : originalOrders) {
-                for (OrderItem orderItem : order.getOrderItems()) {
-                    if (orderItem.getName().toLowerCase().contains(query.toLowerCase())) {
-                        matchingOrders.add(order);
-                        break;
-                    }
-                }
+    public void validateCustomerOwnedData(Order order) throws SecurityException {
+        if (shouldValidateCustomerOwnedData()) {
+            Customer activeCustomer = CustomerState.getCustomer();
+            if (activeCustomer != null && !(activeCustomer.equals(order.getCustomer()))) {
+                throw new SecurityException(ACTIVE_CUSTOMER_OWNERSHIP_ERROR_MESSAGE);
+            } else if (activeCustomer == null && order.getCustomer() != null) {
+                throw new SecurityException(ACTIVE_CUSTOMER_OWNERSHIP_ERROR_MESSAGE);
             }
         }
-        return matchingOrders;
     }
 
-    /**
-     * Filters the orders between the given start date and end date
-     * TODO: Do filtering directly from database query/Solr
-     * @param orders the orders to filter
-     * @param dateStartParam the first date to allow orders from
-     * @param dateEndParam the last date to allow orders to
-     * @return a subset of orders from <code>orders</code> between the start and end dates
-     */
-    protected List<Order> filterDates(List<Order> orders, String dateStartParam, String dateEndParam) {
-        Date startDate = getDateFromString(dateStartParam, true);
-        Date endDate = getDateFromString(dateEndParam, false);
-        List<Order> filteredOrders = new ArrayList<>();
-        for(Order order : orders) {
-            if(order.getSubmitDate().after(startDate) && order.getSubmitDate().before(endDate)) {
-                filteredOrders.add(order);
-            }
-        }
-        return filteredOrders;
-    }
-
-    /**
-     * Converts a MM/DD/YYYY date to a {@link java.util.Date} at either the start or end of day depending on
-     * <code>startOfDay</code>
-     * @param stringDate the date as a MM/DD/YYYY string
-     * @param startOfDay true if the date should represent the first second of the day, false if it should represent
-     *                   the last second of the day
-     * @return a date representing <code>stringDate</code> at the start or end of the day
-     */
-    protected Date getDateFromString(String stringDate, boolean startOfDay) {
-        Date date;
-        try {
-            date = filterDateFormat.parse(stringDate + (startOfDay ? " 00:00:00" : "23:59:59"));
-        } catch (ParseException e) {
-            throw new InvalidParameterException("The start/end date '" + stringDate + "' was specified in an invalid format");
-        }
-        return date;
-    }
-
-    /**
-     * Converts a parameter map which can have multiple values per key into a new map that has only the first value
-     * @param parameterMap the original parameter map with potentially multiple values per key
-     * @return a new map with only the first value per key of the original map
-     */
-    protected Map<String, String> singleValueParameterMap(Map<String, String[]> parameterMap) {
-        Map<String, String> singleValueMap = new HashMap<>();
-        for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-            if (entry.getValue() != null && entry.getValue().length > 0) {
-                singleValueMap.put(entry.getKey(), entry.getValue()[0]);
-            }
-        }
-        return singleValueMap;
+    protected boolean shouldValidateCustomerOwnedData() {
+        return env.getProperty("validate.customer.owned.data", boolean.class, true);
     }
 
 }


### PR DESCRIPTION
## Enhance Order History
This enhances order history by adding a basic search feature, date filtering, and pagination support for the `BroadleafOrderHistoryController`. The majority of the logic for filtering is in `OrderHistoryService` since the majority of the features are shared between the `BroadleafOrderHistoryController` and the `BroadleafAccountOrderHistoryController` located in the Account module.

### Pagination
The enhancement allows for pagination of orders on the order history page. Previously, all orders for would be listed on a single page regardless of the number of orders. Now, the orders are broken into pages.

### Date filtering
The orders can now be filtered within a date range. For example, by changing the start date to 6 months ago and leaving the end date at the current date, you can retrieve all orders within the past 6 months.

### Searching
Orders can be searched using the order number, a product SKU, or a partial product name.

**Note:** The search implementation is very basic and will be replaced in the near future with Solr searching. Date filtering will also likely be done through Solr.