### PR TITLE
Add support to `ExtensionHandler` to get a list of `cacheKeys` for a template site

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/SparselyPopulatedQueryExtensionHandler.java
@@ -160,6 +160,15 @@ public interface SparselyPopulatedQueryExtensionHandler extends ExtensionHandler
     ExtensionResultStatusType getCacheKey(String qualifier, ResultType resultType, ExtensionResultHolder<String> response);
 
     /**
+     * Build a list of cache keys that are related to a TEMPLATE template site
+     *
+     * @param qualifier the suffix for the cache key
+     * @param response the response container
+     * @return the status of the extension operation
+     */
+    ExtensionResultStatusType getCacheKeyListForTemplateSite(String qualifier, ExtensionResultHolder<List<String>> response);
+
+    /**
      * Convert the list of query results into a list that denotes not only the query results, but also whether or not each member
      * represents a deleted/archived item, or an active/normal item.
      *

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -19,14 +19,6 @@
  */
 package org.broadleafcommerce.common.i18n.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.annotation.Resource;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -46,6 +38,14 @@ import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.Resource;
 
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
@@ -218,9 +218,19 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
                 ExtensionResultHolder<ResultType> response = new ExtensionResultHolder<ResultType>();
                 extensionManager.getProxy().getResultType(translation, response);
                 resultType = response.getResult();
+                if (ResultType.STANDARD == resultType) {
+                    String key = getCacheKey(resultType, translation.getEntityType());
+                    LOG.debug("Removing key [" + key + "] for STANDARD site");
+                    getCache().remove(key);
+                } else {
+                    List<String> cacheKeysList =
+                            getCacheKeyListForTemplateSite(translation.getEntityType().getFriendlyType());
+                    for (String key: cacheKeysList) {
+                        LOG.debug("Removing key [" + key + "] for TEMPLATE site");
+                        getCache().remove(key);
+                    }
+                }
             }
-            String key = getCacheKey(resultType, translation.getEntityType());
-            getCache().remove(key);
         }
     }
 
@@ -393,6 +403,20 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
             }
         }
         return cacheKey;
+    }
+
+    @Override
+    public List<String> getCacheKeyListForTemplateSite(String propertyName) {
+        List<String> cacheKeyList = new ArrayList<>();
+        String cacheKey = StringUtils.join(new String[] {propertyName}, "|");
+        if (extensionManager != null) {
+            ExtensionResultHolder<List<String>> result = new ExtensionResultHolder<List<String>>();
+            extensionManager.getProxy().getCacheKeyListForTemplateSite(cacheKey, result);
+            if (result.getResult() != null) {
+                cacheKeyList = result.getResult();
+            }
+        }
+        return cacheKeyList;
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationSupport.java
@@ -19,14 +19,15 @@
  */
 package org.broadleafcommerce.common.i18n.service;
 
-import net.sf.ehcache.Cache;
-
 import org.broadleafcommerce.common.extension.ResultType;
 import org.broadleafcommerce.common.extension.StandardCacheItem;
 import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
 import org.broadleafcommerce.common.i18n.domain.Translation;
 
+import java.util.List;
 import java.util.Map;
+
+import net.sf.ehcache.Cache;
 
 /**
  * {@link TranslationService} functionality, primarily in support of {@link TranslationOverrideStrategy} instances.
@@ -51,6 +52,15 @@ public interface TranslationSupport {
      * @return
      */
     Cache getCache();
+
+    /**
+     *
+     * Returns a list of cacheKeys for a template site
+     *
+     * @param propertyName
+     * @return
+     */
+    List<String> getCacheKeyListForTemplateSite(String propertyName);
 
     /**
      * Retrieve the threshold under which the full list of standard site translation overrides are cached. See


### PR DESCRIPTION
BroadleafCommerce/QA#2574 

- Add support to extensionHandler to get a list of cacheKeys for a template site