### PR TITLE
Admin Offer Enhancements

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
@@ -22,10 +22,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.locale.domain.Locale;
 import org.broadleafcommerce.common.presentation.client.OperationType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.time.SystemTime;
+import org.broadleafcommerce.common.util.DateUtil;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferAdminPresentation;
@@ -36,21 +40,38 @@ import org.broadleafcommerce.openadmin.dto.CriteriaTransferObject;
 import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.broadleafcommerce.openadmin.dto.FilterAndSortCriteria;
 import org.broadleafcommerce.openadmin.dto.MergedPropertyType;
 import org.broadleafcommerce.openadmin.dto.PersistencePackage;
 import org.broadleafcommerce.openadmin.dto.PersistencePerspective;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.service.handler.ClassCustomPersistenceHandlerAdapter;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.EmptyFilterValues;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.InspectHelper;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FieldPath;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FieldPathBuilder;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FilterMapping;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.Restriction;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.predicate.PredicateProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
 
 /**
  * Created by Jon on 11/23/15.
@@ -66,6 +87,10 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
     protected static final String OFFER_ITEM_QUALIFIER_RULE_TYPE = "offerItemQualifierRuleType";
     protected static final String STACKABLE = "stackableWithOtherOffers";
     protected static final String OFFER_ITEM_TARGET_RULE_TYPE = "offerItemTargetRuleType";
+    protected static final String IS_ACTIVE = "isActive";
+
+    @Value("${admin.offer.isactive.filter:false}")
+    protected boolean isActiveFilter = false;
 
     public OfferCustomPersistenceHandler() {
         super(Offer.class);
@@ -100,6 +125,9 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
         properties.put(QUALIFIERS_CAN_BE_QUALIFIERS, buildQualifiersCanBeQualifiersFieldMetaData());
         properties.put(QUALIFIERS_CAN_BE_TARGETS, buildQualifiersCanBeTargetsFieldMetaData());
         properties.put(STACKABLE, buildStackableFieldMetaData());
+        if (isActiveFilter) {
+            properties.put(IS_ACTIVE, buildIsActiveFieldMetaData());
+        }
 
         allMergedProperties.put(MergedPropertyType.PRIMARY, properties);
         Class<?>[] entityClasses = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(ceilingEntityClass);
@@ -119,6 +147,17 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
         advancedLabelMetadata.setOrder(5000);
         advancedLabelMetadata.setDefaultValue("true");
         return advancedLabelMetadata;
+    }
+
+    protected FieldMetadata buildIsActiveFieldMetaData() {
+        BasicFieldMetadata isActive = new BasicFieldMetadata();
+        isActive.setFieldType(SupportedFieldType.BOOLEAN);
+        isActive.setName(IS_ACTIVE);
+        isActive.setFriendlyName("OfferImpl_Is_Active");
+        isActive.setProminent(true);
+        isActive.setGridOrder(999999);
+        isActive.setVisibility(VisibilityEnum.FORM_HIDDEN);
+        return isActive;
     }
 
     protected FieldMetadata buildQualifiersCanBeQualifiersFieldMetaData() {
@@ -157,6 +196,7 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
 
     @Override
     public DynamicResultSet fetch(PersistencePackage persistencePackage, CriteriaTransferObject cto, DynamicEntityDao dynamicEntityDao, RecordHelper helper) throws ServiceException {
+        addIsActiveFiltering(cto);
         DynamicResultSet resultSet = helper.getCompatibleModule(OperationType.BASIC).fetch(persistencePackage, cto);
         String customCriteria = "";
         if (persistencePackage.getCustomCriteria().length > 0) {
@@ -195,8 +235,79 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
                 setValue = setValue.replaceAll("\\%", "").replaceAll("\\$", "");
                 discountValue.setValue(setValue);
             }
+
+            addIsActiveStatus(helper, entity);
         }
         return resultSet;
+    }
+
+    protected void addIsActiveFiltering(CriteriaTransferObject cto) {
+        if (isActiveFilter && cto.getCriteriaMap().containsKey(IS_ACTIVE)) {
+            FilterAndSortCriteria filter = cto.get(IS_ACTIVE);
+            final Boolean isActive = Boolean.parseBoolean(filter.getFilterValues().get(0));
+            FilterMapping filterMapping = new FilterMapping()
+                .withFieldPath(new FieldPath().withTargetProperty("id"))
+                .withDirectFilterValues(new EmptyFilterValues())
+                .withRestriction(new Restriction()
+                     .withPredicateProvider(new PredicateProvider() {
+                        @Override
+                        public Predicate buildPredicate(CriteriaBuilder builder, FieldPathBuilder fieldPathBuilder,
+                                                        From root, String ceilingEntity, String fullPropertyName,
+                                                        Path explicitPath, List directValues) {
+                            Date currentTime = SystemTime.asDate(true);
+                            if (isActive) {
+                                return builder.and(
+                                        builder.isNotNull(root.get("startDate")),
+                                        builder.lessThan(root.get("startDate"), currentTime),
+                                        builder.or(
+                                            builder.isNull(root.get("endDate")),
+                                            builder.greaterThan(root.get("endDate"), currentTime)
+                                        )
+                                );
+                            } else {
+                                return builder.or(
+                                        builder.isNull(root.get("startDate")),
+                                        builder.greaterThan(root.get("startDate"), currentTime),
+                                        builder.and(
+                                            builder.isNotNull(root.get("endDate")),
+                                            builder.lessThan(root.get("endDate"), currentTime)
+                                        )
+                                );
+                            }
+                        }
+                    }
+                 )
+            );
+            cto.getAdditionalFilterMappings().add(filterMapping);
+        }
+    }
+
+    protected void addIsActiveStatus(RecordHelper helper, Entity entity) {
+        if (isActiveFilter) {
+            try {
+                boolean isActive = false;
+                Property startDate = entity.findProperty("startDate");
+                if (startDate != null) {
+                    Property endDate = entity.findProperty("endDate");
+                    Date end = null;
+                    if (endDate != null) {
+                        end = helper.getSimpleDateFormatter().parse(endDate.getValue());
+                    }
+                    Date date = helper.getSimpleDateFormatter().parse(startDate.getValue());
+                    isActive = DateUtil.isActive(date, end, true);
+                }
+                entity.addProperty(buildIsActiveProperty(isActive));
+            } catch (ParseException e) {
+                throw ExceptionHelper.refineException(e);
+            }
+        }
+    }
+
+    protected Property buildIsActiveProperty(boolean isActive) {
+        Property property = new Property();
+        property.setName(IS_ACTIVE);
+        property.setValue(String.valueOf(isActive));
+        return property;
     }
 
     protected Property buildAdvancedVisibilityOptionsProperty(Property timeRule) {

--- a/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
@@ -54,3 +54,6 @@ errorNeedAllowedValue=Failed to generate Skus. One of the Product Options has no
 noSkusGenerated=No Skus were generated. Each product option value permutation already has a Sku associated with it.
 noProductOptionsConfigured=This product has no Product Options configured to generate Skus from.
 numberSkusGenerated=Sku(s) generated from the configured product options.
+
+Duplication_Failure=Entity Failed Duplication
+Validation_Failure=Entity Failed Validation For Duplication

--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
@@ -443,6 +443,7 @@ OfferImpl_Customer=Which customers can use this offer?
 
 OfferImpl_Qualifiers_Can_Be_Targets=Can these qualifiers also receive item discounts?
 OfferImpl_Qualifiers_Can_Be_Qualifiers=Can these qualifiers be used to qualify for other offers?
+OfferImpl_Is_Active=Is Active
 
 OfferImpl_Qualifying_Item_Rule_Question=Should this offer target orders with specific items (e.g. Buy X get Y)?
 OfferImpl_Qualifying_Item_Rule=What product or category condition is needed to qualify for this offer?

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -419,6 +419,43 @@ $(document).ready(function() {
         }
     });
 
+    $('body').on('click', 'button.duplicate-button, a.duplicate-button', function(event) {
+        var $button = $(this);
+        var $form = BLCAdmin.getForm($button);
+
+        var currentAction = $form.attr('action');
+        var dupUrl = currentAction + '/duplicate';
+
+        BLCAdmin.entityForm.showActionSpinner($button.closest('.entity-form-actions'));
+
+        // On success this should redirect, on failure we'll get some JSON back
+        BLC.ajax({
+            url: dupUrl,
+            type: "POST",
+            data: $form.serializeArray(),
+            complete: BLCAdmin.entityForm.hideActionSpinner()
+        }, function (data) {
+            $("#headerFlashAlertBoxContainer").removeClass("hidden");
+            $(".errors, .error, .tab-error-indicator, .tabError").remove();
+            $('.has-error').removeClass('has-error');
+
+            if (!data.errors) {
+                var $titleBar = $form.closest('.main-content').find('.content-area-title-bar');
+                BLCAdmin.alert.showAlert($titleBar, 'Successfully ' + BLCAdmin.messages.duplicated + '!', {
+                    alertType: 'save-alert',
+                    autoClose: 2000,
+                    clearOtherAlerts: true
+                });
+            } else {
+                BLCAdmin.entityForm.showErrors(data, BLCAdmin.messages.problemDuplicating);
+            }
+
+            BLCAdmin.runPostFormSubmitHandlers($form, data);
+        });
+
+        event.preventDefault();
+    });
+
     $('body').on('click', 'button.submit-button, a.submit-button', function(event) {
         var $button = $(this);
         if ($button.hasClass('disabled') || $button.is(':disabled')) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/ui/messages_en.js
@@ -24,6 +24,7 @@
         done : 'Done',
         updated : 'Updated',
         deleted : 'Deleted',
+        duplicated : 'Duplicated',
         
         // Rule builder messages
         rule : 'Rule',
@@ -48,6 +49,7 @@
 
         problemSaving : 'There was a problem saving. See errors below',
         problemDeleting : 'There was a problem deleting this record. See errors below',
+        problemDuplicating : 'There was a problem duplicating this record. See errors below',
         problemReverting : 'There was a problem reverting this record.',
         globalErrors : 'Global Errors',
 

--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopyContext.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopyContext.java
@@ -55,6 +55,11 @@ public class MultiTenantCopyContext {
     protected Map<String, Map<Object, Object>> equivalentsMap;
     protected GenericEntityService genericEntityService;
     protected List<DeferredOperation> deferredOperations = new ArrayList<DeferredOperation>();
+    /**
+     * hints used to fine tune copying - generally support for hints is included in {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
+     */
+    protected Map<String, String> copyHints = new HashMap<String, String>();
+    protected Boolean isForDuplicate = false;
     
     public MultiTenantCopyContext(Catalog fromCatalog, Catalog toCatalog, Site fromSite, Site toSite, 
             GenericEntityService genericEntityService, MultiTenantCopierExtensionManager extensionManager) {
@@ -197,6 +202,29 @@ public class MultiTenantCopyContext {
 
     public List<DeferredOperation> getDeferredOperations() {
         return deferredOperations;
+    }
+
+    /**
+     * Provides a place for the caller to provide generic information to inform the copy operation. It's still up
+     * to the entity implementation of {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)}
+     * to actually harvest and utilize the information in some meaningful way.
+     *
+     * @return
+     */
+    public Map<String, String> getCopyHints() {
+        return copyHints;
+    }
+
+    public void setCopyHints(Map<String, String> copyHints) {
+        this.copyHints = copyHints;
+    }
+
+    public Boolean getForDuplicate() {
+        return isForDuplicate;
+    }
+
+    public void setForDuplicate(Boolean forDuplicate) {
+        isForDuplicate = forDuplicate;
     }
 
     protected boolean checkCloneStatus(Object instance) {

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicateModifier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicateModifier.java
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.persistence;
+
+/**
+ * Perform final modifications on a duplicated entity before persistence.
+ *
+ * @author Jeff Fischer
+ */
+public interface EntityDuplicateModifier<T> {
+
+    void modifyInitialDuplicateState(T copy);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+
+import java.util.Map;
+
+/**
+ * Create a production duplicate of an entity. In the case of the enterprise module, the entity to be duplicated may not
+ * be a sandbox copy. In the case of the multitenant module, the entity to be duplicated must not be referenced in a derived
+ * catalog (apart from a standard site override) and must not be owned by another site.
+ * </p>
+ * The feature must first be enabled before use. To enable, add the following property to your Spring property file:
+ * </p>
+ * {@code admin.entity.duplication.isactive=true}
+ *
+ * @author Jeff Fischer
+ */
+public interface EntityDuplicator {
+
+    /**
+     * Validate whether or not this feature is enabled and whether or not the passed entity params are valid for duplication.
+     *
+     * @param entityClass
+     * @param id
+     * @return
+     */
+    boolean validate(Class<?> entityClass, Long id);
+
+    /**
+     * Validate whether or not this feature is enabled and whether or not the passed entity params are valid for duplication.
+     *
+     * @param entity
+     * @return
+     */
+    boolean validate(Object entity);
+
+    /**
+     * Create a production duplicate of the entity specified in the params. The is the most oft used copy method.
+     *
+     * @param entityClass the class for the entity
+     * @param id the primary key
+     * @param copyHints hints used to fine tune copying - generally support for hints is included in {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
+     * @param modifiers list of modifications to perform to the resulting duplicate prior to persistence
+     * @param <T> the entity type
+     * @return the duplicated entity
+     */
+    <T> T copy(Class<T> entityClass, Long id, Map<String, String> copyHints, EntityDuplicateModifier... modifiers);
+
+    /**
+     * Create a production duplicate of the entity specified in the params. The is the least oft used copy method.
+     *
+     * @param context prepopulated copy context that is setup for catalog and/or site
+     * @param entity the instance to duplicate
+     * @param copyHints hints used to fine tune copying - generally support for hints is included in {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
+     * @param modifiers list of modifications to perform to the resulting duplicate prior to persistence
+     * @param <T> the entity type
+     * @return the duplicated entity
+     */
+    <T> T copy(MultiTenantCopyContext context, MultiTenantCloneable<T> entity, Map<String, String> copyHints, EntityDuplicateModifier... modifiers);
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorExtensionHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorExtensionHandler.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extension.ExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+
+/**
+ * Allow other modules to contribute to the duplication lifecycle
+ *
+ * @author Jeff Fischer
+ */
+public interface EntityDuplicatorExtensionHandler extends ExtensionHandler {
+
+    /**
+     * Confirm whether or not duplication operation is allowed
+     *
+     * @param entity
+     * @param resultHolder
+     * @return
+     */
+    ExtensionResultStatusType validateDuplicate(Object entity, ExtensionResultHolder<Boolean> resultHolder);
+
+    /**
+     * Perform any required context and state setup before commencing with the duplication
+     *
+     * @param entity
+     * @param resultHolder
+     * @return
+     */
+    ExtensionResultStatusType setupDuplicate(Object entity, ExtensionResultHolder<MultiTenantCopyContext> resultHolder);
+
+    /**
+     * Tear down any expired context and state used during the duplication
+     *
+     * @return
+     */
+    ExtensionResultStatusType tearDownDuplicate();
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorExtensionManager.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extension.ExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionManager;
+import org.broadleafcommerce.common.extension.ExtensionManagerOperation;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Manage the interaction between a duplication operation and other modules that wish to contribute to that lifecycle
+ *
+ * @author Jeff Fischer
+ */
+@Service("blEntityDuplicatorExtensionManager")
+public class EntityDuplicatorExtensionManager extends ExtensionManager<EntityDuplicatorExtensionHandler> implements EntityDuplicatorExtensionHandler {
+
+    public static final ExtensionManagerOperation validateDuplicate = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((EntityDuplicatorExtensionHandler) handler).validateDuplicate(params[0], (ExtensionResultHolder<Boolean>) params[1]);
+        }
+    };
+
+    public static final ExtensionManagerOperation setupDuplicate = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((EntityDuplicatorExtensionHandler) handler).setupDuplicate(params[0], (ExtensionResultHolder<MultiTenantCopyContext>) params[1]);
+        }
+    };
+
+    public static final ExtensionManagerOperation tearDownDuplicate = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((EntityDuplicatorExtensionHandler) handler).tearDownDuplicate();
+        }
+    };
+
+    public EntityDuplicatorExtensionManager() {
+        super(EntityDuplicatorExtensionHandler.class);
+    }
+
+    @Override
+    public ExtensionResultStatusType validateDuplicate(Object entity, ExtensionResultHolder<Boolean> resultHolder) {
+        return execute(validateDuplicate, entity, resultHolder);
+    }
+
+    @Override
+    public ExtensionResultStatusType setupDuplicate(Object entity, ExtensionResultHolder<MultiTenantCopyContext> resultHolder) {
+        return execute(setupDuplicate, entity, resultHolder);
+    }
+
+    @Override
+    public ExtensionResultStatusType tearDownDuplicate() {
+        return execute(tearDownDuplicate);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        //not used - fulfills interface contract
+        return true;
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicatorImpl.java
@@ -1,0 +1,164 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.CopyOperation;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopier;
+import org.broadleafcommerce.common.copy.MultiTenantCopierExtensionManager;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.exception.ExceptionHelper;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.site.domain.Site;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+import javax.annotation.Resource;
+
+/**
+ * @see EntityDuplicator
+ * @author Jeff Fischer
+ */
+@Service("blEntityDuplicator")
+public class EntityDuplicatorImpl extends MultiTenantCopier implements EntityDuplicator {
+
+    @Value("${admin.entity.duplication.isactive:false}")
+    protected boolean isActive = false;
+
+    @Resource(name = "blEntityDuplicatorExtensionManager")
+    protected EntityDuplicatorExtensionManager extensionManager;
+
+    @Resource(name = "blMultiTenantCopierExtensionManager")
+    protected MultiTenantCopierExtensionManager mtCopierExtensionManager;
+
+    @Override
+    public void copyEntities(final MultiTenantCopyContext context) throws Exception {
+        throw new UnsupportedOperationException("Not Supported");
+    }
+
+    @Override
+    public boolean validate(Class<?> entityClass, Long id) {
+        if (!isActive) {
+            return false;
+        }
+        Object entity = genericEntityService.readGenericEntity(entityClass, id);
+        return validate(entity);
+    }
+
+    @Override
+    public boolean validate(Object entity) {
+        if (!isActive) {
+            return false;
+        }
+        ExtensionResultHolder<Boolean> response = new ExtensionResultHolder<Boolean>();
+        response.setResult(true);
+        if (extensionManager != null) {
+            extensionManager.validateDuplicate(entity, response);
+        }
+        return response.getResult();
+    }
+
+    @Override
+    public <T> T copy(Class<T> entityClass, Long id, Map<String, String> copyHints, EntityDuplicateModifier... modifiers) {
+        genericEntityService.flush();
+        genericEntityService.clear();
+        Object entity = genericEntityService.readGenericEntity(entityClass, id);
+        if (!(entity instanceof MultiTenantCloneable)) {
+            IllegalArgumentException e = new IllegalArgumentException("Copying is only supported for classes implementing MultiTenantCloneable");
+            LOG.error(String.format("Unable to duplicate entity %s:%s", entityClass.getName(), id), e);
+            throw e;
+        }
+        boolean isValid = validate(entity);
+        T dup;
+        if (isValid) {
+            try {
+                Site currentSite = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
+                MultiTenantCopyContext context = new MultiTenantCopyContext(null, null, currentSite, currentSite, genericEntityService, mtCopierExtensionManager);
+                if (extensionManager != null) {
+                    ExtensionResultHolder<MultiTenantCopyContext> contextResponse = new ExtensionResultHolder<MultiTenantCopyContext>();
+                    extensionManager.setupDuplicate(entity, contextResponse);
+                    if (contextResponse.getResult() != null) {
+                        context = contextResponse.getResult();
+                    }
+                }
+                dup = performCopy(context, (MultiTenantCloneable<T>) entity, copyHints, modifiers);
+            } catch (Exception e) {
+                LOG.error(String.format("Unable to duplicate entity %s:%s", entityClass.getName(), id), e);
+                throw ExceptionHelper.refineException(e);
+            } finally {
+                if (extensionManager != null) {
+                    extensionManager.tearDownDuplicate();
+                }
+            }
+        } else {
+            LOG.error(String.format("Entity not valid for duplication - %s:%s", entityClass.getName(), id));
+            throw new IllegalArgumentException(String.format("Entity not valid for duplication - %s:%s", entityClass.getName(), id));
+        }
+        return dup;
+    }
+
+    @Override
+    public <T> T copy(final MultiTenantCopyContext context, final MultiTenantCloneable<T> entity, Map<String, String> copyHints, final EntityDuplicateModifier... modifiers) {
+        if (!(entity instanceof MultiTenantCloneable)) {
+            IllegalArgumentException e = new IllegalArgumentException("Copying is only supported for classes implementing MultiTenantCloneable");
+            LOG.error(String.format("Unable to duplicate entity %s:%s", entity.getClass().getName(), genericEntityService.getIdentifier(entity)), e);
+            throw e;
+        }
+        boolean isValid = validate(entity);
+        T dup;
+        if (isValid) {
+            try {
+                if (extensionManager != null) {
+                    ExtensionResultHolder<MultiTenantCopyContext> contextResponse = new ExtensionResultHolder<MultiTenantCopyContext>();
+                    extensionManager.setupDuplicate(entity, contextResponse);
+                }
+                dup = performCopy(context, entity, copyHints, modifiers);
+            } catch (Exception e) {
+                LOG.error(String.format("Unable to duplicate entity %s:%s", entity.getClass().getName(), genericEntityService.getIdentifier(entity)), e);
+                throw ExceptionHelper.refineException(e);
+            } finally {
+                if (extensionManager != null) {
+                    extensionManager.tearDownDuplicate();
+                }
+            }
+        } else {
+            LOG.error(String.format("Entity not valid for duplication - %s:%s", entity.getClass().getName(), genericEntityService.getIdentifier(entity)));
+            throw new IllegalArgumentException(String.format("Entity not valid for duplication - %s:%s", entity.getClass().getName(), genericEntityService.getIdentifier(entity)));
+        }
+        return dup;
+    }
+
+    protected <T> T performCopy(final MultiTenantCopyContext context, final MultiTenantCloneable<T> entity, Map<String, String> copyHints, final EntityDuplicateModifier... modifiers) throws Exception {
+        context.getCopyHints().putAll(copyHints);
+        context.setForDuplicate(true);
+        persistCopyObjectTree(new CopyOperation<T, CloneNotSupportedException>() {
+            @Override
+            public T execute(T original) throws CloneNotSupportedException {
+                T response = entity.createOrRetrieveCopyInstance(context).getClone();
+                for (EntityDuplicateModifier modifier : modifiers) {
+                    modifier.modifyInitialDuplicateState(response);
+                }
+                return response;
+            }
+        }, (Class<T>) entity.getClass(), (T) entity, context);
+        return context.getClonedVersion((Class<T>) entity.getClass(), genericEntityService.getIdentifier(entity));
+    }
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.core.offer.domain;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -46,8 +46,6 @@ import org.broadleafcommerce.common.util.DateUtil;
 import org.broadleafcommerce.core.offer.service.type.OfferDiscountType;
 import org.broadleafcommerce.core.offer.service.type.OfferItemRestrictionRuleType;
 import org.broadleafcommerce.core.offer.service.type.OfferType;
-import org.broadleafcommerce.core.promotionMessage.domain.PromotionMessage;
-import org.broadleafcommerce.core.promotionMessage.domain.type.PromotionMessageType;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -93,6 +91,7 @@ import javax.persistence.Transient;
 })
 public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation {
 
+    public static final String EXCLUDE_OFFERCODE_COPY_HINT = "exclude-offerCodes";
     public static final long serialVersionUID = 1L;
 
     @Id
@@ -805,9 +804,11 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
         cloned.setRequiresRelatedTargetAndQualifiers(requiresRelatedTargetAndQualifiers);
         cloned.setTotalitarianOffer(totalitarianOffer);
         cloned.setType(getType());
-        for(OfferCode entry : offerCodes){
-            OfferCode clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
-            cloned.getOfferCodes().add(clonedEntry);
+        if (!BooleanUtils.toBoolean(context.getCopyHints().get(EXCLUDE_OFFERCODE_COPY_HINT))) {
+            for (OfferCode entry : offerCodes) {
+                OfferCode clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+                cloned.getOfferCodes().add(clonedEntry);
+            }
         }
         for(OfferQualifyingCriteriaXref entry : qualifyingItemCriteria){
             OfferQualifyingCriteriaXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
@@ -1,0 +1,22 @@
+package org.broadleafcommerce.core.offer.service;
+
+import org.broadleafcommerce.common.persistence.EntityDuplicateModifier;
+import org.broadleafcommerce.core.offer.domain.Offer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Modify new Offer duplicates before persistence
+ *
+ * @author Jeff Fischer
+ */
+@Component("blOfferDuplicateModifier")
+public class OfferDuplicateModifier implements EntityDuplicateModifier<Offer> {
+
+    @Override
+    public void modifyInitialDuplicateState(Offer copy) {
+        String currentName = copy.getName();
+        copy.setName("Copy Of ("+currentName+")");
+        copy.setStartDate(null);
+        copy.setEndDate(null);
+    }
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferService.java
@@ -288,4 +288,13 @@ public interface OfferService {
     public Boolean deleteOfferCode(OfferCode code);
 
     public Offer findOfferById(Long offerId);
+
+    /**
+     * Make a production copy of an offer.
+     *
+     * @param offerId
+     * @return
+     */
+    Offer duplicate(Long offerId);
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -21,6 +21,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.persistence.EntityDuplicateModifier;
+import org.broadleafcommerce.common.persistence.EntityDuplicator;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
 import org.broadleafcommerce.common.util.StreamCapableTransactionalOperationAdapter;
 import org.broadleafcommerce.common.util.StreamingTransactionCapableUtil;
@@ -112,6 +114,12 @@ public class OfferServiceImpl implements OfferService {
 
     @Resource(name="blStreamingTransactionCapableUtil")
     protected StreamingTransactionCapableUtil transUtil;
+
+    @Resource(name="blEntityDuplicator")
+    protected EntityDuplicator duplicator;
+
+    @Resource(name="blOfferDuplicateModifier")
+    protected EntityDuplicateModifier<Offer> offerDuplicateModifier;
 
     @Override
     public List<Offer> findAllOffers() {
@@ -616,6 +624,14 @@ public class OfferServiceImpl implements OfferService {
 
         offerCodeDao.delete(code);
         return true;
+    }
+
+    @Transactional("blTransactionManager")
+    @Override
+    public Offer duplicate(Long originalOfferId) {
+        Map<String, String> copyHints = new HashMap<String, String>();
+        copyHints.put(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, "true");
+        return duplicator.copy(OfferImpl.class, originalOfferId, copyHints, offerDuplicateModifier);
     }
 
     @Override


### PR DESCRIPTION
BroadleafCommerce/QA#3206

- Add an optional offer list grid filter for isActive. Becomes active when the `admin.offer.isactive.filter=true` property is set in a Spring property file.
- Add optional support for duplicating an entity. Includes support for an admin tool option. Becomes active when the `admin.entity.duplication.isactive=true` property is set in a Spring property file.