### PR TITLE
Add property source and module registration interfaces for backwards and forwards compatibility with the Broadleaf 5.x line

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/config/FrameworkCommonClasspathPropertySource.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/FrameworkCommonClasspathPropertySource.java
@@ -1,0 +1,78 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+/**
+ * 
+ */
+package org.broadleafcommerce.common.config;
+
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * <p>
+ * This is a non-functional 5.0 and 5.1-compatible version of this interface that <i>only has functionality in Broadleaf 5.2</i>. This was added into
+ * the 5.0 and 5.1 streams in order to allow 3rd-party integration modules to be compatible with Broadleaf 5.0, 5.1 and 5.2 all at the same
+ * time.
+ * 
+ * <p>
+ * A holder for a folder containing a {@code common.properties} file to be added to the Spring {@link Environment} in a programmatic way without Spring Boot and with very specific
+ * ordering semantics. This is generally only used within the Broadleaf Framework and supporting modules. This assumes that the location is on the
+ * classpath as this drives the creation of a {@link ClassPathResource}. To write your custom one of these, implementations should add an entry to
+ * {@code META-INF/spring.factories} like:
+ * 
+ * <pre>
+ * org.broadleafcommerce.common.config.FrameworkCommonClasspathPropertySource=org.broadleafcommerce.common.config.BroadleafCommonPropertySource
+ * </pre>
+ * 
+ * <p>
+ * Any properties resolved by these classes have a lower precedence than any {@link BroadleafSharedOverrideProfileAwarePropertySource}. However, these have a higher
+ * precedence than any {@literal @}PropertySource annotations. Given the ordering mentioned in <a href="http://docs.spring.io/autorepo/docs/spring-boot/current/reference/html/boot-features-external-config.html#boot-features-external-config">this Spring Boot doc</a>
+ * properties resolved by these classes come immediately before the {@literal @}PropertySource annotations.
+ * 
+ * @author Phillip Verheyden (phillipuniverse)
+ * @since 5.0.12-GA, 5.1.5-GA, 5.2.0-GA
+ * @see {@link DefaultOrderFrameworkCommonClasspathPropertySource}
+ * @see {@link BroadleafSharedOverrideProfileAwarePropertySource}
+ * @see {@link BroadleafEnvironmentConfiguringApplicationListener}
+ */
+public interface FrameworkCommonClasspathPropertySource {
+
+    /**
+     * All of the property configurations registered by the core framework (e.g. broadleaf-framework, broadleaf-common, broadleaf-open-admin-platform, etc)
+     * have this ordering.
+     * 
+     * This ordering is mainly for backwards-compatibilty's sake, as this was the ordering essentially defined in the old StandardConfigLocations.txt
+     */
+    public static final int BROADLEAF_COMMON_ORDER = -8000;
+    public static final int PROFILE_ORDER = -7000;
+    public static final int PROFILE_WEB_ORDER = -6000;
+    public static final int FRAMEWORK_ORDER = -5000;
+    public static final int FRAMEWORK_WEB_ORDER = -4000;
+    public static final int OPEN_ADMIN_ORDER = -3000;
+    public static final int ADMIN_MODULE_ORDER = -2000;
+    public static final int CMS_ORDER = -1000;
+    
+    public static final int DEFAULT_ORDER = 1000;
+    
+    /**
+     * A folder on the classpath that contains a {@code common.properties} file. Note that this cannot be prefixed with {@code "classpath:"} or any of those
+     * varieties since this drives the creation of an {@link ClassPathResource} already based on this location.
+     */
+    String getClasspathFolder();
+    
+}

--- a/common/src/main/java/org/broadleafcommerce/common/module/BroadleafModuleRegistration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/module/BroadleafModuleRegistration.java
@@ -1,0 +1,132 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+/**
+ * 
+ */
+package org.broadleafcommerce.common.module;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.logging.ModuleLifecycleLoggingBean;
+import org.broadleafcommerce.common.util.ModulePresentUtil;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+
+/**
+ * <p>
+ * This is a non-functional 5.0 and 5.1-compatible version of this interface that <i>only has functionality in Broadleaf 5.2</i>. This was added into
+ * the 5.0 and 5.1 streams in order to allow 3rd-party integration modules to be compatible with Broadleaf 5.0, 5.1 and 5.2 all at the same
+ * time.
+ * 
+ * <p>
+ * Provides the ability for modules to register themselves with Broadleaf to be used with {@link org.broadleafcommerce.common.condition.ConditionalOnBroadleafModule} and {@link ModulePresentUtil}
+ * in order to provide different behavior in inter-module dependencies.
+ * 
+ * <p>
+ * Module implementations should be registered in a {@code spring.factories} file like so:
+ * 
+ * <pre>
+ * org.broadleafcommerce.common.condition.BroadleafModuleRegistration=com.broadleafcommerce.mymodule.registration.MyModuleRegistration
+ * </pre>
+ * 
+ * <p>
+ * In order to preserve compile-time checking, additional modules should be added to the {@link BroadleafModuleEnum}. However, if they aren't,
+ * this can always be checked at runtime instead by just looking for the String-based module name.
+ * 
+ * @author Phillip Verheyden (phillipuniverse)
+ * @see {@link org.broadleafcommerce.common.condition.OnBroadleafModuleCondition}
+ * @see {@link org.broadleafcommerce.common.condition.ConditionalOnBroadleafModule}
+ * @see {@link ModuleLifecycleLoggingBean}
+ * @see {@link SpringFactoriesLoader}
+ * @since 5.0.12-GA, 5.1.5-GA, 5.2.0-GA
+ */
+public interface BroadleafModuleRegistration {
+
+    /**
+     * The module name that is being registered. This should generally be the same as the logging information from a {@link ModuleLifecycleLoggingBean}.
+     */
+    public String getModuleName();
+    
+    /**
+     * List of modules that are known to have declared a {@link BroadleafModuleRegistration} in their {@code spring.factories}.
+     * 
+     * Note that any changes here should also be done in the respective module
+     */
+    public enum BroadleafModuleEnum {
+        ACCOUNT ("Account"),
+        ADMIN ("Admin"),
+        ADVANCED_CMS ("Advanced CMS"),
+        ADVANCED_INVENTORY ("Advanced Inventory"),
+        ADVANCED_OFFER ("Advanced Offer"),
+        AFFILIATE ("Affilliate"),
+        AMAZONS3 ("AmazonS3"),
+        AVALARA ("Avalara"),
+        CART_RULES ("Cart Rules"),
+        CATALOG_ACCESS_POLICY ("Catalog Access Policies"),
+        CUSTOMER_SEGMENT ("Customer Segment"),
+        CUSTOM_FIELD ("Custom Field"),
+        GIFT_CARD_AND_CUSTOMER_CREDIT ("Gift Cards and Customer Credit (AccountCredit)"),
+        ENTERPRISE ("Enterprise"),
+        ENTERPRISE_SEARCH ("Enterprise Search"),
+        EXPORT ("Export"),
+        FREE_GEO_IP ("FreeGeoIP"),
+        I18N_ENTERPRISE ("i18n Enterprise"),
+        IMPORT ("Import"),
+        JOBS_AND_EVENTS ("Jobs and Events"),
+        MARKETPLACE ("Marketplace"),
+        MAX_MIND_GEO ("MaxMindGeo"),
+        MENU ("Menu"),
+        MERCHANDISING_GROUP ("Merchandising Group"),
+        MULTI_TENANT_SINGLE_SCHEMA ("MultiTenant - SingleSchema"),
+        OMS ("OMS"),
+        PAYPAL ("Paypal"),
+        PRICE_LIST ("PriceList"),
+        PROCESS ("Process"),
+        PRODUCT_TYPE ("Product Type"),
+        PUNCHOUT2GO ("PunchOut2Go"),
+        QUOTE ("Quote"),
+        REST_API ("Broadleaf REST APIs"),
+        SUBSCRIPTION ("Subscription"),
+        TAXCLOUD ("TaxCloud"),
+        THEME ("Theme"),
+        THYMELEAF2 ("Broadleaf Thymeleaf 2 Support"),
+        THYMELEAF3 ("Broadleaf Thymeleaf 3 Support"),
+        
+        /**
+         * Added in order to provide an optional default value to {@link ConditionalOnBroadleafModule}
+         */
+        IGNORED ("IGNORED");
+
+        private final String name;
+
+        BroadleafModuleEnum(String name) {
+            this.name = name;
+        }
+
+        public boolean equalsModuleName(String name) {
+            return StringUtils.equals(name, this.name);
+        }
+        
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+}


### PR DESCRIPTION
It is currently not possible to make Broadleaf modules compatible with Broadleaf 5.0/5.1 and 5.2 at the same time, because of a couple of required interfaces that 5.2-compatible modules must implement. This adds those interfaces into Broadleaf 5.0 and 5.1 so that a module can be compatible with all 3, even though the implementation of those interfaces in 5.0 and 5.1 will mean nothing.