### PR TITLE
Added ability to have an amount off offer split among the matching order items

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableCandidateItemOffer.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableCandidateItemOffer.java
@@ -52,6 +52,8 @@ public interface PromotableCandidateItemOffer extends Serializable {
      * Public only for unit testing - not intended to be called
      */
     public Money calculateSavingsForOrderItem(PromotableOrderItem orderItem, int qtyToReceiveSavings);
+    
+    public int calcuateMaximumOrderItemsForSplitOffer(PromotableOrderItem orderItem);
 
     public int calculateMaximumNumberOfUses();
     
@@ -112,5 +114,9 @@ public interface PromotableCandidateItemOffer extends Serializable {
      * @return
      */
     public int getMinimumRequiredTargetQuantity();
+    
+    public void setItemsApplied(int numApplied);
+    
+    public int getItemsApplied();
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtility.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtility.java
@@ -54,6 +54,15 @@ public class PromotableOfferUtility {
             adjustmentValue = new Money(offerUnitValue, currency);
         }
         
+        if (OfferDiscountType.SPLIT_AMOUNT_OFF.equals(discountType)) {
+            BigDecimal offerValue = offerUnitValue;
+            
+            if (rounding.isRoundOfferValues()) {
+                offerValue = offerValue.setScale(rounding.getRoundingScale(), rounding.getRoundingMode());
+            }
+            adjustmentValue = new Money(offerValue, currency, 5);
+        }
+        
         if (OfferDiscountType.FIX_PRICE.equals(discountType)) {
             adjustmentValue = currentPriceDetailValue.subtract(new Money(offerUnitValue, currency));
         }
@@ -107,6 +116,11 @@ public class PromotableOfferUtility {
                 } else {
                     return BigDecimal.ZERO;
                 }
+            }
+        }
+        if (OfferDiscountType.SPLIT_AMOUNT_OFF.equals(offer.getDiscountType())) {
+            if (promotableCandidateItemOffer.getItemsApplied() > 0) {
+                return offer.getValue().divide(new BigDecimal(promotableCandidateItemOffer.getItemsApplied()), 5, RoundingMode.HALF_EVEN);
             }
         }
         return offer.getValue();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetail.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetail.java
@@ -208,5 +208,9 @@ public interface PromotableOrderItemPriceDetail {
      * @return
      */
     PromotableOrderItemPriceDetail copyWithFinalizedData();
+    
+    void setOverride(boolean isOverride);
+    
+    boolean isOverride();
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailAdjustment.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailAdjustment.java
@@ -98,5 +98,7 @@ public interface PromotableOrderItemPriceDetailAdjustment extends Serializable {
      * @return
      */
     public PromotableOrderItemPriceDetailAdjustment copy();
+    
+    public void addToAdjustmentValues(Money val);
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailAdjustmentImpl.java
@@ -160,4 +160,13 @@ public class PromotableOrderItemPriceDetailAdjustmentImpl extends AbstractPromot
         newAdjustment.appliedToSalePrice = appliedToSalePrice;
         return newAdjustment;
     }
+
+    @Override
+    public void addToAdjustmentValues(Money val) {
+        saleAdjustmentValue = saleAdjustmentValue.add(val);
+        retailAdjustmentValue = retailAdjustmentValue.add(val);
+        if (adjustmentValue != null) {
+            adjustmentValue = adjustmentValue.add(val);
+        }
+    }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
@@ -39,6 +39,7 @@ public class PromotableOrderItemPriceDetailImpl implements PromotableOrderItemPr
     protected List<PromotionDiscount> promotionDiscounts = new ArrayList<PromotionDiscount>();
     protected List<PromotionQualifier> promotionQualifiers = new ArrayList<PromotionQualifier>();
     protected int quantity;
+    protected boolean isOverride = false;
     protected boolean useSaleAdjustments = false;
     protected boolean adjustmentsFinalized = false;
     protected Money adjustedTotal;
@@ -489,7 +490,7 @@ public class PromotableOrderItemPriceDetailImpl implements PromotableOrderItemPr
             offerIds.add(offerId);
         }
         Collections.sort(offerIds);
-        return promotableOrderItem.getOrderItem().toString() + offerIds.toString() + useSaleAdjustments;
+        return promotableOrderItem.getOrderItem().toString() + offerIds.toString() + useSaleAdjustments + (isOverride ? isOverride : "");
     }
 
     @Override
@@ -593,6 +594,16 @@ public class PromotableOrderItemPriceDetailImpl implements PromotableOrderItemPr
     @Override
     public boolean useSaleAdjustments() {
         return useSaleAdjustments;
+    }
+
+    @Override
+    public void setOverride(boolean isOverride) {
+        this.isOverride = isOverride;
+    }
+
+    @Override
+    public boolean isOverride() {
+        return isOverride;
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailWrapper.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailWrapper.java
@@ -152,4 +152,14 @@ public class PromotableOrderItemPriceDetailWrapper implements PromotableOrderIte
         return detail.copyWithFinalizedData();
     }
 
+    @Override
+    public void setOverride(boolean isOverride) {
+        detail.setOverride(isOverride);
+    }
+
+    @Override
+    public boolean isOverride() {
+        return detail.isOverride();
+    }
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
@@ -20,6 +20,8 @@ package org.broadleafcommerce.core.offer.service.processor;
 import org.apache.commons.beanutils.BeanComparator;
 import org.apache.commons.collections.comparators.NullComparator;
 import org.apache.commons.collections.comparators.ReverseComparator;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.BankersRounding;
@@ -35,6 +37,7 @@ import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfil
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfillmentGroupAdjustment;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableOrder;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableOrderItem;
+import org.broadleafcommerce.core.offer.service.type.OfferDiscountType;
 import org.broadleafcommerce.core.offer.service.type.OfferRuleType;
 import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
 import org.springframework.stereotype.Service;
@@ -55,8 +58,14 @@ import java.util.Map;
 @Service("blFulfillmentGroupOfferProcessor")
 public class FulfillmentGroupOfferProcessorImpl extends OrderOfferProcessorImpl implements FulfillmentGroupOfferProcessor {
 
+    private static final Log LOG = LogFactory.getLog(FulfillmentGroupOfferProcessorImpl.class);
+    
     @Override
     public void filterFulfillmentGroupLevelOffer(PromotableOrder order, List<PromotableCandidateFulfillmentGroupOffer> qualifiedFGOffers, Offer offer) {
+        if (OfferDiscountType.SPLIT_AMOUNT_OFF.equals(offer.getDiscountType().getType())) {
+            LOG.warn("Offers of type FULFILLMENT_GROUP may not have a discount type of SPLIT_AMOUNT_OFF. Ignoring fulfillment group offer (name=" + offer.getName() + ")");
+            return;
+        }
         for (PromotableFulfillmentGroup fulfillmentGroup : order.getFulfillmentGroups()) {
             boolean fgLevelQualification = false;
             fgQualification: {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
@@ -23,14 +23,12 @@ import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.core.offer.dao.OfferDao;
 import org.broadleafcommerce.core.offer.domain.FulfillmentGroupAdjustment;
 import org.broadleafcommerce.core.offer.domain.Offer;
-import org.broadleafcommerce.core.offer.domain.OfferItemCriteria;
 import org.broadleafcommerce.core.offer.domain.OfferOfferRuleXref;
 import org.broadleafcommerce.core.offer.domain.OrderAdjustment;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustment;
 import org.broadleafcommerce.core.offer.service.OfferServiceUtilities;
 import org.broadleafcommerce.core.offer.service.discount.CandidatePromotionItems;
 import org.broadleafcommerce.core.offer.service.discount.PromotionQualifier;
-import org.broadleafcommerce.core.offer.service.discount.domain.PromotableCandidateItemOffer;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableCandidateOrderOffer;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfillmentGroup;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfillmentGroupAdjustment;
@@ -83,6 +81,10 @@ public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements Or
     public void filterOrderLevelOffer(PromotableOrder promotableOrder, List<PromotableCandidateOrderOffer> qualifiedOrderOffers, Offer offer) {
         if (offer.getDiscountType().getType().equals(OfferDiscountType.FIX_PRICE.getType())) {
             LOG.warn("Offers of type ORDER may not have a discount type of FIX_PRICE. Ignoring order offer (name=" + offer.getName() + ")");
+            return;
+        }
+        if (OfferDiscountType.SPLIT_AMOUNT_OFF.equals(offer.getDiscountType().getType())) {
+            LOG.warn("Offers of type ORDER may not have a discount type of SPLIT_AMOUNT_OFF. Ignoring order offer (name=" + offer.getName() + ")");
             return;
         }
         boolean orderLevelQualification = false;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/type/OfferDiscountType.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/type/OfferDiscountType.java
@@ -36,6 +36,7 @@ public class OfferDiscountType implements Serializable, BroadleafEnumerationType
     public static final OfferDiscountType PERCENT_OFF = new OfferDiscountType("PERCENT_OFF", "Percent Off");
     public static final OfferDiscountType AMOUNT_OFF = new OfferDiscountType("AMOUNT_OFF", "Amount Off");
     public static final OfferDiscountType FIX_PRICE = new OfferDiscountType("FIX_PRICE", "Fixed Price");
+    public static final OfferDiscountType SPLIT_AMOUNT_OFF = new OfferDiscountType("SPLIT_AMOUNT_OFF", "Split Amount Off");
 
     public static OfferDiscountType getInstance(final String type) {
         return TYPES.get(type);


### PR DESCRIPTION
This is similar to an amount off order item discount except that that the value of the offer is split among all matching offers. So a $5 split amount offer would always adjust the order subtotal by $5 regardless of how many items are matched. This is a useful offer when considering returns since a $5 off order promo would effectively be split among all order items in the order when considering returns, whereas a split amount order item offer will already have the discount split among the targeted order items

Additionally this was a feature requested by O'Reilly.