### PR TITLE
Fill In Saved Customer Addresses

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/checkout/model/PaymentInfoForm.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/checkout/model/PaymentInfoForm.java
@@ -32,14 +32,14 @@ public class PaymentInfoForm implements Serializable {
     protected Address address = new AddressImpl();
     protected boolean shouldUseShippingAddress = false;
     protected Long customerPaymentId;
+    protected Long customerAddressId;
     protected boolean shouldSaveNewPayment = true;
     protected boolean shouldUseCustomerPayment = false;
     protected String emailAddress;
-
     protected String paymentName;
+
     protected boolean isDefault = false;
     protected String paymentToken;
-
     public PaymentInfoForm() {
         address.setPhonePrimary(new PhoneImpl());
         address.setPhoneSecondary(new PhoneImpl());
@@ -68,6 +68,14 @@ public class PaymentInfoForm implements Serializable {
 
     public void setCustomerPaymentId(Long customerPaymentId) {
         this.customerPaymentId = customerPaymentId;
+    }
+
+    public Long getCustomerAddressId() {
+        return customerAddressId;
+    }
+
+    public void setCustomerAddressId(Long customerAddressId) {
+        this.customerAddressId = customerAddressId;
     }
 
     public boolean getShouldSaveNewPayment() {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/checkout/model/ShippingInfoForm.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/checkout/model/ShippingInfoForm.java
@@ -40,11 +40,11 @@ public class ShippingInfoForm implements Serializable {
     protected String addressName;
     protected FulfillmentOption fulfillmentOption;
     protected Long fulfillmentOptionId;
+    protected Long customerAddressId;
     protected PersonalMessage personalMessage = new PersonalMessageImpl();
     protected String deliveryMessage;
     protected boolean useBillingAddress = false;
     protected boolean saveAsDefault = false;
-
     public ShippingInfoForm() {
         address.setPhonePrimary(new PhoneImpl());
         address.setPhoneSecondary(new PhoneImpl());
@@ -54,17 +54,25 @@ public class ShippingInfoForm implements Serializable {
     public Long getFulfillmentOptionId() {
         return fulfillmentOptionId;
     }
-    
+
     public void setFulfillmentOptionId(Long fulfillmentOptionId) {
         this.fulfillmentOptionId = fulfillmentOptionId;
     }
-    
+
     public FulfillmentOption getFulfillmentOption() {
         return fulfillmentOption;
     }
 
     public void setFulfillmentOption(FulfillmentOption fulfillmentOption) {
         this.fulfillmentOption = fulfillmentOption;
+    }
+
+    public Long getCustomerAddressId() {
+        return customerAddressId;
+    }
+
+    public void setCustomerAddressId(Long customerAddressId) {
+        this.customerAddressId = customerAddressId;
     }
 
     public Address getAddress() {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafManageCustomerPaymentsController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafManageCustomerPaymentsController.java
@@ -25,6 +25,7 @@ import org.broadleafcommerce.core.web.controller.account.validator.AccountPaymen
 import org.broadleafcommerce.core.web.payment.service.SavedPaymentService;
 import org.broadleafcommerce.core.web.service.InitBinderService;
 import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerAddress;
 import org.broadleafcommerce.profile.core.domain.CustomerPayment;
 import org.broadleafcommerce.profile.core.service.AddressService;
 import org.broadleafcommerce.profile.core.service.CustomerAddressService;
@@ -81,6 +82,15 @@ public class BroadleafManageCustomerPaymentsController extends BroadleafAbstract
     public String addCustomerPayment(HttpServletRequest request, Model model,
             PaymentInfoForm paymentInfoForm, BindingResult bindingResult) {
         Customer customer = CustomerState.getCustomer();
+
+        //Set address if a saved one was selected
+        if(!paymentInfoForm.getShouldUseShippingAddress() && paymentInfoForm.getCustomerAddressId() != null) {
+            CustomerAddress address = customerAddressService
+                    .readCustomerAddressById(paymentInfoForm.getCustomerAddressId());
+            if(address != null && address.getCustomer().equals(customer)) {
+                paymentInfoForm.setAddress(address.getAddress());
+            }
+        }
 
         addressService.populateAddressISOCountrySub(paymentInfoForm.getAddress());
         paymentInfoFormValidator.validate(paymentInfoForm, bindingResult);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafPaymentInfoController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafPaymentInfoController.java
@@ -30,6 +30,7 @@ import org.broadleafcommerce.core.web.order.CartState;
 import org.broadleafcommerce.core.web.payment.service.SavedPaymentService;
 import org.broadleafcommerce.profile.core.domain.Address;
 import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerAddress;
 import org.broadleafcommerce.profile.core.domain.CustomerPayment;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.ui.Model;
@@ -64,6 +65,15 @@ public class BroadleafPaymentInfoController extends AbstractCheckoutController {
                                  PaymentInfoForm paymentForm, BindingResult result) throws PricingException, ServiceException {
         Order cart = CartState.getCart();
         Customer customer = CustomerState.getCustomer();
+
+        //Set address if a saved one was selected
+        if(!paymentForm.getShouldUseShippingAddress() && paymentForm.getCustomerAddressId() != null) {
+            CustomerAddress address = customerAddressService
+                    .readCustomerAddressById(paymentForm.getCustomerAddressId());
+            if(address != null && address.getCustomer().equals(customer)) {
+                paymentForm.setAddress(address.getAddress());
+            }
+        }
 
         preProcessBillingAddress(paymentForm, cart);
         paymentInfoFormValidator.validate(paymentForm, result);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafShippingInfoController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafShippingInfoController.java
@@ -108,9 +108,16 @@ public class BroadleafShippingInfoController extends AbstractCheckoutController 
     public String saveSingleShip(HttpServletRequest request, HttpServletResponse response, Model model,
                                  ShippingInfoForm shippingForm, BindingResult result) throws PricingException, ServiceException {
         Order cart = CartState.getCart();
+        Customer customer = CustomerState.getCustomer();
 
         if (shippingForm.shouldUseBillingAddress()){
             copyBillingAddressToShippingAddress(cart, shippingForm);
+        } else if(shippingForm.getCustomerAddressId() != null) {
+            //Fill in saved address
+            CustomerAddress customerAddress = customerAddressService.readCustomerAddressById(shippingForm.getCustomerAddressId());
+            if(customerAddress != null && customerAddress.getCustomer().equals(customer)) {
+                shippingForm.setAddress(customerAddress.getAddress());
+            }
         }
 
         addressService.populateAddressISOCountrySub(shippingForm.getAddress());
@@ -132,7 +139,6 @@ public class BroadleafShippingInfoController extends AbstractCheckoutController 
             shippingForm.getAddress().setPhoneFax(null);
         }
 
-        Customer customer = CustomerState.getCustomer();
         if (!customer.isAnonymous() && shippingForm.isSaveAsDefault()) {
             Address address = addressService.saveAddress(shippingForm.getAddress());
             CustomerAddress customerAddress = customerAddressService.create();


### PR DESCRIPTION
This changes the approach for loading saved customer addresses. Previously, the addresses were loaded from the manage addresses page with a `GET` request. With dynamic regional forms, one Ajax request would be needed to load the form for the right country, and another to load the address information. Rather than use nested Ajax requests, I've added a `customerAddressId` to the related forms and use it to fill in the saved address on the server's side.