### PR TITLE
Translation links in modals were not getting enabled

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1382,9 +1382,13 @@ $(document).ready(function() {
     // primary entity buttons should be disabled until page is loaded
     $(window).load(function () {
         $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
-        $('a.show-translations').removeClass('disabled');
     });
 
+    //moved show-translations to an initializationHandler so it gets fired for modals as well 
+    BLCAdmin.addInitializationHandler(function($container) {
+        $('a.show-translations').removeClass('disabled');
+     });
+    
     $(window).resize(function() {
         $.doTimeout('resize', 150, function() {
             if (BLCAdmin.currentModal() != null) {


### PR DESCRIPTION
Moved the after-load initialization of translation links to an initializtionHandler.  Translation links in modals were not getting enabled.  Fixes https://github.com/BroadleafCommerce/QA/issues/3252