### PR TITLE
Moved the placement of the select/edit/delete icons in the admin farther up on the image so that thumbnail (resized images) will still have the icon in a focusable area.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/media-asset.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/media-asset.css
@@ -71,7 +71,7 @@
     position: relative;
     width: 50px;
     height: 50px;
-    margin: 40% 10px;
+    margin: 10% 10px;
 }
 .media-image-container .media-actions button > i {
     margin: 0;


### PR DESCRIPTION
Fixes https://github.com/BroadleafCommerce/QA/issues/3214