### PR TITLE
Add setters in ExampleBean of MergeBeanDefinitionTest

### DIFF
--- a/common/src/test/java/org/broadleafcommerce/test/common/context/merge/reader/MergeBeanDefinitionTest.java
+++ b/common/src/test/java/org/broadleafcommerce/test/common/context/merge/reader/MergeBeanDefinitionTest.java
@@ -61,6 +61,18 @@ public class MergeBeanDefinitionTest {
         public String field1;
         public String field2;
         public String field3;
+		
+        public void setField1(String field1) {
+			this.field1 = field1;
+		}
+		public void setField2(String field2) {
+			this.field2 = field2;
+		}
+		public void setField3(String field3) {
+			this.field3 = field3;
+		}
+        
+        
     }
     
     public static class AnonymousBean { }


### PR DESCRIPTION
The Broadleaf-common project does not compile because of a missing setter in ExampleBean nested class in MergeBeanDefinitionTest