### PR TITLE
Allow content targeting against arbitrary http request cookie values

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/config/AdminWebConfig.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/config/AdminWebConfig.java
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.admin.web.config;
+
+import org.broadleafcommerce.admin.web.rulebuilder.service.extension.CookieFieldServiceExtensionHandler;
+import org.broadleafcommerce.openadmin.web.rulebuilder.service.RuleBuilderFieldServiceExtensionManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * @author Jeff Fischer
+ */
+@Configuration
+public class AdminWebConfig {
+
+    @Bean
+    @ConditionalOnProperty("cookie.content.targeting.enabled")
+    public CookieFieldServiceExtensionHandler blCookieFieldServiceExtensionHandler(@Qualifier("blCookieRuleConfigs") List configs,
+                                                                                   @Qualifier("blRuleBuilderFieldServiceExtensionManager") RuleBuilderFieldServiceExtensionManager extensionManager) {
+        CookieFieldServiceExtensionHandler handler = new CookieFieldServiceExtensionHandler(extensionManager, configs);
+        return handler;
+    }
+
+}

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/extension/CookieFieldServiceExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/extension/CookieFieldServiceExtensionHandler.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.admin.web.rulebuilder.service.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.presentation.RuleIdentifier;
+import org.broadleafcommerce.core.rule.RuleDTOConfig;
+import org.broadleafcommerce.openadmin.web.rulebuilder.dto.FieldData;
+import org.broadleafcommerce.openadmin.web.rulebuilder.service.AbstractRuleBuilderFieldServiceExtensionHandler;
+import org.broadleafcommerce.openadmin.web.rulebuilder.service.RuleBuilderFieldServiceExtensionManager;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Add configured cookies as fields to request-based rule builder
+ *
+ * @author Jeff Fischer
+ */
+public class CookieFieldServiceExtensionHandler extends AbstractRuleBuilderFieldServiceExtensionHandler {
+
+    public static final String COOKIE_ATTRIBUTE_NAME = "_blCookieAttribute";
+
+    protected RuleBuilderFieldServiceExtensionManager extensionManager;
+    protected List<RuleDTOConfig> fieldConfigs;
+
+    public CookieFieldServiceExtensionHandler(RuleBuilderFieldServiceExtensionManager extensionManager, List<RuleDTOConfig> fieldConfigs) {
+        this.extensionManager = extensionManager;
+        this.fieldConfigs = fieldConfigs;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (isEnabled()) {
+            extensionManager.registerHandler(this);
+        }
+    }
+
+    @Override
+    public ExtensionResultStatusType addFields(List<FieldData> fields, String ruleFieldName, String dtoClassName) {
+        if (RuleIdentifier.REQUEST.equals(ruleFieldName)) {
+            for (RuleDTOConfig fieldConfig : fieldConfigs) {
+                fields.add(new FieldData.Builder()
+                    .label(fieldConfig.getLabel())
+                    .name(fieldConfig.getFieldName())
+                    .operators(fieldConfig.getOperators())
+                    .options(fieldConfig.getOptions())
+                    .type(fieldConfig.getType())
+                    .skipValidation(true)
+                    .overrideEntityKey(COOKIE_ATTRIBUTE_NAME)
+                    .build());
+            }
+            return ExtensionResultStatusType.HANDLED_CONTINUE;
+        }
+
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+
+}

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/extension/CookieFieldServiceExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/extension/CookieFieldServiceExtensionHandler.java
@@ -29,7 +29,22 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 
 /**
- * Add configured cookies as fields to request-based rule builder
+ * Add configured cookies as fields to request-based rule builder.
+ * </p>
+ * Configuration is generally as easy as enabling the feature
+ * via a property and then configuring one or more cookie configurations.
+ * </p>
+ * Add {@code cookie.content.targeting.enabled=true} to a property file visible to both admin and site (i.e. common-shared.properties)
+ * </p>
+ * Add a cookie configuration to your Spring xml or Java configuration. Sample below demonstrated Java-based config:
+ * {@code
+ *    @Merge("blCookieRuleConfigs")
+ *    public RuleDTOConfig myCookieRuleDTOConfig() {
+ *        RuleDTOConfig config = new RuleDTOConfig("myFieldName", "myLabel");
+ *        config.setAlternateName("cookieName");
+ *        return config;
+ *    }
+ * }
  *
  * @author Jeff Fischer
  */

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
@@ -550,7 +550,7 @@ public class DataDTOToMVELTranslator {
 
                 switch(type) {
                     case BOOLEAN:
-                        response.append(value[j]);
+                        response.append(parsableVal);
                         break;
                     case DECIMAL:
                         try {
@@ -631,7 +631,7 @@ public class DataDTOToMVELTranslator {
                         if (!ignoreQuotes) {
                             response.append("\"");
                         }
-                        response.append(value[j]);
+                        response.append(parsableVal);
                         if (!ignoreQuotes) {
                             response.append("\"");
                         }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
@@ -550,7 +550,7 @@ public class DataDTOToMVELTranslator {
 
                 switch(type) {
                     case BOOLEAN:
-                        response.append(parsableVal);
+                        response.append(value[j]);
                         break;
                     case DECIMAL:
                         try {
@@ -625,14 +625,16 @@ public class DataDTOToMVELTranslator {
                         response.append("\")");
                         break;
                     default:
+                        String stringVersionState = String.valueOf(value[j]);
+                        boolean alreadyHasQuotes = stringVersionState.startsWith("\"") && stringVersionState.endsWith("\"");
                         if (ignoreCase) {
                             response.append("MvelHelper.toUpperCase(");
                         }
-                        if (!ignoreQuotes) {
+                        if (!ignoreQuotes && !alreadyHasQuotes) {
                             response.append("\"");
                         }
-                        response.append(parsableVal);
-                        if (!ignoreQuotes) {
+                        response.append(stringVersionState);
+                        if (!ignoreQuotes && !alreadyHasQuotes) {
                             response.append("\"");
                         }
                         if (ignoreCase) {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleFilter.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleFilter.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.cookie;
+
+import org.broadleafcommerce.common.web.filter.AbstractIgnorableOncePerRequestFilter;
+import org.broadleafcommerce.common.web.filter.FilterOrdered;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Populate configured cookie values on the http request thread for use by MVEL request-based rules
+ */
+public class CookieRuleFilter extends AbstractIgnorableOncePerRequestFilter {
+
+    protected CookieRuleRequestProcessor processor;
+
+    public CookieRuleFilter(CookieRuleRequestProcessor processor) {
+        this.processor = processor;
+    }
+
+    @Override
+    protected void doFilterInternalUnlessIgnored(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
+        ServletWebRequest request = new ServletWebRequest(httpServletRequest, httpServletResponse);
+        try {
+            processor.process(request);
+            filterChain.doFilter(httpServletRequest, httpServletResponse);
+        } finally {
+            processor.postProcess(request);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return FilterOrdered.POST_SECURITY_LOW;
+    }
+}
+

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleRequestProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleRequestProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.cookie;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.security.util.CookieUtils;
+import org.broadleafcommerce.common.util.BLCRequestUtils;
+import org.broadleafcommerce.common.web.AbstractBroadleafWebRequestProcessor;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.broadleafcommerce.core.rule.RuleDTOConfig;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Populate configured cookie values on the http request thread for use by MVEL request-based rules
+ *
+ * @author Jeff Fischer
+ */
+public class CookieRuleRequestProcessor extends AbstractBroadleafWebRequestProcessor {
+
+    public static final String FORWARD_HEADER = "X-FORWARDED-FOR";
+    public static final String COOKIE_ATTRIBUTE_NAME = "_blCookieAttribute";
+    protected static final String BLC_RULE_MAP_PARAM = "blRuleMap";
+
+    protected CookieUtils cookieUtils;
+    protected List<RuleDTOConfig> configs;
+
+    public CookieRuleRequestProcessor(List<RuleDTOConfig> configs, CookieUtils cookieUtils) {
+        this.cookieUtils = cookieUtils;
+        this.configs = configs;
+    }
+
+    @Override
+    public void process(WebRequest request) {
+        if (request instanceof ServletWebRequest) {
+            ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+            Map proxy = (Map) BLCRequestUtils.getSessionAttributeIfOk(request, COOKIE_ATTRIBUTE_NAME);
+            if (proxy == null) {
+                proxy = getVals(servletWebRequest);
+                BLCRequestUtils.setSessionAttributeIfOk(request, COOKIE_ATTRIBUTE_NAME, proxy);
+            }
+            BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().put(COOKIE_ATTRIBUTE_NAME, proxy);
+
+            Map<String, Object> ruleMap = getRuleMapFromRequest(request);
+            ruleMap.put(COOKIE_ATTRIBUTE_NAME, proxy);
+            request.setAttribute(BLC_RULE_MAP_PARAM, ruleMap, WebRequest.SCOPE_REQUEST);
+        }
+    }
+
+    protected Map<String,Object> getRuleMapFromRequest(WebRequest request) {
+        Map<String,Object> ruleMap = (Map<String, Object>) request.getAttribute(BLC_RULE_MAP_PARAM, WebRequest.SCOPE_REQUEST);
+        if (ruleMap == null) {
+            ruleMap = new HashMap<>();
+        }
+        return ruleMap;
+    }
+
+    protected Map<String, String> getVals(ServletWebRequest request) {
+        Map<String, String> vals = new HashMap<String, String>();
+        for (RuleDTOConfig config : configs) {
+            if (config.getAlternateName() != null) {
+                String val = cookieUtils.getCookieValue(request.getRequest(), config.getAlternateName());
+                if (!StringUtils.isEmpty(val)) {
+                    vals.put(config.getFieldName(), val);
+                }
+            }
+        }
+        return vals;
+    }
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleRequestProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/cookie/CookieRuleRequestProcessor.java
@@ -32,7 +32,21 @@ import java.util.Map;
 
 /**
  * Populate configured cookie values on the http request thread for use by MVEL request-based rules
- *
+ * </p>
+ * Configuration is generally as easy as enabling the feature
+ * via a property and then configuring one or more cookie configurations.
+ * </p>
+ * Add {@code cookie.content.targeting.enabled=true} to a property file visible to both admin and site (i.e. common-shared.properties)
+ * </p>
+ * Add a cookie configuration to your Spring xml or Java configuration. Sample below demonstrated Java-based config:
+ * {@code
+ *    @Merge("blCookieRuleConfigs")
+ *    public RuleDTOConfig myCookieRuleDTOConfig() {
+ *        RuleDTOConfig config = new RuleDTOConfig("myFieldName", "myLabel");
+ *        config.setAlternateName("cookieName");
+ *        return config;
+ *    }
+ * }
  * @author Jeff Fischer
  */
 public class CookieRuleRequestProcessor extends AbstractBroadleafWebRequestProcessor {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rule/RuleDTOConfig.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rule/RuleDTOConfig.java
@@ -1,0 +1,109 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.rule;
+
+import org.broadleafcommerce.common.presentation.RuleOperatorType;
+import org.broadleafcommerce.common.presentation.RuleOptionType;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+
+/**
+ * Provide confiration information about arbitrary field data used to drive rule builders in the admin. Can be employed
+ * to create dynamic RuleBuilderFieldService implementations with field data being derived from external sources.
+ *
+ * @author Jeff Fischer
+ */
+public class RuleDTOConfig {
+
+    /**
+     * Name of the field as it appears in MVEL
+     */
+    protected String fieldName;
+    /**
+     * The name as it appears to the user in MVEL. Specify a i18n key here instead and declare the key/value pair in a message property file for translatable labels.
+     */
+    protected String label;
+    /**
+     * The type of operators for the rule
+     */
+    protected String operators = RuleOperatorType.TEXT_LIST;
+    /**
+     * The type of options to provide to the user for selection or entry
+     */
+    protected String options = RuleOptionType.EMPTY_COLLECTION;
+    /**
+     * The type of the value being entered by the user
+     */
+    protected SupportedFieldType type = SupportedFieldType.STRING;
+    /**
+     * An alternate name for the field. This is useful when the external source has a different name for the field than what you want to use in the rule builder.
+     */
+    protected String alternateName;
+
+    public RuleDTOConfig(String fieldName, String label) {
+        this.fieldName = fieldName;
+        this.label = label;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getOperators() {
+        return operators;
+    }
+
+    public void setOperators(String operators) {
+        this.operators = operators;
+    }
+
+    public String getOptions() {
+        return options;
+    }
+
+    public void setOptions(String options) {
+        this.options = options;
+    }
+
+    public SupportedFieldType getType() {
+        return type;
+    }
+
+    public void setType(SupportedFieldType type) {
+        this.type = type;
+    }
+
+    public String getAlternateName() {
+        return alternateName;
+    }
+
+    public void setAlternateName(String alternateName) {
+        this.alternateName = alternateName;
+    }
+}


### PR DESCRIPTION
BroadleafCommerce/QA#3216

- Support an arbitrary field configuration pattern for rule builder field services. 
- Support adding arbitrary cookie names as http request rule builder options. 
- Support harvesting cookie key/value pairs based on configuration for use by http request based MVEL during content targeting in the site.

Review the javadocs on org.broadleafcommerce.admin.web.rulebuilder.service.extension.CookieFieldServiceExtensionHandler for configuration instructions.