### PR TITLE
Fixed issue where debugQuery=true was passed to Solr on every single query

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -222,9 +222,9 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         
         modifySolrQuery(solrQuery, searchCriteria.getQuery(), facets, searchCriteria, defaultSort);
 
-        solrQuery.setShowDebugInfo(true);
-
         if (LOG.isTraceEnabled()) {
+            solrQuery.setShowDebugInfo(true);
+
             try {
                 LOG.trace(URLDecoder.decode(solrQuery.toString(), "UTF-8"));
             } catch (Exception e) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -30,6 +30,7 @@ import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.locale.domain.Locale;
+import org.broadleafcommerce.common.util.BLCSystemProperty;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.catalog.dao.ProductDao;
 import org.broadleafcommerce.core.catalog.dao.SkuDao;
@@ -112,6 +113,13 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
 
     @Value("${solr.global.facets.category.search:false}")
     protected boolean globalFacetsForCategorySearch;
+
+    /**
+     * @return whether or not to enable debug query info for the SolrQuery
+     */
+    protected boolean shouldShowDebugQuery() {
+        return BLCSystemProperty.resolveBooleanSystemProperty("solr.showDebugQuery", false);
+    }
 
     @Override
     public void rebuildIndex() throws ServiceException, IOException {
@@ -222,9 +230,9 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         
         modifySolrQuery(solrQuery, searchCriteria.getQuery(), facets, searchCriteria, defaultSort);
 
-        if (LOG.isTraceEnabled()) {
-            solrQuery.setShowDebugInfo(true);
+        solrQuery.setShowDebugInfo(shouldShowDebugQuery());
 
+        if (LOG.isTraceEnabled()) {
             try {
                 LOG.trace(URLDecoder.decode(solrQuery.toString(), "UTF-8"));
             } catch (Exception e) {


### PR DESCRIPTION
BroadleafCommerce/QA#3088

This issue was easily fixed by moving `solrQuery.setShowDebugInfo(true)` into the trace logging if statement.