### PR TITLE
Added support for setting map values to null through fields such as custom fields

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -336,8 +336,6 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 }
                 String value = property.getValue();
                 if (metadata != null) {
-                    Boolean mutable = metadata.getMutable();
-                    Boolean readOnly = metadata.getReadOnly();
 
                     if (metadata.getFieldType().equals(SupportedFieldType.BOOLEAN)) {
                         if (value == null) {
@@ -345,55 +343,46 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                         }
                     }
 
-                    if ((mutable == null || mutable) && (readOnly == null || !readOnly) && property.getEnabled()) {
+                    if (attemptToPopulateValue(property, fieldManager, instance, setId, metadata, entity, value)) {
+                        boolean isValid = true;
+                        PopulateValueRequest request = new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd());
+                        handled = false;
                         if (value != null) {
-                            handled = false;
-                            PopulateValueRequest request = new PopulateValueRequest(setId,
-                                    fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd());
-
-                            boolean attemptToPopulate = true;
                             for (PopulateValueRequestValidator validator : populateValidators) {
                                 PropertyValidationResult validationResult = validator.validate(request, instance);
                                 if (!validationResult.isValid()) {
                                     entity.addValidationError(property.getName(), validationResult.getErrorMessage());
-                                    attemptToPopulate = false;
+                                    isValid = false;
                                 }
                             }
-
-                            if (attemptToPopulate) {
-                                try {
-                                    boolean isBreakDetected = false;
-                                    for (FieldPersistenceProvider fieldPersistenceProvider : fieldPersistenceProviders) {
-                                        if (!isBreakDetected || fieldPersistenceProvider.alwaysRun()) {
-                                            MetadataProviderResponse response = fieldPersistenceProvider.populateValue(request, instance);
-                                            if (MetadataProviderResponse.NOT_HANDLED != response) {
-                                                handled = true;
-                                            }
-                                            if (MetadataProviderResponse.HANDLED_BREAK == response) {
-                                                isBreakDetected = true;
-                                            }
+                        }
+                        if (isValid) {
+                            try {
+                                boolean isBreakDetected = false;
+                                for (FieldPersistenceProvider fieldPersistenceProvider : fieldPersistenceProviders) {
+                                    if (!isBreakDetected || fieldPersistenceProvider.alwaysRun() && (value != null || fieldPersistenceProvider.canHandlePopulateNull())) {
+                                        MetadataProviderResponse response = fieldPersistenceProvider.populateValue(request, instance);
+                                        if (MetadataProviderResponse.NOT_HANDLED != response) {
+                                            handled = true;
+                                        }
+                                        if (MetadataProviderResponse.HANDLED_BREAK == response) {
+                                            isBreakDetected = true;
                                         }
                                     }
-                                    if (!handled) {
-                                        defaultFieldPersistenceProvider.populateValue(new PopulateValueRequest(setId,
-                                                fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd()), instance);
+                                }
+                                if (!handled) {
+                                    if (value == null) {
+                                        property.setIsDirty(true);
                                     }
-                                } catch (ParentEntityPersistenceException | javax.validation.ValidationException e) {
-                                    entityPersistenceException = e;
-                                    cleanupFailedPersistenceAttempt(instance);
-                                    break;
+                                    defaultFieldPersistenceProvider.populateValue(new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd()), instance);
+                                    if (value == null) {
+                                        fieldManager.setFieldValue(instance, property.getName(), null);
+                                    }
                                 }
-                            }
-                        } else {
-                            try {
-                                if (fieldManager.getFieldValue(instance, property.getName()) != null && !entity.isPreAdd() && (metadata.getFieldType() != SupportedFieldType.ID || setId) && metadata.getFieldType() != SupportedFieldType.PASSWORD) {
-                                    property.setIsDirty(true);
-                                    PopulateValueRequest request = new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd());
-                                    defaultFieldPersistenceProvider.populateValue(request, instance);
-                                    fieldManager.setFieldValue(instance, property.getName(), null);
-                                }
-                            } catch (FieldNotAvailableException e) {
-                                throw new IllegalArgumentException(e);
+                            } catch (ParentEntityPersistenceException | javax.validation.ValidationException e) {
+                                entityPersistenceException = e;
+                                cleanupFailedPersistenceAttempt(instance);
+                                break;
                             }
                         }
                     }
@@ -433,6 +422,28 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             session.setFlushMode(originalFlushMode);
         }
         return instance;
+    }
+
+    protected boolean attemptToPopulateValue(Property property, FieldManager fieldManager, Serializable instance,
+                                             Boolean setId, BasicFieldMetadata metadata, Entity entity, String value) throws IllegalAccessException {
+        Boolean mutable = metadata.getMutable();
+        Boolean readOnly = metadata.getReadOnly();
+        boolean generalConditionsMet = (mutable == null || mutable) && (readOnly == null || !readOnly) && property.getEnabled();
+
+        if (generalConditionsMet && value == null) {
+            boolean currentValueIsNotNull = false;
+            try {
+                currentValueIsNotNull = fieldManager.getFieldValue(instance, property.getName()) != null;
+            } catch (FieldNotAvailableException e) {
+                throw new IllegalArgumentException(e);
+            }
+
+            boolean valueIsNotNullId = metadata.getFieldType() != SupportedFieldType.ID || setId;
+            boolean valueIsNotPassword = metadata.getFieldType() != SupportedFieldType.PASSWORD;
+
+            return currentValueIsNotNull && !entity.isPreAdd() && valueIsNotNullId && valueIsNotPassword;
+        }
+        return generalConditionsMet;
     }
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/AbstractFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/AbstractFieldPersistenceProvider.java
@@ -86,4 +86,10 @@ public abstract class AbstractFieldPersistenceProvider implements FieldPersisten
     public boolean alwaysRun() {
         return false;
     }
+
+    @Override
+    public boolean canHandlePopulateNull() {
+        return false;
+    }
+
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/FieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/FieldPersistenceProvider.java
@@ -113,4 +113,10 @@ public interface FieldPersistenceProvider extends Ordered {
      * @return if this provider should always run
      */
     boolean alwaysRun();
+
+    /**
+     * If the provider should handle populating null values or if it should delegate to the default persistence provider
+     * @return
+     */
+    boolean canHandlePopulateNull();
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.value.ValueAssignable;
@@ -90,9 +91,7 @@ public class MapFieldPersistenceProvider extends BasicFieldPersistenceProvider {
                 } catch (FieldNotAvailableException e) {
                     throw new IllegalArgumentException(e);
                 }
-                dirty = persistValue
-                        || (assignableValue != null && assignableValue.getValue() == null && populateValueRequest.getProperty().getValue() != null)
-                        || (assignableValue != null && !assignableValue.getValue().equals(populateValueRequest.getProperty().getValue()));
+                dirty = persistValue || (assignableValue != null && ObjectUtils.notEqual(assignableValue.getValue(), populateValueRequest.getProperty().getValue()));
                 if (dirty) {
                     updateAssignableValue(populateValueRequest, instance, parent, valueType, persistValue, assignableValue);
                 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
@@ -166,6 +166,11 @@ public class MapFieldPersistenceProvider extends BasicFieldPersistenceProvider {
             parent = populateValueRequest.getPersistenceManager().getDynamicEntityDao().merge(parent);
             assignableValue = establishAssignableValue(populateValueRequest, parent);
         }
+        if (populateValueRequest.getProperty().getValue() == null) {
+            populateValueRequest.getPersistenceManager().getDynamicEntityDao()
+                .getStandardEntityManager().remove(assignableValue);
+            return;
+        }
         String key = populateValueRequest.getProperty().getName().substring(populateValueRequest
                 .getProperty().getName().indexOf(FieldManager.MAPFIELDSEPARATOR) + FieldManager
                 .MAPFIELDSEPARATOR.length(), populateValueRequest.getProperty().getName().length());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/MapFieldPersistenceProvider.java
@@ -32,9 +32,11 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.provide
 import org.broadleafcommerce.openadmin.server.service.type.MetadataProviderResponse;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.List;
+
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 
@@ -150,6 +152,11 @@ public class MapFieldPersistenceProvider extends BasicFieldPersistenceProvider {
     @Override
     public int getOrder() {
         return FieldPersistenceProvider.MAP_FIELD;
+    }
+
+    @Override
+    public boolean canHandlePopulateNull() {
+        return true;
     }
 
     protected void updateAssignableValue(PopulateValueRequest populateValueRequest, Serializable instance, Object parent, Class<?>


### PR DESCRIPTION
Currently you're unable to unset values set through CustomFields (or at least for something like ProductAttributes). This was because the BasicPersistenceModule would not run through custom FieldPersistenceProviders if the value was null and the way the default FieldPersistenceProvider handled null map values would result in no change to the database. The change made was to add a function to FieldPersistenceProviders to ask if they supported populating null values and if so we would use it to handle the null value. If no FieldPersistenceProviders are found meeting that criteria the default FieldPersistenceProvider is used like it was before.

Specifically referring to the MapFieldPersistenceProvider, the entry in the map still remains but it's value is set to null.