### PR TITLE
Fixed issue where BLC was swapping Solr cores when there was an error during reindexing.

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -171,12 +171,9 @@ public class SolrIndexServiceImpl implements SolrIndexService {
         LOG.info("Rebuilding the entire Solr index...");
         StopWatch s = new StopWatch();
 
-        try{
-            preBuildIndex();
-            buildIndex();
-        } finally {
-            postBuildIndex();
-        }
+        preBuildIndex();
+        buildIndex();
+        postBuildIndex();
 
         LOG.info(String.format("Finished building entire Solr index in %s", s.toLapString()));
     }


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/3171 QA-3171 issue where BLC was swapping Solr cores when there was an

error during reindexing, which leaves the live site with an empty index.