### PR TITLE
Offer Codes cannot be added to an Offer

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -289,7 +289,7 @@
          */
         updateEntityFormActions : function() {
             var $currModal = BLCAdmin.currentModal();
-            if ($currModal && $currModal.has('.modal-add-entity-form')) {
+            if ($currModal && $currModal.has('.modal-add-entity-form').length) {
                 // in community, modal submit gets disabled when there is a validation error
                 $('.submit-button', $currModal).prop('disabled', !this.getEntityFormChangesCount());
             }


### PR DESCRIPTION
BroadleafCommerce/QA#3210
Fix Save button disabled in 'Add Offer Codes' modal window