### PR TITLE
Product Add-Ons Don't Allow Separate Skus

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/call/ConfigurableOrderItemRequest.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/call/ConfigurableOrderItemRequest.java
@@ -38,6 +38,10 @@ public class ConfigurableOrderItemRequest extends AddToCartItem {
     protected Boolean hasConfigurationError;
     protected Boolean discountsAllowed;
 
+    protected boolean expandable;
+    protected boolean firstExpandable;
+    protected boolean lastExpandable;
+
     public Product getProduct() {
         return product;
     }
@@ -136,5 +140,29 @@ public class ConfigurableOrderItemRequest extends AddToCartItem {
 
     public void setDiscountsAllowed(Boolean discountsAllowed) {
         this.discountsAllowed = discountsAllowed;
+    }
+
+    public boolean isExpandable() {
+        return expandable;
+    }
+
+    public void setExpandable(boolean expandable) {
+        this.expandable = expandable;
+    }
+
+    public boolean isFirstExpandable() {
+        return firstExpandable;
+    }
+
+    public void setFirstExpandable(boolean firstExpandable) {
+        this.firstExpandable = firstExpandable;
+    }
+
+    public boolean isLastExpandable() {
+        return lastExpandable;
+    }
+
+    public void setLastExpandable(boolean lastExpandable) {
+        this.lastExpandable = lastExpandable;
     }
 }


### PR DESCRIPTION
BroadleafCommerce/QA#2803
add additional attributes to ConfigurableOrderItemRequest