### PR TITLE
Fixed an issue where overriding a product's additional sku would cause the add to cart to fail (MT Only)

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
@@ -164,9 +164,12 @@ public class ProductOptionDaoImpl implements ProductOptionDao {
         predicates.add(cb.equal(root.get("productOptionValue").get("attributeValue"), attributeValue));
 
         // restrict to skus that have ids within the given list of skus ids
-        Predicate skuDomainPredicate = buildSkuDomainPredicate(cb, root.get("sku").get("id"), possibleSkuIds);
-        if (skuDomainPredicate != null) {
-            predicates.add(skuDomainPredicate);
+        if (possibleSkuIds != null && possibleSkuIds.size() > 0) {
+            possibleSkuIds = sandBoxHelper.mergeCloneIds(SkuImpl.class, possibleSkuIds.toArray(new Long[possibleSkuIds.size()]));
+            Predicate skuDomainPredicate = buildSkuDomainPredicate(cb, root.get("sku").get("id"), possibleSkuIds);
+            if (skuDomainPredicate != null) {
+                predicates.add(skuDomainPredicate);
+            }
         }
 
         // restrict archived values

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.core.catalog.dao;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
 import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
@@ -164,7 +165,7 @@ public class ProductOptionDaoImpl implements ProductOptionDao {
         predicates.add(cb.equal(root.get("productOptionValue").get("attributeValue"), attributeValue));
 
         // restrict to skus that have ids within the given list of skus ids
-        if (possibleSkuIds != null && possibleSkuIds.size() > 0) {
+        if (CollectionUtils.isNotEmpty(possibleSkuIds)) {
             possibleSkuIds = sandBoxHelper.mergeCloneIds(SkuImpl.class, possibleSkuIds.toArray(new Long[possibleSkuIds.size()]));
             Predicate skuDomainPredicate = buildSkuDomainPredicate(cb, root.get("sku").get("id"), possibleSkuIds);
             if (skuDomainPredicate != null) {


### PR DESCRIPTION
BroadleafCommerce/QA#2984 

- Use the original sku id when querying the DB for matching skus