### PR TITLE
Catch all Payment Type Variable Expression made public

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/expression/checkout/PaymentMethodVariableExpression.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/expression/checkout/PaymentMethodVariableExpression.java
@@ -95,7 +95,7 @@ public class PaymentMethodVariableExpression implements BroadleafVariableExpress
         return orderContainsPaymentOfType(order, PaymentType.THIRD_PARTY_ACCOUNT);
     }
 
-    protected boolean orderContainsPaymentOfType(Order order, PaymentType paymentType) {
+    public boolean orderContainsPaymentOfType(Order order, PaymentType paymentType) {
         List<OrderPayment> orderPayments = orderPaymentService.readPaymentsForOrder(order);
 
         for (OrderPayment payment : orderPayments) {


### PR DESCRIPTION
Addressing Issue: https://github.com/BroadleafCommerce/QA/issues/3234

We have a number of supported PaymentTypes that are not covered by the out-of-the-box public methods in the PaymentMethodVariableExpression class. Making this previously protected method public gives an option to cover these without making your own variable expression.