### PR TITLE
Allow listgrid fields to utilize a custom renderer

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -68,6 +68,7 @@ public class BasicFieldMetadata extends FieldMetadata {
     protected String broadleafEnumeration;
     protected Boolean hideEnumerationIfEmpty;
     protected SupportedFieldType fieldComponentRenderer;
+    protected SupportedFieldType gridFieldComponentRenderer;
     protected Boolean readOnly;
     protected Map<String, List<Map<String, String>>> validationConfigurations = new HashMap<>(5);
     protected Boolean requiredOverride;
@@ -301,9 +302,16 @@ public class BasicFieldMetadata extends FieldMetadata {
         return fieldComponentRenderer;
     }
 
-    
     public void setFieldComponentRenderer(SupportedFieldType fieldComponentRenderer) {
         this.fieldComponentRenderer = fieldComponentRenderer;
+    }
+
+    public SupportedFieldType getGridFieldComponentRenderer() {
+        return gridFieldComponentRenderer;
+    }
+
+    public void setGridFieldComponentRenderer(SupportedFieldType gridFieldComponentRenderer) {
+        this.gridFieldComponentRenderer = gridFieldComponentRenderer;
     }
 
     public Boolean getReadOnly() {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
@@ -110,6 +110,7 @@ public class FieldMetadataOverride extends MetadataOverride {
     private String broadleafEnumeration;
     private Boolean hideEnumerationIfEmpty;
     private SupportedFieldType fieldComponentRenderer;
+    private SupportedFieldType gridFieldComponentRenderer;
     private Boolean readOnly;
     private Map<String, List<Map<String, String>>> validationConfigurations;
     private Boolean requiredOverride;
@@ -341,7 +342,6 @@ public class FieldMetadataOverride extends MetadataOverride {
         this.hideEnumerationIfEmpty = hideEnumerationIfEmpty;
     }
 
-    
     public SupportedFieldType getFieldComponentRenderer() {
         return fieldComponentRenderer;
     }
@@ -349,6 +349,15 @@ public class FieldMetadataOverride extends MetadataOverride {
     public void setFieldComponentRenderer(SupportedFieldType fieldComponentRenderer) {
         this.fieldComponentRenderer = fieldComponentRenderer;
     }
+
+    public SupportedFieldType getGridFieldComponentRenderer() {
+        return gridFieldComponentRenderer;
+    }
+
+    public void setGridFieldComponentRenderer(SupportedFieldType gridFieldComponentRenderer) {
+        this.gridFieldComponentRenderer = gridFieldComponentRenderer;
+    }
+
 
     public Boolean getReadOnly() {
         return readOnly;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
@@ -411,6 +411,8 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
                         Boolean.parseBoolean(stringValue));
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.FIELDCOMPONENTRENDERER)) {
                 fieldMetadataOverride.setFieldComponentRenderer(SupportedFieldType.valueOf(stringValue));
+            } else if (entry.getKey().equals(PropertyType.AdminPresentation.GRIDFIELDCOMPONENTRENDERER)) {
+                fieldMetadataOverride.setGridFieldComponentRenderer(SupportedFieldType.valueOf(stringValue));
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.TOOLTIP)) {
                 fieldMetadataOverride.setTooltip(stringValue);
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.HELPTEXT)) {
@@ -526,6 +528,7 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
             override.setBroadleafEnumeration(annot.broadleafEnumeration());
             override.setHideEnumerationIfEmpty(annot.hideEnumerationIfEmpty());
             override.setFieldComponentRenderer(annot.fieldComponentRenderer());
+            override.setGridFieldComponentRenderer(annot.gridFieldComponentRenderer());
             override.setColumnWidth(annot.columnWidth());
             override.setExplicitFieldType(annot.fieldType());
             override.setDisplayType(annot.displayType());
@@ -657,6 +660,9 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
         }
         if (basicFieldMetadata.getFieldComponentRenderer() != null) {
             metadata.setFieldComponentRenderer(basicFieldMetadata.getFieldComponentRenderer());
+        }
+        if (basicFieldMetadata.getGridFieldComponentRenderer() != null) {
+            metadata.setGridFieldComponentRenderer(basicFieldMetadata.getGridFieldComponentRenderer());
         }
         if (basicFieldMetadata.getFriendlyName() != null) {
             metadata.setFriendlyName(basicFieldMetadata.getFriendlyName());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/Field.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/Field.java
@@ -41,6 +41,7 @@ public class Field {
     protected String value;
     protected String displayValue;
     protected String fieldComponentRenderer;
+    protected String gridFieldComponentRenderer;
     protected String foreignKeyDisplayValueProperty;
     protected String foreignKeyClass;
     protected String foreignKeySectionPath;
@@ -101,6 +102,11 @@ public class Field {
 
     public Field withFieldComponentRenderer(String fieldComponentRenderer) {
         setFieldComponentRenderer(fieldComponentRenderer);
+        return this;
+    }
+
+    public Field withGridFieldComponentRenderer(String gridFieldComponentRenderer) {
+        setGridFieldComponentRenderer(gridFieldComponentRenderer);
         return this;
     }
     
@@ -384,6 +390,14 @@ public class Field {
 
     public void setFieldComponentRenderer(String fieldComponentRenderer) {
         this.fieldComponentRenderer = fieldComponentRenderer;
+    }
+
+    public String getGridFieldComponentRenderer() {
+        return gridFieldComponentRenderer;
+    }
+
+    public void setGridFieldComponentRenderer(String gridFieldComponentRenderer) {
+        this.gridFieldComponentRenderer = gridFieldComponentRenderer;
     }
 
     public String getValue() {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -999,6 +999,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                     f.withName(property.getName())
                      .withFieldType(fieldType)
                      .withFieldComponentRenderer(fmd.getFieldComponentRenderer()==null?null:fmd.getFieldComponentRenderer().toString())
+                     .withGridFieldComponentRenderer(fmd.getGridFieldComponentRenderer()==null?null:fmd.getGridFieldComponentRenderer().toString())
                      .withOrder(fmd.getOrder())
                      .withFriendlyName(fmd.getFriendlyName())
                      .withForeignKeyDisplayValueProperty(fmd.getForeignKeyDisplayValueProperty())

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -159,6 +159,18 @@
                                 </th:block>
                             </span>
 
+                            <span th:if="${field.fieldType == 'MEDIA'}">
+                                <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
+                                      <img class="thumbnail" th:style="${'width: 100%;'}"
+                                           blc:src="@{${field.media.url}} + ?smallAdminThumbnail"
+                                           th:attr="data-fullurl=@{${field.media.url}}" />
+                                </th:block>
+                                <th:block th:unless="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
+                                     <div th:replace="${'fields/' + #strings.toLowerCase(field.gridFieldComponentRenderer)}"></div>
+                                </th:block>
+
+                            </span>
+
                             <span th:if="${field.fieldType == 'COLOR'}">
                                 <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
                                     <span class="sandbox-color-square"

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -1,5 +1,5 @@
 <comment th:remove="all" xmlns:th="http://www.w3.org/1999/html">
-<!-- This component represents a list grid toolbar -->
+<!-- This component represents a list grid -->
 </comment>
 
 <th:block th:if="${!#strings.isEmpty(listGrid.templateOverride)}">
@@ -144,27 +144,41 @@
                                th:href="@{${record.path}}"
                                th:utext="${#strings.isEmpty(field.displayValue) ? '(No value set)' : field.displayValue}"></a>
 
-
                             <th:block th:if="${!headerField.mainEntityLink and headerField.canLinkToExternalEntity and !#strings.isEmpty(field.value)}">
                                 <a class="external-link" th:href="@{${headerField.foreignKeySectionPath + '/' + field.value}}" th:utext="${field.displayValue}"></a>
                             </th:block>
 
                             <span th:if="${field.fieldType == 'IMAGE'}">
-                                <img class="thumbnail" th:style="${'width: 100%;'}"
-                                    blc:src="@{${field.value + record.getField('thumbnailKey').value}}"
-                                    th:attr="data-fullurl=@{${field.value}}" />
+                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                    <img class="thumbnail" th:style="${'width: 100%;'}"
+                                         blc:src="@{${field.value + record.getField('thumbnailKey').value}}"
+                                         th:attr="data-fullurl=@{${field.value}}" />
+                                </th:block>
+                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                        <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                </th:block>
                             </span>
 
                             <span th:if="${field.fieldType == 'COLOR'}">
-                                <span class="sandbox-color-square" 
-                                    th:style="${'background-color: ' + field.value + ';'}"></span>
+                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                    <span class="sandbox-color-square"
+                                          th:style="${'background-color: ' + field.value + ';'}"></span>
+                                </th:block>
+                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                     <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                </th:block>
                             </span>
 
                             <th:block th:unless="${headerField.mainEntityLink
                                     or headerField.canLinkToExternalEntity 
                                     or field.fieldType == 'IMAGE'
-                                    or field.fieldType == 'COLOR'}"
+                                    or field.fieldType == 'COLOR'}">
+
+                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}"
                                   th:utext="${field.displayValue}"></th:block>
+                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                    <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                </th:block>
                         </th:block>
 
                         <th:block th:case="'asset_grid'">

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -149,23 +149,23 @@
                             </th:block>
 
                             <span th:if="${field.fieldType == 'IMAGE'}">
-                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
                                     <img class="thumbnail" th:style="${'width: 100%;'}"
                                          blc:src="@{${field.value + record.getField('thumbnailKey').value}}"
                                          th:attr="data-fullurl=@{${field.value}}" />
                                 </th:block>
-                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
-                                        <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                <th:block th:unless="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
+                                        <div th:replace="${'fields/' + #strings.toLowerCase(field.gridFieldComponentRenderer)}"></div>
                                 </th:block>
                             </span>
 
                             <span th:if="${field.fieldType == 'COLOR'}">
-                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
+                                <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
                                     <span class="sandbox-color-square"
                                           th:style="${'background-color: ' + field.value + ';'}"></span>
                                 </th:block>
-                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
-                                     <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                <th:block th:unless="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
+                                     <div th:replace="${'fields/' + #strings.toLowerCase(field.gridFieldComponentRenderer)}"></div>
                                 </th:block>
                             </span>
 
@@ -174,10 +174,10 @@
                                     or field.fieldType == 'IMAGE'
                                     or field.fieldType == 'COLOR'}">
 
-                                <th:block th:if="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}"
+                                <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}"
                                   th:utext="${field.displayValue}"></th:block>
-                                <th:block th:unless="${field.gridComponentRenderer == null or #strings.equals(field.gridComponentRenderer, 'UNKNOWN')}">
-                                    <div th:replace="${'fields/' + #strings.toLowerCase(field.gridComponentRenderer)}"></div>
+                                <th:block th:unless="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
+                                    <div th:replace="${'fields/' + #strings.toLowerCase(field.gridFieldComponentRenderer)}"></div>
                                 </th:block>
                         </th:block>
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -159,18 +159,6 @@
                                 </th:block>
                             </span>
 
-                            <span th:if="${field.fieldType == 'MEDIA'}">
-                                <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
-                                      <img class="thumbnail" th:style="${'width: 100%;'}"
-                                           blc:src="@{${field.media.url}} + ?smallAdminThumbnail"
-                                           th:attr="data-fullurl=@{${field.media.url}}" />
-                                </th:block>
-                                <th:block th:unless="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
-                                     <div th:replace="${'fields/' + #strings.toLowerCase(field.gridFieldComponentRenderer)}"></div>
-                                </th:block>
-
-                            </span>
-
                             <span th:if="${field.fieldType == 'COLOR'}">
                                 <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
                                     <span class="sandbox-color-square"

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
@@ -256,13 +256,23 @@ public @interface AdminPresentation {
     boolean allowNoValueEnumOption() default false;
 
     /**
-     * Optional - drives the component that renders the UI
+     * Optional - drives the component that renders the UI for an entityform
      *
      * When not specified, will default to the fieldType
      * 
      * @return the component name responsible for rendering this field
      */
     SupportedFieldType fieldComponentRenderer() default SupportedFieldType.UNKNOWN;
+
+
+    /**
+     * Optional - drives the component that renders the UI for a listgrid
+     *
+     * When not specified, will default to the fieldType
+     *
+     * @return the component name responsible for rendering this field
+     */
+    SupportedFieldType gridFieldComponentRenderer() default SupportedFieldType.UNKNOWN;
 
     /**
      * Optional - only required if you want to make the field immutable

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
@@ -51,6 +51,7 @@ public class PropertyType {
         public static final String BROADLEAFENUMERATION = "broadleafEnumeration";
         public static final String HIDEENUMERATIONIFEMPTY = "hideEnumerationIfEmpty";
         public static final String FIELDCOMPONENTRENDERER = "fieldComponentRenderer";
+        public static final String GRIDFIELDCOMPONENTRENDERER = "gridFieldComponentRenderer";
         public static final String REQUIREDOVERRIDE = "requiredOverride";
         public static final String EXCLUDED = "excluded";
         public static final String TOOLTIP = "tooltip";


### PR DESCRIPTION
Adding in a gridFieldComponentRenderer to allow for custom display of Listgrid entries. Based off of fieldComponentRenderer, but that is designed for entityForms instead.