### PR TITLE
Page field translations via admin ui persist with wrong entity type

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminPageController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminPageController.java
@@ -45,7 +45,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Handles admin operations for the {@link Page} entity. This entity has fields that are 
  * dependent on the value of the {@link Page#getPageTemplate()} field, and as such,
- * it deviates from the typical {@link AdminAbstractEntityController}.
+ * it deviates from the typical {@link AdminBasicEntityController}.
  * 
  * @author Andre Azzolini (apazzolini)
  */
@@ -92,6 +92,10 @@ public class AdminPageController extends AdminBasicEntityController {
             dynamicForm = getDynamicFieldTemplateForm(info, id, null);
         } else {
             dynamicForm = getEntityForm(info, null);
+        }
+        if (dynamicForm.getCeilingEntityClassname().equals(PageTemplate.class.getName())) {
+            dynamicForm.setTranslationCeilingEntity(Page.class.getName());
+            dynamicForm.setTranslationId(id);
         }
         ef.putDynamicFormInfo("pageTemplate", info);
         ef.putDynamicForm("pageTemplate", dynamicForm);


### PR DESCRIPTION
BroadleafCommerce#1581
move logic from advanced cms to core. DynamicForm translation entity should be page, not pageTemplate