### PR TITLE
Enabled entityManager.find() catalog validation when grabbing a page entity.

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
@@ -31,6 +31,7 @@ import org.broadleafcommerce.common.sandbox.domain.SandBox;
 import org.broadleafcommerce.common.sandbox.domain.SandBoxImpl;
 import org.broadleafcommerce.common.time.SystemTime;
 import org.broadleafcommerce.common.util.DateUtil;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 
@@ -76,7 +77,25 @@ public class PageDaoImpl implements PageDao {
 
     @Override
     public Page readPageById(Long id) {
-        return em.find(PageImpl.class, id);
+        Boolean internalValidateFindPreviouslySet = false;
+        BroadleafRequestContext broadleafRequestContext = BroadleafRequestContext.getBroadleafRequestContext();
+        Page page;
+
+        try {
+
+            if (broadleafRequestContext != null && !broadleafRequestContext.getInternalValidateFind()) {
+                broadleafRequestContext.setInternalValidateFind(true);
+                internalValidateFindPreviouslySet = true;
+            }
+
+            page = em.find(PageImpl.class, id);
+        } finally {
+
+            if (internalValidateFindPreviouslySet) {
+                broadleafRequestContext.setInternalValidateFind(false);
+            }
+        }
+        return page;
     }
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
@@ -31,7 +31,6 @@ import org.broadleafcommerce.common.sandbox.domain.SandBox;
 import org.broadleafcommerce.common.sandbox.domain.SandBoxImpl;
 import org.broadleafcommerce.common.time.SystemTime;
 import org.broadleafcommerce.common.util.DateUtil;
-import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 
@@ -77,25 +76,7 @@ public class PageDaoImpl implements PageDao {
 
     @Override
     public Page readPageById(Long id) {
-        Boolean internalValidateFindPreviouslySet = false;
-        BroadleafRequestContext broadleafRequestContext = BroadleafRequestContext.getBroadleafRequestContext();
-        Page page;
-
-        try {
-
-            if (broadleafRequestContext != null && !broadleafRequestContext.getInternalValidateFind()) {
-                broadleafRequestContext.setInternalValidateFind(true);
-                internalValidateFindPreviouslySet = true;
-            }
-
-            page = em.find(PageImpl.class, id);
-        } finally {
-
-            if (internalValidateFindPreviouslySet) {
-                broadleafRequestContext.setInternalValidateFind(false);
-            }
-        }
-        return page;
+        return em.find(PageImpl.class, id);
     }
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PageHandlerMapping.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PageHandlerMapping.java
@@ -82,7 +82,7 @@ public class PageHandlerMapping extends BLCAbstractHandlerMapping {
 
             } finally {
                 if (internalValidateFindPreviouslySet) {
-                    BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+                    BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(false);
                 }
             }
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PageHandlerMapping.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PageHandlerMapping.java
@@ -69,7 +69,22 @@ public class PageHandlerMapping extends BLCAbstractHandlerMapping {
         BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
         if (context != null && context.getRequestURIWithoutContext() != null) {
             String requestUri = URLDecoder.decode(context.getRequestURIWithoutContext(), charEncoding);
-            PageDTO page = pageService.findPageByURI(context.getLocale(), requestUri, buildMvelParameters(request), context.isSecure());
+            
+            Boolean internalValidateFindPreviouslySet = false;
+            PageDTO page;
+            
+            try {
+                if (!BroadleafRequestContext.getBroadleafRequestContext().getInternalValidateFind()) {
+                    BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+                    internalValidateFindPreviouslySet = true;
+                }
+                page = pageService.findPageByURI(context.getLocale(), requestUri, buildMvelParameters(request), context.isSecure());
+
+            } finally {
+                if (internalValidateFindPreviouslySet) {
+                    BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+                }
+            }
 
             if (page != null && ! (page instanceof NullPageDTO)) {
                 context.getRequest().setAttribute(PAGE_ATTRIBUTE_NAME, page);

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafPageController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafPageController.java
@@ -77,7 +77,23 @@ public class BroadleafPageController extends BroadleafAbstractController impleme
         
         // Allow extension managers to override the path.
         ExtensionResultHolder<String> erh = new ExtensionResultHolder<String>();
-        ExtensionResultStatusType extResult = templateOverrideManager.getProxy().getOverrideTemplate(erh, page);
+        Boolean internalValidateFindPreviouslySet = false;
+        ExtensionResultStatusType extResult;
+        
+        try {
+            if (!BroadleafRequestContext.getBroadleafRequestContext().getInternalValidateFind()) {
+                BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+                internalValidateFindPreviouslySet = true;
+            }
+
+            extResult = templateOverrideManager.getProxy().getOverrideTemplate(erh, page);
+        } finally {
+
+            if (internalValidateFindPreviouslySet) {
+                BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+            }
+        }
+    
         if (extResult != ExtensionResultStatusType.NOT_HANDLED) {
             templatePath = erh.getResult();
         }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafPageController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/controller/BroadleafPageController.java
@@ -90,7 +90,7 @@ public class BroadleafPageController extends BroadleafAbstractController impleme
         } finally {
 
             if (internalValidateFindPreviouslySet) {
-                BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(true);
+                BroadleafRequestContext.getBroadleafRequestContext().setInternalValidateFind(false);
             }
         }
     


### PR DESCRIPTION
Prevents page variables from unintentionally appearing across catalogs.

Addresses BroadleafCommerce/QA#3021.