### PR TITLE
Allow passed in arguments to have precedence over blSelectize defaults

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1180,13 +1180,13 @@ $.fn.blSelectize = function (settings_user) {
             settings_user = {};
         }
         // add default settings here
-        settings_user['dropdownParent'] = 'body';
-        settings_user['hideSelected'] = true;
-        settings_user['selectOnTab'] = true;
-        settings_user['plugins'] = ['clear_on_type', 'enter_key_blur'];
-        settings_user['placeholder'] = 'Click here to select ...';
-        settings_user['positionDropdown'] = 'auto';
-        settings_user['onInitialize'] = function() {
+        settings_user['dropdownParent'] = settings_user['dropdownParent'] || 'body';
+        settings_user['hideSelected'] = settings_user['hideSelected'] || true;
+        settings_user['selectOnTab'] = settings_user['selectOnTab'] || true;
+        settings_user['plugins'] = settings_user['plugins'] || ['clear_on_type', 'enter_key_blur'];
+        settings_user['placeholder'] = settings_user['placeholder'] || 'Click here to select ...';
+        settings_user['positionDropdown'] = settings_user['positionDropdown'] || 'auto';
+        settings_user['onInitialize'] = settings_user['onInitialize'] || function() {
             if (Object.keys(this.options).length <= 1) {
                 // Remove the dropdown css
                 this.$control.addClass('remove-caret');


### PR DESCRIPTION
This change makes it so that the defaults added by blSelectize can be ignored by defining the setting via the arguments to `blSelectize`. This is helpful, for example, if you would like to remove the `clear_on_type` plugin. With this change now you would call `blSelectize` with an object that has the key `plugins` and set it to the list of plugins or an empty list and that list of plugins will be used instead of the defaults added by `blSelectize`