### PR TITLE
Update Spring Security to the latest patch release 4.2.4 for CVE-2017-8030

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.3.14.RELEASE</spring.version>
-        <spring.security.version>4.2.3.RELEASE</spring.security.version>
+        <spring.security.version>4.2.4.RELEASE</spring.security.version>
         <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
         <spring.mobile.version>1.1.5.RELEASE</spring.mobile.version>
         <jackson.version>2.8.11</jackson.version>


### PR DESCRIPTION
See blog post at https://spring.io/blog/2018/01/30/cve-2017-8030-spring-security-5-0-1-4-2-4-4-1-5-released.