### PR TITLE
Update Spring, Spring Boot and Jackson dependencies to the latest patch releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>4.3.12.RELEASE</spring.version>
+        <spring.version>4.3.13.RELEASE</spring.version>
         <spring.security.version>4.2.3.RELEASE</spring.security.version>
-        <spring.boot.version>1.5.8.RELEASE</spring.boot.version>
+        <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
         <spring.mobile.version>1.1.5.RELEASE</spring.mobile.version>
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.8.10</jackson.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>
         <geb.version>1.0</geb.version>
         <spock.core.version>1.1-groovy-2.4</spock.core.version>


### PR DESCRIPTION
This updates them to 4.3.13 1.5.9 and 2.8.10, respectively.