### PR TITLE
Make dynamic pricing more efficient during cart processing

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Sku.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Sku.java
@@ -141,7 +141,7 @@ public interface Sku extends Serializable, MultiTenantCloneable<Sku>, Indexable 
      *
      * @return
      */
-    Money getUnmodifiedRetailPrice();
+    Money getBaseRetailPrice();
 
     /**
      * Returns the basic sale price of the Sku. This price does not include any dynamic pricing, including PriceList
@@ -149,7 +149,7 @@ public interface Sku extends Serializable, MultiTenantCloneable<Sku>, Indexable 
      *
      * @return
      */
-    Money getUnmodifiedSalePrice();
+    Money getBaseSalePrice();
 
     /**
      * Sets the retail price for the Sku. This price will automatically be overridden if your system is utilizing

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Sku.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Sku.java
@@ -136,6 +136,22 @@ public interface Sku extends Serializable, MultiTenantCloneable<Sku>, Indexable 
     public Money getRetailPrice();
 
     /**
+     * Returns the basic retail price of the Sku. This price does not include any dynamic pricing, including PriceList
+     * modification.
+     *
+     * @return
+     */
+    Money getUnmodifiedRetailPrice();
+
+    /**
+     * Returns the basic sale price of the Sku. This price does not include any dynamic pricing, including PriceList
+     * modification.
+     *
+     * @return
+     */
+    Money getUnmodifiedSalePrice();
+
+    /**
      * Sets the retail price for the Sku. This price will automatically be overridden if your system is utilizing
      * the DynamicSkuPricingService.
      * 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
@@ -32,7 +32,6 @@ import org.broadleafcommerce.common.presentation.ValidationConfiguration;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.util.HibernateUtils;
-import org.broadleafcommerce.core.catalog.service.dynamic.DefaultDynamicSkuPricingInvocationHandler;
 import org.broadleafcommerce.core.catalog.service.dynamic.DynamicSkuPrices;
 import org.broadleafcommerce.core.catalog.service.dynamic.SkuPricingConsiderationContext;
 import org.hibernate.annotations.Cache;
@@ -40,9 +39,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.proxy.HibernateProxy;
-import org.springframework.util.ClassUtils;
 
-import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 
 import javax.persistence.CascadeType;
@@ -154,10 +151,12 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
             if (dynamicPrices != null) {
                 returnPrice = dynamicPrices.getSalePrice();
             } else {
-                DefaultDynamicSkuPricingInvocationHandler handler = new DefaultDynamicSkuPricingInvocationHandler(sku, salePrice);
-                Sku proxy = (Sku) Proxy.newProxyInstance(sku.getClass().getClassLoader(), ClassUtils.getAllInterfacesForClass(sku.getClass()), handler);
-                dynamicPrices = SkuPricingConsiderationContext.getSkuPricingService().getSkuPrices(proxy, SkuPricingConsiderationContext.getSkuPricingConsiderationContext());
-                returnPrice = dynamicPrices.getSalePrice();
+                dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(sku);
+                if (SkuPricingConsiderationContext.isPricingConsiderationActive()) {
+                    returnPrice = new Money(salePrice);
+                } else {
+                    returnPrice = dynamicPrices.getSalePrice();
+                }
             }
         } else {
             if (salePrice != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -289,9 +289,6 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @Embedded
     protected Weight weight = new Weight();
 
-    @Transient
-    protected DynamicSkuPrices dynamicPrices = null;
-
     @Column(name = "IS_MACHINE_SORTABLE")
     @AdminPresentation(friendlyName = "ProductImpl_Is_Product_Machine_Sortable",
         group = GroupName.ShippingOther, order = FieldOrder.IS_MACHINE_SORTABLE,
@@ -499,9 +496,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             // We have dynamic pricing, so we will pull the sale price from there
-            if (dynamicPrices == null) {
-                dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
-            }
+            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             returnPrice = dynamicPrices.getSalePrice();
             optionValueAdjustments = dynamicPrices.getPriceAdjustment();
             if (SkuPricingConsiderationContext.isPricingConsiderationActive()) {
@@ -553,9 +548,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             // We have dynamic pricing, so we will pull the retail price from there
-            if (dynamicPrices == null) {
-                dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
-            }
+            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             returnPrice = dynamicPrices.getRetailPrice();
             optionValueAdjustments = dynamicPrices.getPriceAdjustment();
             if (SkuPricingConsiderationContext.isPricingConsiderationActive()) {
@@ -607,9 +600,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @Override
     public DynamicSkuPrices getPriceData() {
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
-            if (dynamicPrices == null) {
-                dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
-            }
+            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             return dynamicPrices;
         } else {
             DynamicSkuPrices dsp = new DynamicSkuPrices();
@@ -1189,7 +1180,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Override
     public void clearDynamicPrices() {
-        this.dynamicPrices = null;
+        SkuPricingConsiderationContext.removeFromThreadCache(getId());
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -579,6 +579,32 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     }
 
     @Override
+    public Money getUnmodifiedRetailPrice() {
+        Money returnPrice = null;
+        if (retailPrice != null) {
+            returnPrice = new Money(retailPrice, getCurrency());
+        }
+        if (returnPrice == null && hasDefaultSku()) {
+            Sku defaultSku = lookupDefaultSku();
+            returnPrice = defaultSku.getUnmodifiedRetailPrice();
+        }
+        return returnPrice;
+    }
+
+    @Override
+    public Money getUnmodifiedSalePrice() {
+        Money returnPrice = null;
+        if (salePrice != null) {
+            returnPrice = new Money(salePrice, getCurrency());
+        }
+        if (returnPrice == null && hasDefaultSku()) {
+            Sku defaultSku = lookupDefaultSku();
+            returnPrice = defaultSku.getUnmodifiedSalePrice();
+        }
+        return returnPrice;
+    }
+
+    @Override
     public DynamicSkuPrices getPriceData() {
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             if (dynamicPrices == null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -579,27 +579,27 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     }
 
     @Override
-    public Money getUnmodifiedRetailPrice() {
+    public Money getBaseRetailPrice() {
         Money returnPrice = null;
         if (retailPrice != null) {
             returnPrice = new Money(retailPrice, getCurrency());
         }
         if (returnPrice == null && hasDefaultSku()) {
             Sku defaultSku = lookupDefaultSku();
-            returnPrice = defaultSku.getUnmodifiedRetailPrice();
+            returnPrice = defaultSku.getBaseRetailPrice();
         }
         return returnPrice;
     }
 
     @Override
-    public Money getUnmodifiedSalePrice() {
+    public Money getBaseSalePrice() {
         Money returnPrice = null;
         if (salePrice != null) {
             returnPrice = new Money(salePrice, getCurrency());
         }
         if (returnPrice == null && hasDefaultSku()) {
             Sku defaultSku = lookupDefaultSku();
-            returnPrice = defaultSku.getUnmodifiedSalePrice();
+            returnPrice = defaultSku.getBaseSalePrice();
         }
         return returnPrice;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/dynamic/SkuPricingConsiderationContext.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/dynamic/SkuPricingConsiderationContext.java
@@ -18,22 +18,29 @@
 package org.broadleafcommerce.core.catalog.service.dynamic;
 
 import org.broadleafcommerce.common.classloader.release.ThreadLocalManager;
+import org.broadleafcommerce.common.exception.ExceptionHelper;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.catalog.domain.SkuImpl;
+import org.broadleafcommerce.core.catalog.domain.pricing.SkuPriceWrapper;
+import org.springframework.util.ReflectionUtils;
 
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Convenient place to store the pricing considerations context and the pricing service on thread local. This class is
- * usually filled out by a {@link org.broadleafcommerce.core.web.catalog.DynamicSkuPricingFilter}. The default
- * implementation of this is {@link org.broadleafcommerce.core.web.catalog.DefaultDynamicSkuPricingFilter}.
+ * usually filled out by a DynamicSkuPricingFilter. The default implementation of this is DefaultDynamicSkuPricingFilter.
  * 
  * @author jfischer
  * @see {@link SkuImpl#getRetailPrice}
  * @see {@link SkuImpl#getSalePrice}
- * @see {@link org.broadleafcommerce.core.web.catalog.DynamicSkuPricingFilter}
  */
 public class SkuPricingConsiderationContext {
 
+    protected static final ConcurrentHashMap<String, Field> FIELD_CACHE = new ConcurrentHashMap<>();
     private static final ThreadLocal<SkuPricingConsiderationContext> skuPricingConsiderationContext = ThreadLocalManager.createThreadLocal(SkuPricingConsiderationContext.class);
 
     public static HashMap getSkuPricingConsiderationContext() {
@@ -51,6 +58,18 @@ public class SkuPricingConsiderationContext {
     public static void setSkuPricingService(DynamicSkuPricingService skuPricingService) {
         SkuPricingConsiderationContext.skuPricingConsiderationContext.get().pricingService = skuPricingService;
     }
+
+    public static void startPricingConsideration() {
+        SkuPricingConsiderationContext.skuPricingConsiderationContext.get().isActive = true;
+    }
+
+    public static void endPricingConsideration() {
+        SkuPricingConsiderationContext.skuPricingConsiderationContext.get().isActive = false;
+    }
+
+    public static boolean isPricingConsiderationActive() {
+        return SkuPricingConsiderationContext.skuPricingConsiderationContext.get().isActive;
+    }
     
     public static boolean hasDynamicPricing() {
         return (
@@ -60,6 +79,54 @@ public class SkuPricingConsiderationContext {
         );
     }
 
+    public static DynamicSkuPrices getDynamicSkuPrices(Sku sku) {
+        DynamicSkuPrices prices = null;
+        if (SkuPricingConsiderationContext.hasDynamicPricing()) {
+            // We have dynamic pricing, so we will pull the retail price from there
+            if (!SkuPricingConsiderationContext.isPricingConsiderationActive()) {
+                SkuPriceWrapper wrapper = new SkuPriceWrapper(sku);
+                SkuPricingConsiderationContext.startPricingConsideration();
+                try {
+                    prices = SkuPricingConsiderationContext.getSkuPricingService().getSkuPrices(wrapper, SkuPricingConsiderationContext.getSkuPricingConsiderationContext());
+                } finally {
+                    SkuPricingConsiderationContext.endPricingConsideration();
+                }
+            } else {
+                try {
+                    prices = new DynamicSkuPrices();
+                    Field retail = getSingleField(sku.getClass(), "retailPrice");
+                    Object retailVal = retail.get(sku);
+                    Money retailPrice = retailVal == null ? null : new Money((BigDecimal) retailVal);
+                    Field sale = getSingleField(sku.getClass(), "salePrice");
+                    Object saleVal = sale.get(sku);
+                    Money salePrice = saleVal == null ? null : new Money((BigDecimal) saleVal);
+                    prices.setRetailPrice(retailPrice);
+                    prices.setSalePrice(salePrice);
+                } catch (IllegalAccessException e) {
+                    throw ExceptionHelper.refineException(e);
+                }
+            }
+        }
+        return prices;
+    }
+
+    protected static synchronized Field getSingleField(Class<?> clazz, String fieldName) throws IllegalStateException {
+        String cacheKey = clazz.getName() + fieldName;
+        if (FIELD_CACHE.containsKey(cacheKey)) {
+            return FIELD_CACHE.get(cacheKey);
+        }
+
+        Field field = ReflectionUtils.findField(clazz, fieldName);
+        if (field != null) {
+            field.setAccessible(true);
+        }
+
+        FIELD_CACHE.put(cacheKey, field);
+
+        return field;
+    }
+
     protected DynamicSkuPricingService pricingService;
     protected HashMap considerations;
+    protected boolean isActive = false;
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -148,11 +148,13 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
     @Override
     public void setSku(Sku sku) {
         this.sku = sku;
-        if (sku.hasRetailPrice()) {
-            this.baseRetailPrice = sku.getRetailPrice().getAmount();
+        Money retail = sku.getUnmodifiedRetailPrice();
+        if (retail != null) {
+            this.baseRetailPrice = retail.getAmount();
         }
-        if (sku.hasSalePrice()) {
-            this.baseSalePrice = sku.getSalePrice().getAmount();
+        Money sale = sku.getUnmodifiedSalePrice();
+        if (sale != null) {
+            this.baseSalePrice = sale.getAmount();
         }
         this.itemTaxable = sku.isTaxable();
         setName(sku.getName());

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -148,11 +148,11 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
     @Override
     public void setSku(Sku sku) {
         this.sku = sku;
-        Money retail = sku.getUnmodifiedRetailPrice();
+        Money retail = sku.getBaseRetailPrice();
         if (retail != null) {
             this.baseRetailPrice = retail.getAmount();
         }
-        Money sale = sku.getUnmodifiedSalePrice();
+        Money sale = sku.getBaseSalePrice();
         if (sale != null) {
             this.baseSalePrice = sale.getAmount();
         }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
@@ -204,8 +204,9 @@ public class OrderItemServiceImpl implements OrderItemService {
         populateDiscreteOrderItem(item, itemRequest);
         
         item.setBundleOrderItem(itemRequest.getBundleOrderItem());
-        item.setBaseSalePrice(itemRequest.getSalePriceOverride()==null?itemRequest.getSku().getSalePrice():itemRequest.getSalePriceOverride());
-        item.setBaseRetailPrice(itemRequest.getSku().getRetailPrice());
+        if (itemRequest.getSalePriceOverride() != null) {
+            item.setBaseSalePrice(itemRequest.getSalePriceOverride());
+        }
         item.setDiscreteOrderItemFeePrices(itemRequest.getDiscreteOrderItemFeePrices());
 
         if (itemRequest.getSalePriceOverride() != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -67,6 +67,8 @@ import org.broadleafcommerce.core.workflow.ProcessContext;
 import org.broadleafcommerce.core.workflow.Processor;
 import org.broadleafcommerce.core.workflow.WorkflowException;
 import org.broadleafcommerce.profile.core.domain.Customer;
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
 import org.hibernate.exception.LockAcquisitionException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
@@ -84,6 +86,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 
 /**
@@ -151,7 +155,42 @@ public class OrderServiceImpl implements OrderService {
 
     @Value("${pricing.retry.wait.interval.for.lock.failure}")
     protected long pricingRetryWaitIntervalForLockFailure = 500L;
-    
+
+    /**
+     * Advanced setting. Should Hibernate auto flush before queries during an
+     * add-to-cart workflow. This should generally be able to be left false. This is a performance measure and
+     * add-to-cart operations will be more efficient when this is false.
+     */
+    @Value("${auto.flush.on.query.during.add.to.cart:false}")
+    protected boolean autoFlushAddToCart = false;
+
+    /**
+     * Advanced setting. Should Hibernate auto flush before queries during an
+     * update-cart workflow. This should generally be able to be left false. This is a performance measure and
+     * update-cart operations will be more efficient when this is false.
+     */
+    @Value("${auto.flush.on.query.during.update.cart:false}")
+    protected boolean autoFlushUpdateCart = false;
+
+    /**
+     * Advanced setting. Should Hibernate auto flush before queries during an
+     * remove-from-cart workflow. This should generally be able to be left false. This is a performance measure and
+     * remove-from-cart operations will be more efficient when this is false.
+     */
+    @Value("${auto.flush.on.query.during.remove.from.cart:false}")
+    protected boolean autoFlushRemoveFromCart = false;
+
+    /**
+     * Advanced setting. Should Hibernate auto flush before queries during an
+     * order save pricing flow. This should generally be able to be left false. This is a performance measure and
+     * save operations will be more efficient when this is false.
+     */
+    @Value("${auto.flush.on.query.during.cart.pricing.save:false}")
+    protected boolean autoFlushSaveCart = false;
+
+    @PersistenceContext(unitName="blPU")
+    protected EntityManager em;
+
     /* Fields */
     protected boolean moveNamedOrderItems = true;
     protected boolean deleteEmptyNamedOrders = true;
@@ -287,7 +326,15 @@ public class OrderServiceImpl implements OrderService {
             int retryCount = 0;
             boolean isValid = false;
             while (!isValid) {
+                Session session = em.unwrap(Session.class);
+                FlushMode current = session.getFlushMode();
                 try {
+                    if (!autoFlushSaveCart) {
+                        //Performance measure. Hibernate will sometimes perform an autoflush when performing query operations and this can
+                        //be expensive. It is possible to avoid the autoflush if there's no concern about queries in the flow returning
+                        //incorrect results because something has not been flushed to the database yet.
+                        session.setFlushMode(FlushMode.MANUAL);
+                    }
                     order = pricingService.executePricing(order);
                     isValid = true;
                 } catch (Exception ex) {
@@ -331,6 +378,10 @@ public class OrderServiceImpl implements OrderService {
                         } else {
                             throw new PricingException(ex);
                         }
+                    }
+                } finally {
+                    if (!autoFlushSaveCart) {
+                        session.setFlushMode(current);
                     }
                 }
             }
@@ -590,7 +641,23 @@ public class OrderServiceImpl implements OrderService {
             int currentAddition = 1;
 
             CartOperationRequest cartOpRequest = new CartOperationRequest(findOrderById(orderId), orderItemRequestDTO, currentAddition == numAdditionRequests);
-            ProcessContext<CartOperationRequest> context = (ProcessContext<CartOperationRequest>) addItemWorkflow.doActivities(cartOpRequest);
+
+            Session session = em.unwrap(Session.class);
+            FlushMode current = session.getFlushMode();
+            if (!autoFlushAddToCart) {
+                //Performance measure. Hibernate will sometimes perform an autoflush when performing query operations and this can
+                //be expensive. It is possible to avoid the autoflush if there's no concern about queries in the flow returning
+                //incorrect results because something has not been flushed to the database yet.
+                session.setFlushMode(FlushMode.MANUAL);
+            }
+            ProcessContext<CartOperationRequest> context;
+            try {
+                context = (ProcessContext<CartOperationRequest>) addItemWorkflow.doActivities(cartOpRequest);
+            } finally {
+                if (!autoFlushAddToCart) {
+                    session.setFlushMode(current);
+                }
+            }
 
             List<ActivityMessageDTO> orderMessages = new ArrayList<ActivityMessageDTO>();
             orderMessages.addAll(((ActivityMessages) context).getActivityMessages());
@@ -627,7 +694,22 @@ public class OrderServiceImpl implements OrderService {
 
                 if (childRequest.getQuantity() > 0) {
                     CartOperationRequest childCartOpRequest = new CartOperationRequest(context.getSeedData().getOrder(), childRequest, currentAddition == numAdditionRequests);
-                    ProcessContext<CartOperationRequest> childContext = (ProcessContext<CartOperationRequest>) addItemWorkflow.doActivities(childCartOpRequest);
+                    Session session = em.unwrap(Session.class);
+                    FlushMode current = session.getFlushMode();
+                    if (!autoFlushAddToCart) {
+                        //Performance measure. Hibernate will sometimes perform an autoflush when performing query operations and this can
+                        //be expensive. It is possible to avoid the autoflush if there's no concern about queries in the flow returning
+                        //incorrect results because something has not been flushed to the database yet.
+                        session.setFlushMode(FlushMode.MANUAL);
+                    }
+                    ProcessContext<CartOperationRequest> childContext;
+                    try {
+                        childContext = (ProcessContext<CartOperationRequest>) addItemWorkflow.doActivities(childCartOpRequest);
+                    } finally {
+                        if (!autoFlushAddToCart) {
+                            session.setFlushMode(current);
+                        }
+                    }
                     orderMessages.addAll(((ActivityMessages) childContext).getActivityMessages());
 
                     addChildItems(childRequest, numAdditionRequests, currentAddition, childContext, orderMessages);
@@ -653,7 +735,22 @@ public class OrderServiceImpl implements OrderService {
         
         try {
             CartOperationRequest cartOpRequest = new CartOperationRequest(findOrderById(orderId), orderItemRequestDTO, priceOrder);
-            ProcessContext<CartOperationRequest> context = (ProcessContext<CartOperationRequest>) updateItemWorkflow.doActivities(cartOpRequest);
+            Session session = em.unwrap(Session.class);
+            FlushMode current = session.getFlushMode();
+            if (!autoFlushUpdateCart) {
+                //Performance measure. Hibernate will sometimes perform an autoflush when performing query operations and this can
+                //be expensive. It is possible to avoid the autoflush if there's no concern about queries in the flow returning
+                //incorrect results because something has not been flushed to the database yet.
+                session.setFlushMode(FlushMode.MANUAL);
+            }
+            ProcessContext<CartOperationRequest> context;
+            try {
+                context = (ProcessContext<CartOperationRequest>) updateItemWorkflow.doActivities(cartOpRequest);
+            } finally {
+                if (!autoFlushUpdateCart) {
+                    session.setFlushMode(current);
+                }
+            }
             context.getSeedData().getOrder().getOrderMessages().addAll(((ActivityMessages) context).getActivityMessages());
             return context.getSeedData().getOrder();
         } catch (WorkflowException e) {
@@ -702,7 +799,22 @@ public class OrderServiceImpl implements OrderService {
         OrderItemRequestDTO orderItemRequestDTO = new OrderItemRequestDTO();
         orderItemRequestDTO.setOrderItemId(orderItemId);
         CartOperationRequest cartOpRequest = new CartOperationRequest(findOrderById(orderId), orderItemRequestDTO, priceOrder);
-        ProcessContext<CartOperationRequest> context = (ProcessContext<CartOperationRequest>) removeItemWorkflow.doActivities(cartOpRequest);
+        Session session = em.unwrap(Session.class);
+        FlushMode current = session.getFlushMode();
+        if (!autoFlushRemoveFromCart) {
+            //Performance measure. Hibernate will sometimes perform an autoflush when performing query operations and this can
+            //be expensive. It is possible to avoid the autoflush if there's no concern about queries in the flow returning
+            //incorrect results because something has not been flushed to the database yet.
+            session.setFlushMode(FlushMode.MANUAL);
+        }
+        ProcessContext<CartOperationRequest> context;
+        try {
+            context = (ProcessContext<CartOperationRequest>) removeItemWorkflow.doActivities(cartOpRequest);
+        } finally {
+            if (!autoFlushRemoveFromCart) {
+                session.setFlushMode(current);
+            }
+        }
         context.getSeedData().getOrder().getOrderMessages().addAll(((ActivityMessages) context).getActivityMessages());
         return context.getSeedData().getOrder();
     }


### PR DESCRIPTION
BroadleafCommerce/QA#2982

- Avoid sku proxy during dynamic pricing while still guaranteeing no recursion
- Don't engage dynamic pricing when adding an item to the cart. Rather, save full pricing for an actual cart pricing call.
- Control auto flush mode during cart workflow activities for better performance
- Make sure dynamic pricing is not called multiple times for the same sku during a request
