### PR TITLE
ListGrid bugfix involving listgrid template and ListGrid.hideIdColumn

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
@@ -405,7 +405,7 @@ public class ListGrid {
     }
     
     public Boolean getHideIdColumn() {
-        return hideIdColumn == null ? false : hideIdColumn;
+        return hideIdColumn == null ? true : hideIdColumn;
     }
 
     /* ************************** */

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -64,7 +64,7 @@
                         </div>
                     </th>
 
-                    <th width="75" th:unless="${listGrid.hideIdColumn or !#props.forceShowIdColumns}">
+                    <th width="75" th:unless="${listGrid.hideIdColumn and !#props.forceShowIdColumns}">
                         <div class="listgrid-headerBtn split dropdown" th:unless="${listGrid.canFilterAndSort}">
                             <div class="listgrid-title">
                                 <span>Id</span>
@@ -245,7 +245,7 @@
                         </div>
                     </td>
 
-                    <td th:unless="${listGrid.hideIdColumn or !#props.forceShowIdColumns}" data-fieldname="id" th:text="${record.id}" th:attr="data-fieldvalue=${record.id}"></td>
+                    <td th:unless="${listGrid.hideIdColumn and !#props.forceShowIdColumns}" data-fieldname="id" th:text="${record.id}" th:attr="data-fieldvalue=${record.id}"></td>
                 </tr>
 
             </tbody>


### PR DESCRIPTION
Background:
I wanted to show the entity id as a column on a list grid. A created an admin controller to override the #showEntityList method. In that controller method I retrieved the listGrid from the model and called `setHideIdColumn(false)`.

This did not cause the Id column to appear.

Diagnosis:
Upon debugging, I discovered that in the listgrid template, the display of the id column is gated by this expression:  `th:unless="${listGrid.hideIdColumn or !#props.forceShowIdColumns}"`.
Clever logicians will realize that if `props.forceShowIdColumns` is false (we are not globally forcing the id column to show on every listgrid), then the `OR` expression will evaluate to true, which will trigger the `UNLESS` to skip this tag, regardless of the value of `listGrid.hideIdColumn`. I changed `or` to `and` in the expression and I was able to display the id column on the listgrid.
Plot Twist! Now all list grids in the admin were showing the id column! Even further inspection revealed that listGrid.getHideIdColumn had this logic: `return hideIdColumn == null ? false : hideIdColumn`. This means that if hideIdColumn is not explicitly set, then it will default to false. As it turns out, we practically never set hideIdColumn.

Conclusion:
All the list grids in the admin effectively have hideIdColumn == false, but a logic error in listgrid.html prevents any id columns from being shown.
Currently, the property `listGrid.forceShowIdColumns` is actually being interpreted more as like "allow un-hiding" the id property.

Remedy:
Ultimately, there are 2 changes to be made.
    1) Fix the template logic
    2) Fix the default value for ListGrid.hideIdColumn
    
The easist way is to change the `or` to an `and` in the template logic in `listgrid.html` and change `false` to `true` in `ListGrid.getHideIdeColumn()`