### PR TITLE
Fixed JS error that occurs in IE when clearing filters on Main Entity ListGrids because a variable was not converted to a JQuery object

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -634,7 +634,7 @@
             }
             var filterBuilder = BLCAdmin.filterBuilders.getFilterBuilderByHiddenId(hiddenId);
 
-            var $filterButton = $('.filter-button[data-hiddenid=' + hiddenId + ']')[0];
+            var $filterButton = $($('.filter-button[data-hiddenid=' + hiddenId + ']')[0]);
             var $tbody = $('.list-grid-table[data-hiddenid=' + hiddenId + ']:not([id$=-header])');
             var $filterFields = $tbody.closest('.listgrid-body-wrapper').prev().find('.filter-fields');
 


### PR DESCRIPTION
see BroadleafCommerce/QA#2975 for details.