### PR TITLE
Enhanced FieldDefinition fields with `@AdminPresentation` so that they could be overridden, and added more field types to DynamicSupportedFieldTypes enumeration so that more basic fields are available in the admin.

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinition.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinition.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.cms.field.domain;
 
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumeration;
+import org.broadleafcommerce.common.presentation.client.DynamicSupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 
 import java.io.Serializable;
@@ -28,88 +29,90 @@ import java.io.Serializable;
  */
 public interface FieldDefinition extends Serializable, MultiTenantCloneable<FieldDefinition> {
 
-    public Long getId();
+    Long getId();
 
-    public void setId(Long id);
+    void setId(Long id);
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public SupportedFieldType getFieldType();
+    SupportedFieldType getFieldType();
 
     String getFieldTypeVal();
+    
+    DynamicSupportedFieldType getDynamicSupportedFieldType();
 
-    public void setFieldType(SupportedFieldType fieldType);
+    void setFieldType(SupportedFieldType fieldType);
 
     void setFieldType(String fieldType);
 
-    public String getSecurityLevel();
+    String getSecurityLevel();
 
-    public void setSecurityLevel(String securityLevel);
+    void setSecurityLevel(String securityLevel);
 
-    public Boolean getHiddenFlag();
+    Boolean getHiddenFlag();
 
-    public void setHiddenFlag(Boolean hiddenFlag);
+    void setHiddenFlag(Boolean hiddenFlag);
 
-    public String getValidationRegEx();
+    String getValidationRegEx();
 
-    public void setValidationRegEx(String validationRegEx);
+    void setValidationRegEx(String validationRegEx);
 
-    public Integer getMaxLength();
+    Integer getMaxLength();
 
-    public void setMaxLength(Integer maxLength);
+    void setMaxLength(Integer maxLength);
 
-    public String getColumnWidth();
+    String getColumnWidth();
 
-    public void setColumnWidth(String columnWidth);
+    void setColumnWidth(String columnWidth);
 
-    public Boolean getTextAreaFlag();
+    Boolean getTextAreaFlag();
 
-    public void setTextAreaFlag(Boolean textAreaFlag);
+    void setTextAreaFlag(Boolean textAreaFlag);
     
-    public Boolean getRequiredFlag();
+    Boolean getRequiredFlag();
 
-    public void setRequiredFlag(Boolean requiredFlag);
+    void setRequiredFlag(Boolean requiredFlag);
 
-    public DataDrivenEnumeration getDataDrivenEnumeration();
+    DataDrivenEnumeration getDataDrivenEnumeration();
     
-    public void setDataDrivenEnumeration(DataDrivenEnumeration dataDrivenEnumeration);
+    void setDataDrivenEnumeration(DataDrivenEnumeration dataDrivenEnumeration);
 
-    public Boolean getAllowMultiples();
+    Boolean getAllowMultiples();
 
-    public void setAllowMultiples(Boolean allowMultiples);
+    void setAllowMultiples(Boolean allowMultiples);
 
-    public String getFriendlyName();
+    String getFriendlyName();
 
-    public void setFriendlyName(String friendlyName);
+    void setFriendlyName(String friendlyName);
 
-    public String getValidationErrorMesageKey();
+    String getValidationErrorMesageKey();
 
-    public void setValidationErrorMesageKey(String validationErrorMesageKey);
+    void setValidationErrorMesageKey(String validationErrorMesageKey);
 
-    public FieldGroup getFieldGroup();
+    FieldGroup getFieldGroup();
 
-    public void setFieldGroup(FieldGroup fieldGroup);
+    void setFieldGroup(FieldGroup fieldGroup);
 
-    public int getFieldOrder();
+    int getFieldOrder();
 
-    public void setFieldOrder(int fieldOrder);
+    void setFieldOrder(int fieldOrder);
 
-    public String getTooltip();
+    String getTooltip();
 
-    public void setTooltip(String tooltip);
+    void setTooltip(String tooltip);
 
-    public String getHelpText();
+    String getHelpText();
 
-    public void setHelpText(String helpText);
+    void setHelpText(String helpText);
 
-    public String getHint();
+    String getHint();
 
-    public void setHint(String hint);
+    void setHint(String hint);
 
-    public String getAdditionalForeignKeyClass();
+    String getAdditionalForeignKeyClass();
 
-    public void setAdditionalForeignKeyClass(String className);
+    void setAdditionalForeignKeyClass(String className);
 
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -92,24 +92,31 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected String fieldType;
 
     @Column (name = "SECURITY_LEVEL")
+    @AdminPresentation(excluded = true)
     protected String securityLevel;
 
     @Column (name = "HIDDEN_FLAG")
+    @AdminPresentation(excluded = true)
     protected Boolean hiddenFlag = false;
 
     @Column (name = "VLDTN_REGEX")
+    @AdminPresentation(excluded = true)
     protected String validationRegEx;
 
     @Column (name = "VLDTN_ERROR_MSSG_KEY")
+    @AdminPresentation(excluded = true)
     protected String validationErrorMesageKey;
 
     @Column (name = "MAX_LENGTH")
+    @AdminPresentation(excluded = true)
     protected Integer maxLength;
 
     @Column (name = "COLUMN_WIDTH")
+    @AdminPresentation(excluded = true)
     protected String columnWidth;
 
     @Column (name = "TEXT_AREA_FLAG")
+    @AdminPresentation(excluded = true)
     protected Boolean textAreaFlag = false;
     
     @Column(name = "REQUIRED_FLAG")
@@ -121,6 +128,7 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected DataDrivenEnumeration dataDrivenEnumeration;
 
     @Column (name = "ALLOW_MULTIPLES")
+    @AdminPresentation(excluded = true)
     protected Boolean allowMultiples = false;
 
     @ManyToOne(targetEntity = FieldGroupImpl.class)
@@ -132,12 +140,15 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected Integer fieldOrder = 0;
 
     @Column (name = "TOOLTIP")
+    @AdminPresentation(excluded = true)
     protected String tooltip;
 
     @Column (name = "HELP_TEXT")
+    @AdminPresentation(excluded = true)
     protected String helpText;
 
     @Column (name = "HINT")
+    @AdminPresentation(excluded = true)
     protected String hint;
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -29,6 +29,7 @@ import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
+import org.broadleafcommerce.common.presentation.client.DynamicSupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -163,18 +164,25 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     public SupportedFieldType getFieldType() {
         if (fieldType == null) {
             return null;
-        }
-        
-        if (fieldType.startsWith(SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
+        } else if (fieldType.startsWith(SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
             return SupportedFieldType.ADDITIONAL_FOREIGN_KEY;
+        } else {
+            return SupportedFieldType.valueOf(fieldType);
         }
-        
-        return SupportedFieldType.valueOf(fieldType);
     }
 
     @Override
     public String getFieldTypeVal() {
         return fieldType;
+    }
+    
+    @Override
+    public DynamicSupportedFieldType getDynamicSupportedFieldType() {
+        if (fieldType == null) {
+            return null;
+        } else {
+            return DynamicSupportedFieldType.getInstance(fieldType);
+        }
     }
     
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
@@ -37,7 +37,7 @@ public class DynamicSupportedFieldType implements Serializable, BroadleafEnumera
 
     private static final long serialVersionUID = 1L;
 
-    private static final Map<String, DynamicSupportedFieldType> TYPES = new LinkedHashMap<String, DynamicSupportedFieldType>();
+    private static final Map<String, DynamicSupportedFieldType> TYPES = new LinkedHashMap<>();
 
     public static final DynamicSupportedFieldType STRING = new DynamicSupportedFieldType("STRING", "String");
     public static final DynamicSupportedFieldType HTML = new DynamicSupportedFieldType("HTML", "Rich Text");

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
@@ -47,6 +47,10 @@ public class DynamicSupportedFieldType implements Serializable, BroadleafEnumera
     public static final DynamicSupportedFieldType PRODUCT_LOOKUP = new DynamicSupportedFieldType("ADDITIONAL_FOREIGN_KEY|org.broadleafcommerce.core.catalog.domain.Product", "Product Lookup");
     public static final DynamicSupportedFieldType CATEGORY_LOOKUP = new DynamicSupportedFieldType("ADDITIONAL_FOREIGN_KEY|org.broadleafcommerce.core.catalog.domain.Category", "Category Lookup");
     public static final DynamicSupportedFieldType DATE = new DynamicSupportedFieldType("DATE", "Date");
+    public static final DynamicSupportedFieldType INTEGER = new DynamicSupportedFieldType("INTEGER", "Integer");
+    public static final DynamicSupportedFieldType DECIMAL = new DynamicSupportedFieldType("DECIMAL", "Decimal");
+    public static final DynamicSupportedFieldType BOOLEAN = new DynamicSupportedFieldType("BOOLEAN", "Boolean");
+    public static final DynamicSupportedFieldType DATA_DRIVEN_ENUMERATION = new DynamicSupportedFieldType("DATA_DRIVEN_ENUMERATION", "Data Driven Enumeration");
 
     public static DynamicSupportedFieldType getInstance(final String type) {
         return TYPES.get(type);

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/client/DynamicSupportedFieldType.java
@@ -50,7 +50,6 @@ public class DynamicSupportedFieldType implements Serializable, BroadleafEnumera
     public static final DynamicSupportedFieldType INTEGER = new DynamicSupportedFieldType("INTEGER", "Integer");
     public static final DynamicSupportedFieldType DECIMAL = new DynamicSupportedFieldType("DECIMAL", "Decimal");
     public static final DynamicSupportedFieldType BOOLEAN = new DynamicSupportedFieldType("BOOLEAN", "Boolean");
-    public static final DynamicSupportedFieldType DATA_DRIVEN_ENUMERATION = new DynamicSupportedFieldType("DATA_DRIVEN_ENUMERATION", "Data Driven Enumeration");
 
     public static DynamicSupportedFieldType getInstance(final String type) {
         return TYPES.get(type);


### PR DESCRIPTION
## Changes
- DynamicSupportedFieldTypes is used by PageType in the admin to determine what FieldDefinitions can be used by Pages to create PageFields. However, it was missing several commonly used SupportedFieldTypes that have now been added:
    - Boolean
    - Integer
    - Decimal
- Added `@AdminPresentation(excluded = true)` for all FieldDefinition fields that previously had no AdminPresentation so that they can be overridden with MetaDataOverrides.
- Made `FieldDefinition#fieldType` accessible as a `DynamicSupportedFieldType` so as to all access to friendlyType or other options.