### PR TITLE
Image corruption can occur when multiple treatments for the same image are requested concurrently

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetStorageServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetStorageServiceImpl.java
@@ -35,6 +35,7 @@ import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.file.domain.FileWorkArea;
 import org.broadleafcommerce.common.file.service.BroadleafFileService;
 import org.broadleafcommerce.common.file.service.GloballySharedInputStream;
+import org.broadleafcommerce.common.io.ConcurrentFileOutputStream;
 import org.broadleafcommerce.common.util.StreamCapableTransactionalOperationAdapter;
 import org.broadleafcommerce.common.util.StreamingTransactionCapableUtil;
 import org.broadleafcommerce.openadmin.server.service.artifact.ArtifactService;
@@ -99,6 +100,9 @@ public class StaticAssetStorageServiceImpl implements StaticAssetStorageService 
     @Resource(name="blStreamingTransactionCapableUtil")
     protected StreamingTransactionCapableUtil transUtil;
 
+    @Resource(name = "blConcurrentFileOutputStream")
+    protected ConcurrentFileOutputStream concurrentFileOutputStream;
+
     protected StaticAsset findStaticAsset(String fullUrl) {
         StaticAsset staticAsset = staticAssetService.findStaticAssetByFullUrl(fullUrl);
 
@@ -153,8 +157,6 @@ public class StaticAssetStorageServiceImpl implements StaticAssetStorageService 
     }
     
     protected void createLocalFileFromInputStream(InputStream is, File baseLocalFile) throws IOException {
-        FileOutputStream tos = null;
-        FileWorkArea workArea = null;
         try {
             if (!baseLocalFile.getParentFile().exists()) {
                 boolean directoriesCreated = false;
@@ -170,37 +172,11 @@ public class StaticAssetStorageServiceImpl implements StaticAssetStorageService 
                     }
                 }
             }
-            
-            workArea = broadleafFileService.initializeWorkArea();
-            File tmpFile = new File(FilenameUtils.concat(workArea.getFilePathLocation(), baseLocalFile.getName()));
-            
-            tos = new FileOutputStream(tmpFile);
 
-            IOUtils.copy(is, tos);
-            
-            // close the input/output streams before trying to move files around
-            is.close();
-            tos.close();
+            concurrentFileOutputStream.write(is, baseLocalFile);
 
-            // Adding protection against this file already existing / being written by another thread.
-            // Adding locks would be useless here since another VM could be executing the code. 
-            if (!baseLocalFile.exists()) {
-                try {
-                    FileUtils.moveFile(tmpFile, baseLocalFile);
-                } catch (FileExistsException e) {
-                    // No problem
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("File exists error moving file " + tmpFile.getAbsolutePath(), e);
-                    }
-                }
-            }
         } finally {
             IOUtils.closeQuietly(is);
-            IOUtils.closeQuietly(tos);
-            
-            if (workArea != null) {
-                broadleafFileService.closeWorkArea(workArea);
-            }
         }
     }    
 

--- a/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStream.java
+++ b/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStream.java
@@ -1,0 +1,27 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface ConcurrentFileOutputStream {
+    int write(InputStream src, File dest)  throws IOException;
+    int write(InputStream src, File dest, int bufferSize)  throws IOException;
+}

--- a/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStreamImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStreamImpl.java
@@ -81,11 +81,11 @@ public class ConcurrentFileOutputStreamImpl implements ConcurrentFileOutputStrea
     }
 
     protected void replaceExisting(File src, File dest) throws IOException {
-        if (src.exists()) {
-            try {
-                Files.move(src.toPath(), dest.toPath(), ATOMIC_MOVE, REPLACE_EXISTING);
-            } catch (AtomicMoveNotSupportedException e) {
-                synchronized (getFileMoveLock(dest.getAbsoluteFile())) {
+        synchronized (getFileMoveLock(dest)) {
+            if (src.exists()) {
+                try {
+                    Files.move(src.toPath(), dest.toPath(), ATOMIC_MOVE, REPLACE_EXISTING);
+                } catch (AtomicMoveNotSupportedException e) {
                     Files.move(src.toPath(), dest.toPath(), REPLACE_EXISTING);
                 }
             }

--- a/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStreamImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/io/ConcurrentFileOutputStreamImpl.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.io;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+import static java.nio.file.StandardCopyOption.*;
+
+@Component("blConcurrentFileOutputStream")
+public class ConcurrentFileOutputStreamImpl implements ConcurrentFileOutputStream {
+    private static final Map<String, Object> FILE_MOVE_LOCKS = new WeakHashMap<>();
+
+    @Value("${asset.server.file.buffer.size:8192}")
+    protected int defaultFileBufferSize;
+
+    @Override
+    public int write(InputStream src, File dest) throws IOException {
+        return write(src, dest, defaultFileBufferSize);
+    }
+
+    public int write(InputStream src, File dest, int bufferSize) throws IOException {
+        File tempFile = createTempFile(dest);
+        int totalWrote = writeToTempFile(src, tempFile, bufferSize);
+        replaceExisting(tempFile, dest);
+        return totalWrote;
+    }
+
+    protected File createTempFile(File dest) throws IOException {
+        File tempFile = new File(dest.getAbsolutePath() + getTempFileSuffix());
+        if (!tempFile.exists()) {
+            tempFile.createNewFile();
+        }
+        return tempFile;
+    }
+
+    protected String getTempFileSuffix() {
+        return ".temp-" + UUID.randomUUID();
+    }
+
+    protected int writeToTempFile(InputStream src, File tempFile, int bufferSize) throws IOException {
+        FileOutputStream fos = new FileOutputStream(tempFile);
+
+        int totalWrote = 0;
+
+        int readBytes;
+        byte[] bytes = new byte[bufferSize];
+        while ((readBytes = src.read(bytes)) != -1) {
+            fos.write(bytes, 0, readBytes);
+            totalWrote += readBytes;
+        }
+
+        fos.close();
+
+        return totalWrote;
+    }
+
+    protected void replaceExisting(File src, File dest) throws IOException {
+        if (src.exists()) {
+            try {
+                Files.move(src.toPath(), dest.toPath(), ATOMIC_MOVE, REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                synchronized (getFileMoveLock(dest.getAbsoluteFile())) {
+                    Files.move(src.toPath(), dest.toPath(), REPLACE_EXISTING);
+                }
+            }
+        }
+    }
+
+    protected Object getFileMoveLock(File file) {
+        String filePath = file.getAbsolutePath();
+        synchronized (FILE_MOVE_LOCKS) {
+            if (!FILE_MOVE_LOCKS.containsKey(filePath)) {
+                FILE_MOVE_LOCKS.put(filePath, new Object());
+            }
+            return FILE_MOVE_LOCKS.get(filePath);
+        }
+    }
+}


### PR DESCRIPTION
BroadleafCommerce/QA#3094
concurrent read/write to file component