### PR TITLE
Changed ConditionalOnAdmin to rely on a bean rather than ConditionalOnBroadleafEnum

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/admin/condition/ConditionalOnAdmin.java
+++ b/common/src/main/java/org/broadleafcommerce/common/admin/condition/ConditionalOnAdmin.java
@@ -17,9 +17,8 @@
  */
 package org.broadleafcommerce.common.admin.condition;
 
-import org.broadleafcommerce.common.condition.ConditionalOnBroadleafModule;
-import org.broadleafcommerce.common.module.BroadleafModuleRegistration.BroadleafModuleEnum;
-
+import org.broadleafcommerce.common.config.AdminOnlyTarget;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -39,6 +38,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@ConditionalOnBroadleafModule(BroadleafModuleEnum.ADMIN)
+@ConditionalOnBean(AdminOnlyTarget.class)
 public @interface ConditionalOnAdmin {
 }

--- a/common/src/main/java/org/broadleafcommerce/common/admin/condition/ConditionalOnNotAdmin.java
+++ b/common/src/main/java/org/broadleafcommerce/common/admin/condition/ConditionalOnNotAdmin.java
@@ -17,9 +17,8 @@
  */
 package org.broadleafcommerce.common.admin.condition;
 
-import org.broadleafcommerce.common.condition.ConditionalOnMissingBroadleafModule;
-import org.broadleafcommerce.common.module.BroadleafModuleRegistration.BroadleafModuleEnum;
-
+import org.broadleafcommerce.common.config.AdminOnlyTarget;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -36,6 +35,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@ConditionalOnMissingBroadleafModule(BroadleafModuleEnum.ADMIN)
+@ConditionalOnMissingBean(AdminOnlyTarget.class)
 public @interface ConditionalOnNotAdmin {
 }

--- a/common/src/main/java/org/broadleafcommerce/common/config/AdminOnlyTarget.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/AdminOnlyTarget.java
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.config;
+
+/**
+ * This class is specifically used as a temporary workaround for {@link org.broadleafcommerce.common.admin.condition.ConditionalOnAdmin}
+ * and {@link org.broadleafcommerce.common.admin.condition.ConditionalOnNotAdmin} to allow them to work correctly when using
+ * application servers such as JBoss.
+ *
+ * @author Nick Crum ncrum
+ */
+public class AdminOnlyTarget {
+}

--- a/common/src/main/java/org/broadleafcommerce/common/config/EnableBroadleafAdminRootAutoConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/EnableBroadleafAdminRootAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.broadleafcommerce.common.config.EnableBroadleafAdminRootAutoConfigura
 import org.broadleafcommerce.common.config.EnableBroadleafAdminRootAutoConfiguration.BroadleafAdminRootAutoConfigurationOverrides;
 import org.broadleafcommerce.common.extensibility.FrameworkXmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 
@@ -101,7 +102,13 @@ public @interface EnableBroadleafAdminRootAutoConfiguration {
             "classpath*:/blc-config/admin/bl-*-applicationContext.xml",
             "classpath*:/blc-config/admin/late/bl-*-applicationContext.xml"
     }, reader = FrameworkXmlBeanDefinitionReader.class)
-    class BroadleafAdminRootAutoConfiguration {}
+    class BroadleafAdminRootAutoConfiguration {
+
+        @Bean
+        public AdminOnlyTarget blAdminOnlyTarget() {
+            return new AdminOnlyTarget();
+        }
+    }
     
     @ImportResource("classpath:/override-contexts/admin-root-autoconfiguration-overrides.xml")
     class BroadleafAdminRootAutoConfigurationOverrides {}


### PR DESCRIPTION
This is the first step to better supporting JBoss 7.1 and possibly other application servers. This change is meant to be temporary so that those using JBoss and having to include `broadleaf-admin-module` in their `site` application can work properly. 

@phillipuniverse or I have context on this situation. 

BroadleafCommerce/QA#2697 will be updated with future steps around this issue.