### PR TITLE
Fixed a warning being issued by an unrequired constructor for NotificationDispatcher

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/notification/service/NotificationDispatcherImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/notification/service/NotificationDispatcherImpl.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.notification.service.type.Notification;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
 
@@ -37,7 +36,6 @@ public class NotificationDispatcherImpl implements NotificationDispatcher {
 
     protected final List<NotificationService> notificationServices;
 
-    @Autowired(required = false)
     public NotificationDispatcherImpl(List<NotificationService> notificationServices) {
         this.notificationServices = notificationServices;
     }


### PR DESCRIPTION
Minor thing, doesn't need required=false and the warning is annoying.