### PR TITLE
Added ability to handle extended map entity xrefs through the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
@@ -143,7 +143,7 @@ public class MapStructurePersistenceModule extends BasicPersistenceModule {
                     );
                 } else {
                     String valueClassName = mapStructure.getValueClassName();
-                    Class<?>[] entities = persistenceManager.getDynamicEntityDao().getAllPolymorphicEntitiesFromCeiling(Class.forName(valueClassName));
+                    Class<?>[] entities = persistenceManager.getPolymorphicEntities(valueClassName);
                     valueMergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
                         valueClassName,
                         entities,

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
@@ -142,9 +142,11 @@ public class MapStructurePersistenceModule extends BasicPersistenceModule {
                         MergedPropertyType.MAPSTRUCTUREVALUE
                     );
                 } else {
+                    String valueClassName = mapStructure.getValueClassName();
+                    Class<?>[] entities = persistenceManager.getDynamicEntityDao().getAllPolymorphicEntitiesFromCeiling(Class.forName(valueClassName));
                     valueMergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                        mapStructure.getValueClassName(), 
-                        new Class[]{Class.forName(mapStructure.getValueClassName())},
+                        valueClassName,
+                        entities,
                         null, 
                         new String[]{}, 
                         new ForeignKey[]{}, 
@@ -220,15 +222,17 @@ public class MapStructurePersistenceModule extends BasicPersistenceModule {
                     MergedPropertyType.MAPSTRUCTUREVALUE
                 );
             } else {
+                String valueClassName = mapStructure.getValueClassName();
+                Class<?>[] mapEntities = persistenceManager.getPolymorphicEntities(valueClassName);
                 valueUnfilteredMergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                    mapStructure.getValueClassName(), 
-                    new Class[]{Class.forName(mapStructure.getValueClassName())},
-                    null, 
-                    new String[]{}, 
-                    new ForeignKey[]{}, 
+                    valueClassName,
+                    mapEntities,
+                    null,
+                    new String[]{},
+                    new ForeignKey[]{},
                     MergedPropertyType.MAPSTRUCTUREVALUE,
-                    persistencePerspective.getPopulateToOneFields(), 
-                    persistencePerspective.getIncludeFields(), 
+                    persistencePerspective.getPopulateToOneFields(),
+                    persistencePerspective.getIncludeFields(),
                     persistencePerspective.getExcludeFields(),
                     persistencePerspective.getConfigurationKey(),
                     ""
@@ -328,12 +332,14 @@ public class MapStructurePersistenceModule extends BasicPersistenceModule {
                     MergedPropertyType.MAPSTRUCTUREVALUE
                 );
             } else {
+                String valueClassName = mapStructure.getValueClassName();
+                Class<?>[] mapEntities = persistenceManager.getPolymorphicEntities(valueClassName);
                 valueUnfilteredMergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                    mapStructure.getValueClassName(), 
-                    new Class[]{Class.forName(mapStructure.getValueClassName())},
-                    null, 
-                    new String[]{}, 
-                    new ForeignKey[]{}, 
+                    valueClassName,
+                    mapEntities,
+                    null,
+                    new String[]{},
+                    new ForeignKey[]{},
                     MergedPropertyType.MAPSTRUCTUREVALUE,
                     persistencePerspective.getPopulateToOneFields(), 
                     persistencePerspective.getIncludeFields(), 
@@ -482,9 +488,11 @@ public class MapStructurePersistenceModule extends BasicPersistenceModule {
                     MergedPropertyType.MAPSTRUCTUREVALUE
                 );
             } else {
+                String valueClassName = mapStructure.getValueClassName();
+                Class<?>[] mapEntities = persistenceManager.getPolymorphicEntities(valueClassName);
                 valueUnfilteredMergedProperties = persistenceManager.getDynamicEntityDao().getMergedProperties(
-                    mapStructure.getValueClassName(), 
-                    new Class[]{Class.forName(mapStructure.getValueClassName())},
+                    valueClassName,
+                    mapEntities,
                     null, 
                     new String[]{}, 
                     new ForeignKey[]{}, 


### PR DESCRIPTION
This PR handles the case when an Xref entity is extended and participates in an `@AdminPresentationMap`.

The changes allow for adding properties from extensions of the base class.