### PR TITLE
Allow UTF-8 characters (like accent marks) in message bundles

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/BroadleafMergeResourceBundleMessageSource.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/BroadleafMergeResourceBundleMessageSource.java
@@ -23,8 +23,10 @@ import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.io.ResourceLoader;
+
 import java.text.MessageFormat;
 import java.util.Locale;
+
 import javax.annotation.Resource;
 
 
@@ -56,6 +58,10 @@ public class BroadleafMergeResourceBundleMessageSource extends ReloadableResourc
     @Resource(name = "blBroadleafMergeResourceExtensionManager")
     protected BroadleafMergeResourceExtensionManager extensionManager;
 
+    public BroadleafMergeResourceBundleMessageSource() {
+        setDefaultEncoding("UTF-8");
+    }
+    
     /**
      * The super implementation ensures the basenames defined at the beginning take precedence. We require the opposite in
      * order to be in line with previous assumptions about the applicationContext merge process (meaning, beans defined in
@@ -75,7 +81,7 @@ public class BroadleafMergeResourceBundleMessageSource extends ReloadableResourc
 
     @Override
     protected MessageFormat resolveCode(String code, Locale locale) {
-        ExtensionResultHolder<String> messageHolder = new ExtensionResultHolder<String>();
+        ExtensionResultHolder<String> messageHolder = new ExtensionResultHolder<>();
         extensionManager.getProxy().resolveMessageSource(code, locale, messageHolder);
         if (StringUtils.isNotBlank(messageHolder.getResult())) {
             return createMessageFormat(messageHolder.getResult(), locale);
@@ -86,7 +92,7 @@ public class BroadleafMergeResourceBundleMessageSource extends ReloadableResourc
 
     @Override
     protected String resolveCodeWithoutArguments(String code, Locale locale) {
-        ExtensionResultHolder<String> messageHolder = new ExtensionResultHolder<String>();
+        ExtensionResultHolder<String> messageHolder = new ExtensionResultHolder<>();
         extensionManager.getProxy().resolveMessageSource(code, locale, messageHolder);
         if (StringUtils.isNotBlank(messageHolder.getResult())) {
             return messageHolder.getResult();


### PR DESCRIPTION
This fixes issues in our message bundles with translations that was referenced in BroadleafCommerce/DemoSite#10 and also refines #1639 and #1640 by allowing translations to use their actual accented characters and not html-entities equivalencies.