### PR TITLE
Add method to the framework to query products that use a specific product option

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
@@ -62,10 +62,10 @@ public interface ProductOptionDao {
     Long countAllowedValuesForProductOptionById(Long productOptionId);
 
     /**
-     * Returns a list of Products that are using the passed in ProductOption ID
+     * Returns a list of Product Ids that are using the passed in ProductOption ID
      *
      * @param productOptionId
      * @return
      */
-    public List<Product> findProductsUsingProductOptionById(Long productOptionId);
+    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
@@ -60,4 +60,12 @@ public interface ProductOptionDao {
     public List<AssignedProductOptionDTO> findAssignedProductOptionsByProduct(Product product);
 
     Long countAllowedValuesForProductOptionById(Long productOptionId);
+
+    /**
+     * Returns a list of Products that are using the passed in ProductOption ID
+     *
+     * @param productOptionId
+     * @return
+     */
+    public List<Product> findProductsUsingProductOptionById(Long productOptionId);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDao.java
@@ -61,11 +61,15 @@ public interface ProductOptionDao {
 
     Long countAllowedValuesForProductOptionById(Long productOptionId);
 
+    public Long countProductsUsingProductOptionById(Long productOptionId);
+
     /**
-     * Returns a list of Product Ids that are using the passed in ProductOption ID
+     * Returns a paginated list of Product Ids that are using the passed in ProductOption ID
      *
      * @param productOptionId
+     * @param start
+     * @param pageSize
      * @return
      */
-    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId);
+    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId, int start, int pageSize);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
@@ -21,7 +21,6 @@ package org.broadleafcommerce.core.catalog.dao;
 
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
-import org.broadleafcommerce.common.util.DialectHelper;
 import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.core.catalog.domain.ProductOption;
 import org.broadleafcommerce.core.catalog.domain.ProductOptionImpl;
@@ -64,9 +63,6 @@ public class ProductOptionDaoImpl implements ProductOptionDao {
 
     @Resource(name="blSandBoxHelper")
     protected SandBoxHelper sandBoxHelper;
-
-    @Resource(name = "blDialectHelper")
-    protected DialectHelper dialectHelper;
     
     @Override
     public List<ProductOption> readAllProductOptions() {
@@ -171,10 +167,8 @@ public class ProductOptionDaoImpl implements ProductOptionDao {
             // Product IDs are what we want back
             criteria.select(product.get("id").as(Long.class));
         }
+        criteria.distinct(true);
 
-        if (!dialectHelper.isOracle() && !dialectHelper.isSqlServer()) {
-            criteria.distinct(true);
-        }
         List<Predicate> restrictions = new ArrayList<Predicate>();
         restrictions.add(productOption.get("id").in(sandBoxHelper.mergeCloneIds(ProductOptionImpl.class, productOptionId)));
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
@@ -283,12 +283,16 @@ public interface CatalogService {
      */
     public List<AssignedProductOptionDTO> findAssignedProductOptionsByProduct(Product product);
 
+    public Long countProductsUsingProductOptionById(Long productOptionId);
+
     /**
-     * Returns a list of Product Ids that are using the passed in ProductOption ID
+     * Returns a paginated list of Product Ids that are using the passed in ProductOption ID
      *
      * @param productOptionId
+     * @param start
+     * @param pageSize
      * @return
      */
-    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId);
+    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId, int start, int pageSize);
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
@@ -283,4 +283,12 @@ public interface CatalogService {
      */
     public List<AssignedProductOptionDTO> findAssignedProductOptionsByProduct(Product product);
 
+    /**
+     * Returns a list of Products that are using the passed in ProductOption ID
+     *
+     * @param productOptionId
+     * @return
+     */
+    public List<Product> findProductsUsingProductOptionById(Long productOptionId);
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogService.java
@@ -284,11 +284,11 @@ public interface CatalogService {
     public List<AssignedProductOptionDTO> findAssignedProductOptionsByProduct(Product product);
 
     /**
-     * Returns a list of Products that are using the passed in ProductOption ID
+     * Returns a list of Product Ids that are using the passed in ProductOption ID
      *
      * @param productOptionId
      * @return
      */
-    public List<Product> findProductsUsingProductOptionById(Long productOptionId);
+    public List<Long> findProductIdsUsingProductOptionById(Long productOptionId);
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
@@ -424,4 +424,9 @@ public class CatalogServiceImpl implements CatalogService {
         return productOptionDao.findAssignedProductOptionsByProduct(product);
     }
 
+    @Override
+    public List<Product> findProductsUsingProductOptionById(Long productId) {
+        return productOptionDao.findProductsUsingProductOptionById(productId);
+    }
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
@@ -425,8 +425,8 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public List<Product> findProductsUsingProductOptionById(Long productId) {
-        return productOptionDao.findProductsUsingProductOptionById(productId);
+    public List<Long> findProductIdsUsingProductOptionById(Long productId) {
+        return productOptionDao.findProductIdsUsingProductOptionById(productId);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
@@ -425,8 +425,13 @@ public class CatalogServiceImpl implements CatalogService {
     }
 
     @Override
-    public List<Long> findProductIdsUsingProductOptionById(Long productId) {
-        return productOptionDao.findProductIdsUsingProductOptionById(productId);
+    public Long countProductsUsingProductOptionById(Long productOptionId) {
+        return productOptionDao.countProductsUsingProductOptionById(productOptionId);
+    }
+
+    @Override
+    public List<Long> findProductIdsUsingProductOptionById(Long productId, int start, int pageSize) {
+        return productOptionDao.findProductIdsUsingProductOptionById(productId, start, pageSize);
     }
 
 }


### PR DESCRIPTION
BroadleafCommerce/QA#2972 

- Add support to query products that use a specific product option with a start `position` and `pageSize`
- Added query to do a count of all the products using a product option