### PR TITLE
Allow an EntityForm to contain file upload inputs

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
@@ -63,6 +63,7 @@ public class EntityForm {
     protected String entityType;
     protected String mainEntityName;
     protected String sectionKey;
+    protected String encType;
     protected Boolean readOnly = false;
 
     /**
@@ -110,14 +111,14 @@ public class EntityForm {
     protected Map<String, Object> attributes = new HashMap<String, Object>();
 
     /**
-     * @return a flattened, field name keyed representation of all of 
+     * @return a flattened, field name keyed representation of all of
      * the fields in all of the groups for this form. This set will also includes all of the dynamic form
      * fields.
-     * 
+     *
      * Note that if there collisions between the dynamic form fields and the fields on this form (meaning that they
      * have the same name), then the dynamic form field will be excluded from the map and the preference will be given
      * to first-level entities
-     * 
+     *
      * @see {@link #getFields(boolean)}
      */
     public Map<String, Field> getFields() {
@@ -150,7 +151,7 @@ public class EntityForm {
 
     /**
      * Clears out the cached 'fields' variable which is used to render the form on the frontend. Use this method
-     * if you want to force the entityForm to rebuild itself based on the tabs and groups that have been assigned and 
+     * if you want to force the entityForm to rebuild itself based on the tabs and groups that have been assigned and
      * populated
      */
     public void clearFieldsMap() {
@@ -175,7 +176,7 @@ public class EntityForm {
     /**
      * Convenience method for grabbing a grid by its collection field name. This is very similar to {@link #findField(String)}
      * but differs in that this only searches through the sub collections for the current entity
-     * 
+     *
      * @param collectionFieldName the field name of the collection on the top-level entity
      * @return
      */
@@ -640,6 +641,17 @@ public class EntityForm {
 
     public void setMainEntityName(String mainEntityName) {
         this.mainEntityName = mainEntityName;
+    }
+
+    public String getEncType() {
+        return encType;
+    }
+
+    /**
+     * Changes the encoding type on the built {@code <form>}
+     */
+    public void setEncType(String encType) {
+        this.encType = encType;
     }
 
     public String getSectionKey() {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -646,7 +646,7 @@ $(document).ready(function() {
      * This event handler is fired for `change` type events.
      * It gets the field's id, original value, and new value to be used in the entity form's change map.
      */
-    $body.on('change', 'select, input:radio, input.query-builder-selectize-input', function() {
+    $body.on('change', 'select, input:radio, input.query-builder-selectize-input, input:file', function() {
         BLCAdmin.entityForm.status.handleEntityFormChanges(this);
     });
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -154,12 +154,33 @@
             var submit = BLCAdmin.runSubmitHandlers($form);
 
             if (submit) {
-                BLC.ajax({
-                    url: $form.attr('action'),
-                    dataType: "json",
-                    type: "POST",
-                    data: BLCAdmin.serializeArray($form)
-                }, function (data) {
+                var options = {};
+                if ($form.attr('enctype') == 'multipart/form-data') {
+                    // Got some files I need to upload, use FormData
+                    // so that they are POSTed correctly
+                    // Un-disabling these fields allows us to replicate the same
+                    // functionality as BLC.serializeArray()
+                    var $disabledFields = $form.find(':disabled').attr('disabled', false);
+                    var formData = new FormData($form[0]);
+                    $disabledFields.attr('disabled', true);
+                    options = {
+                        url: $form.attr('action'),
+                        dataType: "json",
+                        type: "POST",
+                        contentType: false,
+                        processData: false,
+                        data: formData
+                    };
+                } else {
+                    // normal case, no multipart
+                    options = {
+                        url: $form.attr('action'),
+                        dataType: "json",
+                        type: "POST",
+                        data: BLCAdmin.serializeArray($form)
+                    };
+                }
+                BLC.ajax(options, function (data) {
                     BLCAdmin.entityForm.hideActionSpinner();
 
                     $(".errors, .error, .tab-error-indicator, .tabError").remove();

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -335,7 +335,14 @@ $(document).ready(function() {
         var $form = BLCAdmin.getForm($tab);
         var href = $(this).attr('href').replace('#', '');
         var currentAction = $form.attr('action');
-        var tabUrl = encodeURI(currentAction + '/1/' + tabKey);
+        var tabUrlSlug = '/1/' + tabKey;
+        if (currentAction.indexOf('?') >= 0) {
+            var questionIdx = currentAction.indexOf('?');
+            currentAction = currentAction.substring(0, questionIdx) + tabUrlSlug + currentAction.substring(questionIdx, currentAction.length);
+        } else {
+            currentAction += tabUrlSlug;
+        }
+        var tabUrl = encodeURI(currentAction);
 
      	if (tabs_action && tabs_action.indexOf(tabUrl + '++') == -1 && tabs_action.indexOf(tabUrl) >= 0) {
      		tabs_action = tabs_action.replace(tabUrl, tabUrl + '++');

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -161,7 +161,20 @@
                     // Un-disabling these fields allows us to replicate the same
                     // functionality as BLC.serializeArray()
                     var $disabledFields = $form.find(':disabled').attr('disabled', false);
-                    var formData = new FormData($form[0]);
+                    var formData = new FormData();
+                    // First append all the files (works even if there are multiple
+                    // in the same file input)
+                    $.each($form.find("input[type='file']"), function(i, tag) {
+                        $.each($(tag)[0].files, function(i, file) {
+                            formData.append(tag.name, file);
+                        });
+                    });
+                    // Then get the other normal properties
+                    var params = $form.serializeArray();
+                    $.each(params, function (i, val) {
+                        formData.append(val.name, val.value);
+                    });
+                    // clean up after ourselves and put disabled back
                     $disabledFields.attr('disabled', true);
                     options = {
                         url: $form.attr('action'),

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
@@ -44,8 +44,8 @@
                       method="POST"
                       th:classappend="${(additionalClasses == null ? '' : additionalClasses + ' ')
                          + (additionalControllerClasses == null ? '' : additionalControllerClasses)}"
-                      th:action="@{${currentUrl}}">
-
+                      th:action="@{${currentUrl}}"
+                      th:attrappend="enctype=${entityForm.encType!=null}?${entityForm.encType}">
                 <span style="display: none;" id="previewurl"
                       th:attr="data-href=@{/sandbox/preview(ceilingEntity=*{ceilingEntityClassname}, id=*{id}, directPreview=true)}"></span>
 


### PR DESCRIPTION
While this does not actually change any field definitions to do file inputs, this allows an extra hook for others to build custom field renderers (and Spring controller endpoints) that expose this within the context of an `EntityForm`. Deep hooks like the ones in this PR are needed because the encoding type of the entire `EntityForm` relies on the `<form>` tag being `multipart/form-data` to send the requests correctly.