### PR TITLE
Rework the asset-grid replace to make sure the images get loaded correctly when the tab loads

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -355,7 +355,8 @@ $(document).ready(function() {
                         initAssetGrid($assetGrid);
                     }
 
-                    $(this).find('.asset-grid-container').replaceWith($assetGrid);
+                    var $assertGridContainer = $('#' + tableId + ' .asset-grid-body-wrapper').find('.asset-grid-container');
+                    $assertGridContainer.replaceWith($assetGrid);
                 });
 
                 hideTabSpinner($tab, $tabBody);


### PR DESCRIPTION
BroadleafCommerce/QA#3189 

Solution provided by [Stacy at Buckle via Helpscout](https://secure.helpscout.net/conversation/516597383/26983?folderId=305501)

- Rework the asset-grid replace