### PR TITLE
When Custom Validator fails validation on Sku add, an NPE occurs when hasDefaultSku is called

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -475,7 +475,7 @@ public class SkuImpl implements Sku {
     }
 
     protected boolean hasDefaultSku() {
-        return (product != null && product.getDefaultSku() != null && !getId().equals(product.getDefaultSku().getId()));
+        return (product != null && product.getDefaultSku() != null && getId() != null && !getId().equals(product.getDefaultSku().getId()));
     }
 
     protected Sku lookupDefaultSku() {


### PR DESCRIPTION
Fixes https://github.com/BroadleafCommerce/QA/issues/3023