### PR TITLE
Remove error logging when product options aren't set during AddToCart

### DIFF
--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-workflow.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-workflow.xml
@@ -92,6 +92,7 @@
                 <property name="unloggedExceptionClasses">
                     <list>
                         <value>org.broadleafcommerce.core.inventory.service.InventoryUnavailableException</value>
+                        <value>org.broadleafcommerce.core.order.service.exception.RequiredAttributeNotProvidedException</value>
                     </list>
                 </property>
             </bean>
@@ -122,6 +123,7 @@
                 <property name="unloggedExceptionClasses">
                     <list>
                         <value>org.broadleafcommerce.core.inventory.service.InventoryUnavailableException</value>
+                        <value>org.broadleafcommerce.core.order.service.exception.RequiredAttributeNotProvidedException</value>
                     </list>
                 </property>
             </bean>


### PR DESCRIPTION
The error generated is noisy in the logs and never presents itself to the user on the frontend.

Changes Made:
- Added `RequiredAttributeNotProvidedException` to the list of `unloggedExceptionClasses`