### PR TITLE
Filter facets that only have zero results

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -48,6 +48,7 @@ import org.broadleafcommerce.core.search.domain.SearchCriteria;
 import org.broadleafcommerce.core.search.domain.SearchFacet;
 import org.broadleafcommerce.core.search.domain.SearchFacetDTO;
 import org.broadleafcommerce.core.search.domain.SearchFacetRange;
+import org.broadleafcommerce.core.search.domain.SearchFacetResultDTO;
 import org.broadleafcommerce.core.search.domain.SearchResult;
 import org.broadleafcommerce.core.search.domain.solr.FieldType;
 import org.broadleafcommerce.core.search.service.SearchService;
@@ -56,15 +57,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
 import javax.annotation.Resource;
 
 /**
@@ -268,6 +272,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         // Get the facets
         setFacetResults(namedFacetMap, response);
         sortFacetResults(namedFacetMap);
+        filterEmptyFacets(facets);
 
         SearchResult result = new SearchResult();
         result.setFacets(facets);
@@ -284,6 +289,23 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         }
 
         return result;
+    }
+
+    protected void filterEmptyFacets(List<SearchFacetDTO> facets) {
+        Iterator<SearchFacetDTO> iter = facets.iterator();
+        while (iter.hasNext()) {
+            SearchFacetDTO dto = iter.next();
+            boolean shouldRemove = true;
+            for (SearchFacetResultDTO result : dto.getFacetValues()) {
+                if (result.getQuantity() != null && result.getQuantity() > 0) {
+                    shouldRemove = false;
+                    break;
+                }
+            }
+            if (shouldRemove) {
+                iter.remove();
+            }
+        }
     }
 
     protected String getDefaultSort(SearchCriteria criteria) {


### PR DESCRIPTION
Added a change to the BroadleafSearchController so that SearchFacetDTOs are not added to the model if it there's no results that have any of its facet values