### PR TITLE
Update Spring and Spring Boot to the latest 4.3.11 and 1.5.7

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -270,7 +270,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring.boot.test.version}</version>
+            <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,9 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>4.3.10.RELEASE</spring.version>
+        <spring.version>4.3.11.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
-        <spring.boot.version>1.5.6.RELEASE</spring.boot.version>
-        <spring.boot.test.version>1.5.6.RELEASE</spring.boot.test.version>
+        <spring.boot.version>1.5.7.RELEASE</spring.boot.version>
         <spring.mobile.version>1.1.5.RELEASE</spring.mobile.version>
         <jackson.version>2.8.9</jackson.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>


### PR DESCRIPTION
This also removes an extraneous boot version property.