### PR TITLE
Offer Validation and Rulebuilder Errors 

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -320,7 +320,7 @@ translation.record.exists.for.locale=Another translation already exists for this
 
 sc_conflict=Http Status 409  - The request could not be completed due to a conflict with the current state of the target resource, likely due to stale state. Please try resetting the state using this link.
 page_reset=Reset
-unhandled_exception_message=Sorry, there was an error processing your request.
+unhandled_exception_message=Sorry, there was an error processing your request
 
 listgrid.record.readonly=This record is not available for edit in this context
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-query-builder.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-query-builder.css
@@ -193,9 +193,10 @@
 }
 
 .query-builder-rules .rules-group-header-item-qty {
-    width: 40px;
+    min-width: 40px;
+    width: auto;
     margin: 5px 0 5px 3px;
-    text-align:right;
+    text-align: center;
 }
 
 .query-builder-rules .query-builder-selectize-input {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1564,3 +1564,12 @@ $('.main-content').scroll(function () {
         $(this).find('.content-yield').height(h - title - tabs);
     }
 });
+
+$('body').on('input', 'input.resize-as-needed', function () {
+    var minSize = $(this).data('min-size') || 1;
+    var maxSize = $(this).data('max-size') || $(this).attr('maxlength') || 30;
+    var newSize = $(this).val().length;
+    newSize = Math.max(minSize, newSize);
+    newSize = Math.min(maxSize, newSize);
+    $(this).attr('size', newSize);
+});

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -42,11 +42,6 @@ var BLCAdmin = (function($) {
                          '.rule-builder-simple-time, .rule-builder-simple, .rule-builder-with-quantity, >div>div>input:not([type=hidden]), .selectize-wrapper';
     
     function showModal($data, onModalHide, onModalHideArgs) {
-
-        if($data.hasClass('wrap-in-modal')) {
-            $data = wrapInModal($data);
-        }
-
         // If we already have an active modal, we don't need another backdrop on subsequent modals
         $data.modal({
             backdrop: (modals.length < 1),
@@ -350,6 +345,9 @@ var BLCAdmin = (function($) {
             if (!$element.find('.content-yield').length) {
                 var content = $('<div>', { 'class': 'content-yield'});
                 $element.find('.modal-body').wrapInner(content);
+            }
+            if($element.hasClass('wrap-in-modal')) {
+                $element = wrapInModal($element);
             }
             $('body').append($element);
             showModal($element, onModalHide, onModalHideArgs);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -42,6 +42,11 @@ var BLCAdmin = (function($) {
                          '.rule-builder-simple-time, .rule-builder-simple, .rule-builder-with-quantity, >div>div>input:not([type=hidden]), .selectize-wrapper';
     
     function showModal($data, onModalHide, onModalHideArgs) {
+
+        if($data.hasClass('wrap-in-modal')) {
+            $data = wrapInModal($data);
+        }
+
         // If we already have an active modal, we don't need another backdrop on subsequent modals
         $data.modal({
             backdrop: (modals.length < 1),
@@ -92,7 +97,6 @@ var BLCAdmin = (function($) {
             }
         });
 
-
         // Only initialize all fields if NOT a normal EntityForm in modal
         // Should initialize for lookups
         if (BLCAdmin.currentModal().find('.modal-body>.content-yield .entity-form.modal-form').length === 0) {
@@ -103,6 +107,16 @@ var BLCAdmin = (function($) {
 
         BLCAdmin.initializeModalButtons($data);
         BLCAdmin.setModalMaxHeight(BLCAdmin.currentModal());
+    }
+
+    function wrapInModal($data) {
+        var id = ($data.attr('id') || 'wrapped') + '-modal';
+        return $(
+            '<div class="modal in" id="' + id + '">' +
+            '    <div class="modal-header"><button class="close" type="button" data-dismiss="modal" aria-hidden="true">×</button></div>' +
+            '    <div class="modal-body" style="padding: 0 20px">' + $data.html() + '</div>' +
+            '</div>'
+        );
     }
 
     function getDependentFieldFilterKey(className, childFieldName) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -621,9 +621,10 @@ $(document).ready(function() {
                 return;
             }
             // This is a special case for rule builders, we need to capture the match quantity value
-            else if ($(this).hasClass('rules-group-header-item-qty')) {
+            else if ($(this).hasClass('rules-group-header-item-qty')
+                    && $(this).closest('.rules-group-container').attr('data-orig-val') === undefined) {
                 var $ruleGroupContainer = $(this).closest('.rules-group-container');
-                $ruleGroupContainer.attr('orig-val', $(this).val());
+                $ruleGroupContainer.attr('data-orig-val', $(this).val());
                 return;
             }
             // If this is a redactor field, we have to set its text attribute, not its value

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/blc-admin-query-builder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/blc-admin-query-builder.js
@@ -125,8 +125,12 @@ $.fn.queryBuilder.define('blc-admin-query-builder', function(options) {
             //Add the Match instructions with quantity field if necessary
             var matchSpan = $("<span>", {"class": "rules-group-header-span", "text": "Match"});
             var itemPK = $("<input>", {"class": "rules-group-header-item-pk", "type": "hidden", "value": options.pk});
-            var itemQty = $("<input>", {"class": "rules-group-header-item-qty", "type": options.quantity ? "text" : "hidden",
+            var itemQty = $("<input>", {"class": "rules-group-header-item-qty resize-as-needed", "type": options.quantity ? "text" : "hidden",
                 "value": options.quantity});
+
+            //This can't be a part of the above line, otherwise jQuery tries to run the deprecated method size(1) instead
+            //of adding the 'size' attribute
+            itemQty.attr('size', options.quantity ? options.quantity.toString().length : 1);
 
             // To introduce additional unique "items that satisfy" text, you must create a property such that
             // the key is in the following format "{Rule Identifier Type}_ItemsThatSatisfyText".

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/utility/error.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/utility/error.html
@@ -1,4 +1,4 @@
-<div id="noAccess" class="content-yield">
+<div id="noAccess" class="content-yield wrap-in-modal">
     <h4 class="empty-main-list-grid">
         <p><span th:utext="#{unhandled_exception_message}"/> : <span th:utext="${exceptionUUID}"/></p>
     </h4>


### PR DESCRIPTION
- Resize the quantity input in the offer rule builder: The input should now expand to fit the text when multiple digits are entered
- Fix JavaScript errors when changing the quantity input: Previously, changing the quantity was throwing JS errors because the `data-orig-val` attribute was added with an incorrect name. Additionally, the `data-orig-val` would have been incorrect since refocusing the input was changing the value, so refocusing after changing it would set the `data-orig-val` to the current value.
- Wrap server errors in a modal: Previously the errors were being shown as a modal without actually being a modal. This was breaking the page as the black overlay would pop up but no message was visible.
- Added validation to the offer 'value' field to make it required. Since the field is dynamically added, no validators were being added to it for some use-cases. Saving without entering a value was causing an exception at the data layer and also causing the black screen described above.

BroadleafCommerce/QA#3235