### PR TITLE
Added a null check when determining correct AdminSection

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/dao/AdminNavigationDaoImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/dao/AdminNavigationDaoImpl.java
@@ -114,13 +114,15 @@ public class AdminNavigationDaoImpl implements AdminNavigationDao {
                 sectionId = getSectionKey(true);
             }
 
-            if (!sectionId.startsWith("/")) {
-                sectionId = "/" + sectionId;
-            }
-            for (AdminSection section : sections) {
-                if (sectionId.equals(section.getUrl())) {
-                    returnSection = section;
-                    break;
+            if (sectionId != null) {
+                if (!sectionId.startsWith("/")) {
+                    sectionId = "/" + sectionId;
+                }
+                for (AdminSection section : sections) {
+                    if (sectionId.equals(section.getUrl())) {
+                        returnSection = section;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
This check was added because outside of a web request (i.e. tests) foreign key lookups will fail when resolving the AdminSection for creating the EntityForm. Normally this works because it will simply grab the section key from the url (which doesn't match because it's the ceiling entities and not the foreign key's), determine that it doesn't match any of the AdminSections and then return the first one.