### PR TITLE
Introduce logging to warn against incorrect page/item management  for StreamCapableTransactionalOperations

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/StreamingTransactionCapableUtil.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/StreamingTransactionCapableUtil.java
@@ -85,11 +85,32 @@ public class StreamingTransactionCapableUtil implements StreamingTransactionCapa
             public void execute() throws Throwable {
                 pagedItems = streamOperation.retrievePage(holder.getVal(), pageSize);
                 streamOperation.pagedExecute(pagedItems);
-                if (((Collection) pagedItems[0]).size() == 0) {
+
+                int pagedItemCount = ((Collection) pagedItems[0]).size();
+                if (pagedItemCount == 0) {
                     holder.setVal(totalCount.intValue());
                 } else {
-                    holder.setVal(holder.getVal() + ((Collection) pagedItems[0]).size());
+                    if (!isFinalPage(holder, pagedItemCount, totalCount) && (pagedItemCount != pageSize)) {
+                        LOG.warn(String.format("In the previous iteration of this streaming transactional operation, " +
+                                "(%s) pagedItems were processed when we were expecting a full page of (%s) items. " +
+                                "Please ensure that your StreamCapableTransactionalOperation#retrieveTotalCount() " +
+                                "and StreamCapableTransactionalOperation#retrievePage(int startPos, int pageSize) " +
+                                "queries contain the same conditions as to ultimately provide the number of entities " +
+                                "equal to the declared total count.", pagedItemCount, pageSize));
+                    }
+
+                    if (pagedItemCount < pageSize) {
+                        holder.setVal(holder.getVal() + pageSize);
+                    } else {
+                        holder.setVal(holder.getVal() + pagedItemCount);
+                    }
                 }
+            }
+
+            private boolean isFinalPage(Holder holder, int pagedItemCount, Long totalCount) {
+                int processedItemCount = holder.getVal() + pagedItemCount;
+
+                return processedItemCount >= totalCount;
             }
         };
         while (holder.getVal() < totalCount) {

--- a/common/src/main/java/org/broadleafcommerce/common/util/StreamingTransactionCapableUtil.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/StreamingTransactionCapableUtil.java
@@ -96,7 +96,8 @@ public class StreamingTransactionCapableUtil implements StreamingTransactionCapa
                                 "Please ensure that your StreamCapableTransactionalOperation#retrieveTotalCount() " +
                                 "and StreamCapableTransactionalOperation#retrievePage(int startPos, int pageSize) " +
                                 "queries contain the same conditions as to ultimately provide the number of entities " +
-                                "equal to the declared total count.", pagedItemCount, pageSize));
+                                "equal to the declared total count. Stream operation: %s",
+                                pagedItemCount, pageSize, streamOperation.getClass()));
                     }
 
                     if (pagedItemCount < pageSize) {


### PR DESCRIPTION
- Introduce warn-level logging to indicate that the retrieved batch has fewer items that what is expected for the page count. Due to the way that we use 'holder.getVal() + pagedItemCount' to set the holder value, pagination will only occur correctly if the pagedItemCount is equal to the pageSize. Otherwise, we end up passing a startPos value to retrievePage() which will cause items to be processed multiple times.

- Additionally update the holder value calculation to use pageSize instead of the pagedItemCount if the pagedItemCount is less than the pageSize. While they should be the same value, this is the safer option as to avoid duplicated processing of the same record. Alternatively, if the pagedItemCount is not less than the pageSize, then we should increment by the pagedItemCount. This accounts for an exact match to the pageSize and the case that the pagedItemCount is higher than the pageSize. While this is not advised, it should not dangerous since it won't cause duplicated processing of any records.