### PR TITLE
Use the raw product option value to get skus when adding to cart instead of the translated value.

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionValueProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionValueProcessor.java
@@ -52,6 +52,7 @@ public class ProductOptionValueProcessor extends AbstractAttrProcessor  {
         dto.setOptionId(productOptionValue.getProductOption().getId());
         dto.setValueId(productOptionValue.getId());
         dto.setValueName(productOptionValue.getAttributeValue());
+        dto.setRawValue(productOptionValue.getRawAttributeValue());
         if (productOptionValue.getPriceAdjustment() != null) {
             dto.setPriceAdjustment(productOptionValue.getPriceAdjustment().getAmount());
         }
@@ -79,6 +80,7 @@ public class ProductOptionValueProcessor extends AbstractAttrProcessor  {
         private Long optionId;
         private Long valueId;
         private String valueName;
+        private String rawValue;
         private BigDecimal priceAdjustment;
         @SuppressWarnings("unused")
         public Long getOptionId() {
@@ -100,6 +102,13 @@ public class ProductOptionValueProcessor extends AbstractAttrProcessor  {
         }
         public void setValueName(String valueName) {
             this.valueName = valueName;
+        }
+        @SuppressWarnings("unused")
+        public String getRawValue() {
+            return rawValue;
+        }
+        public void setRawValue(String rawValue) {
+            this.rawValue = rawValue;
         }
         @SuppressWarnings("unused")
         public BigDecimal getPriceAdjustment() {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValue.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValue.java
@@ -48,10 +48,18 @@ public interface ProductOptionValue extends Serializable, MultiTenantCloneable<P
     public void setId(Long id);
 
     /**
-     * Gets the option value.  (e.g. "red")
-     * @param
+     * Gets the option value. (e.g. "red") This method uses dynamic translation for the current locale.
+     * @return
      */
     public String getAttributeValue();
+
+    /**
+     * Gets the option value. (e.g. "red") This method does not use dynamic translation for the current locale.
+     * Instead it returns the raw value.
+     * 
+     * @return
+     */
+    String getRawAttributeValue();
 
     /**
      * Sets the option value.  (e.g. "red")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -25,18 +25,26 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.core.catalog.service.dynamic.DynamicSkuPrices;
 import org.broadleafcommerce.core.catalog.service.dynamic.SkuPricingConsiderationContext;
-import org.broadleafcommerce.core.search.domain.SearchFacetAdminPresentation;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
 import java.math.BigDecimal;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -98,6 +106,11 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
     @Override
     public String getAttributeValue() {
         return DynamicTranslationProvider.getValue(this, "attributeValue", attributeValue);
+    }
+
+    @Override
+    public String getRawAttributeValue() {
+        return attributeValue;
     }
 
     @Override


### PR DESCRIPTION
Addresses BroadleafCommerce/QA#3056.