### PR TITLE
Qa 3076 redactor widget styling

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/redactor.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/redactor.js
@@ -5930,6 +5930,12 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+						
+						// Fix for Chrome58 Issues
+			                        if (this.utils.browser('chrome')) {
+                        			    this.caret.set(node1, 0, node2, 0);
+			                         }
+			                         // End Chrome58 Issues 
 					}
 
 					this.savedSel = this.$editor.html();

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/redactor/fontfamily.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/redactor/fontfamily.js
@@ -62,7 +62,7 @@ if (!RedactorPlugins) var RedactorPlugins = {};
         	},
         	set: function (value)
         	{
-        		this.inline.format('span', 'syle', 'font-family:' + value + ';');
+        		this.inline.format('span', 'style', 'font-family:' + value + ';');
         	},
         	reset: function()
         	{

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
@@ -6912,6 +6912,12 @@
                     {
                         var node2 = this.selection.getMarker(2);
                         this.selection.setMarker(this.range, node2, false);
+                        
+                        // Fix for Chrome58 Issues
+                        if (this.utils.browser('chrome')) {
+                            this.caret.set(node1, 0, node2, 0);
+                         }
+                         // End Chrome58 Issues        
                     }
 
                     this.savedSel = this.$editor.html();


### PR DESCRIPTION
This branch adds a patch to both duplicates of redactor.js that fixes a chrome specific bug. This branch also fixes a typo in fontfamily.js that prevented font face from being applied to redactor widget text. The redactor widget should be fully functional with these changes.