### PR TITLE
Adding logic to check for hidden inputs with a `.value` class else default to searching for the input without the class.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -894,7 +894,11 @@ var BLCAdmin = (function($) {
                 value = $field.find('select').val();
             }
             if (value == null) {
-                value = $field.find('input[type="hidden"]').val();
+                if ($field.find('input[type="hidden"].value').length) {
+                    value = $field.find('input[type="hidden"].value').val();
+                } else {
+                    value = $field.find('input[type="hidden"]').val();
+                }
             }
             if (value == null) {
                 value = $field.find('input[type="text"]').val();


### PR DESCRIPTION
Fixes https://github.com/BroadleafCommerce/QA/issues/3236