### PR TITLE
Cannot Edit page "Featured Armageddon" in the Admin: Incorrectly Marking Page Name as Too Long

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityForm.java
@@ -137,11 +137,11 @@ public class EntityForm {
         for (Entry<String, EntityForm> entry : dynamicForms.entrySet()) {
             Map<String, Field> dynamicFormFields = entry.getValue().getFields();
             for (Entry<String, Field> dynamicField : dynamicFormFields.entrySet()) {
-                if (fields.containsKey(dynamicField.getKey()) && LOG.isDebugEnabled()) {
-                    LOG.debug("Excluding dynamic field " + StringUtil.sanitize(dynamicField.getKey()) +
-                            " as there is already an occurrence in this entityForm");
-                } else {
+                if (!fields.containsKey(dynamicField.getKey())) {
                     fields.put(dynamicField.getKey(), dynamicField.getValue());
+                } else if (LOG.isDebugEnabled()) {
+                    LOG.debug("Excluding dynamic field " + StringUtil.sanitize(dynamicField.getKey()) +
+                                " as there is already an occurrence in this entityForm");
                 }
             }
         }


### PR DESCRIPTION
BroadleafCommerce/QA#2919
Fix Page name is too long
Looks like if log level was higher then debug, field "Name" (that has entity property name "description") were overridden by dynamic form field "description".