### PR TITLE
Added support for fieldComponentRendererTemplate on AdminPresentation

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -68,7 +68,9 @@ public class BasicFieldMetadata extends FieldMetadata {
     protected String broadleafEnumeration;
     protected Boolean hideEnumerationIfEmpty;
     protected SupportedFieldType fieldComponentRenderer;
+    protected String fieldComponentRendererTemplate;
     protected SupportedFieldType gridFieldComponentRenderer;
+    private String gridFieldComponentRendererTemplate;
     protected Boolean readOnly;
     protected Map<String, List<Map<String, String>>> validationConfigurations = new HashMap<>(5);
     protected Boolean requiredOverride;
@@ -312,6 +314,22 @@ public class BasicFieldMetadata extends FieldMetadata {
 
     public void setGridFieldComponentRenderer(SupportedFieldType gridFieldComponentRenderer) {
         this.gridFieldComponentRenderer = gridFieldComponentRenderer;
+    }
+
+    public String getFieldComponentRendererTemplate() {
+        return fieldComponentRendererTemplate;
+    }
+
+    public void setFieldComponentRendererTemplate(String fieldComponentRendererTemplate) {
+        this.fieldComponentRendererTemplate = fieldComponentRendererTemplate;
+    }
+
+    public String getGridFieldComponentRendererTemplate() {
+        return gridFieldComponentRendererTemplate;
+    }
+
+    public void setGridFieldComponentRendererTemplate(String gridFieldComponentRendererTemplate) {
+        this.gridFieldComponentRendererTemplate = gridFieldComponentRendererTemplate;
     }
 
     public Boolean getReadOnly() {
@@ -633,6 +651,9 @@ public class BasicFieldMetadata extends FieldMetadata {
         metadata.broadleafEnumeration = broadleafEnumeration;
         metadata.hideEnumerationIfEmpty = hideEnumerationIfEmpty;
         metadata.fieldComponentRenderer = fieldComponentRenderer;
+        metadata.fieldComponentRendererTemplate = fieldComponentRendererTemplate;
+        metadata.gridFieldComponentRenderer = gridFieldComponentRenderer;
+        metadata.gridFieldComponentRendererTemplate = gridFieldComponentRendererTemplate;
         metadata.readOnly = readOnly;
         metadata.requiredOverride = requiredOverride;
         metadata.tooltip = tooltip;
@@ -716,6 +737,15 @@ public class BasicFieldMetadata extends FieldMetadata {
             return false;
         }
         if (fieldComponentRenderer != null ? !fieldComponentRenderer.equals(metadata.fieldComponentRenderer) : metadata.fieldComponentRenderer != null) {
+            return false;
+        }
+        if (fieldComponentRendererTemplate != null ? !fieldComponentRendererTemplate.equals(metadata.fieldComponentRendererTemplate) : metadata.fieldComponentRendererTemplate != null) {
+            return false;
+        }
+        if (gridFieldComponentRenderer != null ? !gridFieldComponentRenderer.equals(metadata.gridFieldComponentRenderer) : metadata.gridFieldComponentRenderer != null) {
+            return false;
+        }
+        if (gridFieldComponentRendererTemplate != null ? !gridFieldComponentRendererTemplate.equals(metadata.gridFieldComponentRendererTemplate) : metadata.gridFieldComponentRendererTemplate != null) {
             return false;
         }
         if (columnWidth != null ? !columnWidth.equals(metadata.columnWidth) : metadata.columnWidth != null) {
@@ -892,6 +922,9 @@ public class BasicFieldMetadata extends FieldMetadata {
         result = 31 * result + (broadleafEnumeration != null ? broadleafEnumeration.hashCode() : 0);
         result = 31 * result + (hideEnumerationIfEmpty != null ? hideEnumerationIfEmpty.hashCode() : 0);
         result = 31 * result + (fieldComponentRenderer != null ? fieldComponentRenderer.hashCode() : 0);
+        result = 31 * result + (fieldComponentRendererTemplate != null ? fieldComponentRendererTemplate.hashCode() : 0);
+        result = 31 * result + (gridFieldComponentRenderer != null ? gridFieldComponentRenderer.hashCode() : 0);
+        result = 31 * result + (gridFieldComponentRendererTemplate != null ? gridFieldComponentRendererTemplate.hashCode() : 0);
         result = 31 * result + (readOnly != null ? readOnly.hashCode() : 0);
         result = 31 * result + (validationConfigurations != null ? validationConfigurations.hashCode() : 0);
         result = 31 * result + (requiredOverride != null ? requiredOverride.hashCode() : 0);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/override/FieldMetadataOverride.java
@@ -110,7 +110,9 @@ public class FieldMetadataOverride extends MetadataOverride {
     private String broadleafEnumeration;
     private Boolean hideEnumerationIfEmpty;
     private SupportedFieldType fieldComponentRenderer;
+    private String fieldComponentRendererTemplate;
     private SupportedFieldType gridFieldComponentRenderer;
+    private String gridFieldComponentRendererTemplate;
     private Boolean readOnly;
     private Map<String, List<Map<String, String>>> validationConfigurations;
     private Boolean requiredOverride;
@@ -348,6 +350,22 @@ public class FieldMetadataOverride extends MetadataOverride {
 
     public void setFieldComponentRenderer(SupportedFieldType fieldComponentRenderer) {
         this.fieldComponentRenderer = fieldComponentRenderer;
+    }
+
+    public String getFieldComponentRendererTemplate() {
+        return fieldComponentRendererTemplate;
+    }
+
+    public void setFieldComponentRendererTemplate(String fieldComponentRendererTemplate) {
+        this.fieldComponentRendererTemplate = fieldComponentRendererTemplate;
+    }
+
+    public String getGridFieldComponentRendererTemplate() {
+        return gridFieldComponentRendererTemplate;
+    }
+
+    public void setGridFieldComponentRendererTemplate(String gridFieldComponentRendererTemplate) {
+        this.gridFieldComponentRendererTemplate = gridFieldComponentRendererTemplate;
     }
 
     public SupportedFieldType getGridFieldComponentRenderer() {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
@@ -411,8 +411,12 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
                         Boolean.parseBoolean(stringValue));
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.FIELDCOMPONENTRENDERER)) {
                 fieldMetadataOverride.setFieldComponentRenderer(SupportedFieldType.valueOf(stringValue));
+            } else if (entry.getKey().equals(PropertyType.AdminPresentation.FIELDCOMPONENTRENDERERTEMPLATE)) {
+                fieldMetadataOverride.setFieldComponentRendererTemplate(stringValue);
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.GRIDFIELDCOMPONENTRENDERER)) {
                 fieldMetadataOverride.setGridFieldComponentRenderer(SupportedFieldType.valueOf(stringValue));
+            } else if (entry.getKey().equals(PropertyType.AdminPresentation.GRIDFIELDCOMPONENTRENDERERTEMPLATE)) {
+                fieldMetadataOverride.setGridFieldComponentRendererTemplate(stringValue);
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.TOOLTIP)) {
                 fieldMetadataOverride.setTooltip(stringValue);
             } else if (entry.getKey().equals(PropertyType.AdminPresentation.HELPTEXT)) {
@@ -528,7 +532,9 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
             override.setBroadleafEnumeration(annot.broadleafEnumeration());
             override.setHideEnumerationIfEmpty(annot.hideEnumerationIfEmpty());
             override.setFieldComponentRenderer(annot.fieldComponentRenderer());
+            override.setFieldComponentRendererTemplate(annot.fieldComponentRendererTemplate());
             override.setGridFieldComponentRenderer(annot.gridFieldComponentRenderer());
+            override.setGridFieldComponentRendererTemplate(annot.gridFieldComponentRendererTemplate());
             override.setColumnWidth(annot.columnWidth());
             override.setExplicitFieldType(annot.fieldType());
             override.setDisplayType(annot.displayType());
@@ -661,8 +667,14 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
         if (basicFieldMetadata.getFieldComponentRenderer() != null) {
             metadata.setFieldComponentRenderer(basicFieldMetadata.getFieldComponentRenderer());
         }
+        if (basicFieldMetadata.getFieldComponentRendererTemplate() != null) {
+            metadata.setFieldComponentRendererTemplate(basicFieldMetadata.getFieldComponentRendererTemplate());
+        }
         if (basicFieldMetadata.getGridFieldComponentRenderer() != null) {
             metadata.setGridFieldComponentRenderer(basicFieldMetadata.getGridFieldComponentRenderer());
+        }
+        if (basicFieldMetadata.getGridFieldComponentRendererTemplate() != null) {
+            metadata.setGridFieldComponentRendererTemplate(basicFieldMetadata.getGridFieldComponentRendererTemplate());
         }
         if (basicFieldMetadata.getFriendlyName() != null) {
             metadata.setFriendlyName(basicFieldMetadata.getFriendlyName());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -57,7 +57,6 @@ import org.broadleafcommerce.openadmin.dto.MapStructure;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.dto.SectionCrumb;
 import org.broadleafcommerce.openadmin.dto.TabMetadata;
-import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.domain.PersistencePackageRequest;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminSection;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
@@ -99,11 +98,9 @@ import org.codehaus.jettison.json.JSONObject;
 import org.springframework.context.MessageSource;
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.stereotype.Service;
-
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DateFormat;
@@ -120,7 +117,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
 import javax.annotation.Resource;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
@@ -1001,8 +997,8 @@ public class FormBuilderServiceImpl implements FormBuilderService {
 
                     f.withName(property.getName())
                      .withFieldType(fieldType)
-                     .withFieldComponentRenderer(fmd.getFieldComponentRenderer()==null?null:fmd.getFieldComponentRenderer().toString())
-                     .withGridFieldComponentRenderer(fmd.getGridFieldComponentRenderer()==null?null:fmd.getGridFieldComponentRenderer().toString())
+                     .withFieldComponentRenderer(getFieldComponentRenderer(fmd))
+                     .withGridFieldComponentRenderer(getGridFieldComponentRenderer(fmd))
                      .withOrder(fmd.getOrder())
                      .withFriendlyName(fmd.getFriendlyName())
                      .withForeignKeyDisplayValueProperty(fmd.getForeignKeyDisplayValueProperty())
@@ -1067,6 +1063,20 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                 f.setAssociatedFieldName(null);
             }
         }
+    }
+
+    protected String getFieldComponentRenderer(BasicFieldMetadata fmd) {
+        if (StringUtils.isNotBlank(fmd.getFieldComponentRendererTemplate())) {
+            return fmd.getFieldComponentRendererTemplate();
+        }
+        return fmd.getFieldComponentRenderer()==null?null:fmd.getFieldComponentRenderer().toString();
+    }
+
+    protected String getGridFieldComponentRenderer(BasicFieldMetadata fmd) {
+        if (StringUtils.isNotBlank(fmd.getGridFieldComponentRendererTemplate())) {
+            return fmd.getGridFieldComponentRendererTemplate();
+        }
+        return fmd.getGridFieldComponentRenderer()==null?null:fmd.getGridFieldComponentRenderer().toString();
     }
 
     private Field findAssociatedField(EntityForm ef, Field f) {

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentation.java
@@ -266,6 +266,15 @@ public @interface AdminPresentation {
 
 
     /**
+     * Optional - drives the component that renders the UI for an entityform
+     *
+     * When not specified, will default to the fieldType
+     *
+     * @return the component name responsible for rendering this field
+     */
+    String fieldComponentRendererTemplate() default "";
+
+    /**
      * Optional - drives the component that renders the UI for a listgrid
      *
      * When not specified, will default to the fieldType
@@ -273,6 +282,15 @@ public @interface AdminPresentation {
      * @return the component name responsible for rendering this field
      */
     SupportedFieldType gridFieldComponentRenderer() default SupportedFieldType.UNKNOWN;
+
+    /**
+     * Optional - drives the component that renders the UI for a listgrid
+     *
+     * When not specified, will default to the fieldType
+     *
+     * @return the component name responsible for rendering this field
+     */
+    String gridFieldComponentRendererTemplate() default "";
 
     /**
      * Optional - only required if you want to make the field immutable

--- a/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/override/PropertyType.java
@@ -51,7 +51,9 @@ public class PropertyType {
         public static final String BROADLEAFENUMERATION = "broadleafEnumeration";
         public static final String HIDEENUMERATIONIFEMPTY = "hideEnumerationIfEmpty";
         public static final String FIELDCOMPONENTRENDERER = "fieldComponentRenderer";
+        public static final String FIELDCOMPONENTRENDERERTEMPLATE = "fieldComponentRendererTemplate";
         public static final String GRIDFIELDCOMPONENTRENDERER = "gridFieldComponentRenderer";
+        public static final String GRIDFIELDCOMPONENTRENDERERTEMPLATE = "gridFieldComponentRendererTemplate";
         public static final String REQUIREDOVERRIDE = "requiredOverride";
         public static final String EXCLUDED = "excluded";
         public static final String TOOLTIP = "tooltip";


### PR DESCRIPTION
You can now use a string template name to use a custom template for rendering a field.