### PR TITLE
When calculating target quantity for tiered offers, we need to also factor in the number of qualifying item iterations.

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableCandidateItemOffer.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableCandidateItemOffer.java
@@ -58,6 +58,16 @@ public interface PromotableCandidateItemOffer extends Serializable {
     /**
      * Returns the number of item quantities that qualified as targets for 
      * this promotion.
+     * 
+     * Uses {@link PromotableCandidateItemOffer#isUseQtyOnlyTierCalculation()} to determine how to calculate.
+     * If set to true, this method will use only the quantity in cart for determining which tier level to apply for 
+     * a group of qualifying items. This is old and likely undesired behavior, and is disabled by default. To turn
+     * it back on, use `use.quantity.only.tier.calculation=true` in your `common-shared.properties`.
+     *
+     * Otherwise, the default behavior is to factor in the number of iterations that the qualifying items have been
+     * applied.
+     *
+     * @return
      */
     public int calculateTargetQuantityForTieredOffer();
 
@@ -113,4 +123,33 @@ public interface PromotableCandidateItemOffer extends Serializable {
      */
     public int getMinimumRequiredTargetQuantity();
 
+    /**
+     * Returns whether to use quantity only tier calculation.
+     * If set to true, {@link PromotableCandidateItemOffer#calculateTargetQuantityForTieredOffer()} will use only the 
+     * quantity in cart for determining which tier level to apply for a group of qualifying items. This mode 
+     * is disabled by default. To turn it back on, use
+     * `use.quantity.only.tier.calculation=true` in your `common-shared.properties`.
+     * 
+     * Otherwise, the default behavior is to factor in the number of iterations that the qualifying items have been
+     * applied.
+     * 
+     * @return
+     * @see {@link PromotableCandidateItemOffer#calculateTargetQuantityForTieredOffer()}
+     */
+    boolean isUseQtyOnlyTierCalculation();
+
+    /**
+     * Sets whether to use quantity only tier calculation.
+     * If set to true, {@link PromotableCandidateItemOffer#calculateTargetQuantityForTieredOffer()} will use only the 
+     * quantity in cart for determining which tier level to apply for a group of qualifying items. This mode 
+     * is disabled by default. To turn it back on, use
+     * `use.quantity.only.tier.calculation=true` in your `common-shared.properties`.
+     *
+     * Otherwise, the default behavior is to factor in the number of iterations that the qualifying items have been
+     * applied.
+     *
+     * @param useQtyOnlyTierCalculation 
+     * @see {@link PromotableCandidateItemOffer#calculateTargetQuantityForTieredOffer()}
+     */
+    void setUseQtyOnlyTierCalculation(boolean useQtyOnlyTierCalculation);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
@@ -17,21 +17,19 @@
  */
 package org.broadleafcommerce.core.offer.service.discount.domain;
 
-import org.broadleafcommerce.common.config.service.SystemPropertiesService;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
 import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.domain.OrderItem;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import javax.annotation.Resource;
 
 @Service("blPromotableItemFactory")
 public class PromotableItemFactoryImpl implements PromotableItemFactory {
 
-    @Resource
-    private SystemPropertiesService systemPropertiesService;
+    @Value("${use.quantity.only.tier.calculation:false}")
+    protected boolean useQtyOnlyTierCalculation = false;
 
     public PromotableOrder createPromotableOrder(Order order, boolean includeOrderAndItemAdjustments) {
         return new PromotableOrderImpl(order, this, includeOrderAndItemAdjustments);
@@ -75,8 +73,6 @@ public class PromotableItemFactoryImpl implements PromotableItemFactory {
 
     @Override
     public PromotableCandidateItemOffer createPromotableCandidateItemOffer(PromotableOrder promotableOrder, Offer offer) {
-        boolean useQtyOnlyTierCalculation = 
-                systemPropertiesService.resolveBooleanSystemProperty("use.quantity.only.tier.calculation", false);
         return new PromotableCandidateItemOfferImpl(promotableOrder, offer, useQtyOnlyTierCalculation);
     }
     

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.discount.domain;
 
+import org.broadleafcommerce.common.config.service.SystemPropertiesService;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
@@ -24,8 +25,13 @@ import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.domain.OrderItem;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Resource;
+
 @Service("blPromotableItemFactory")
 public class PromotableItemFactoryImpl implements PromotableItemFactory {
+
+    @Resource
+    private SystemPropertiesService systemPropertiesService;
 
     public PromotableOrder createPromotableOrder(Order order, boolean includeOrderAndItemAdjustments) {
         return new PromotableOrderImpl(order, this, includeOrderAndItemAdjustments);
@@ -69,7 +75,9 @@ public class PromotableItemFactoryImpl implements PromotableItemFactory {
 
     @Override
     public PromotableCandidateItemOffer createPromotableCandidateItemOffer(PromotableOrder promotableOrder, Offer offer) {
-        return new PromotableCandidateItemOfferImpl(promotableOrder, offer);
+        boolean useQtyOnlyTierCalculation = 
+                systemPropertiesService.resolveBooleanSystemProperty("use.quantity.only.tier.calculation", false);
+        return new PromotableCandidateItemOfferImpl(promotableOrder, offer, useQtyOnlyTierCalculation);
     }
     
     @Override


### PR DESCRIPTION
Addresses BroadleafCommerce/QA#3077.