### PR TITLE
Improve i18n support in the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -327,6 +327,12 @@ listgrid.record.readonly=This record is not available for edit in this context
 listgrid.page.next=Next
 listgrid.page.previous=Previous
 listgrid.page.size=Page Size
+listgrid.pagination.of=of
+listgrid.pagination.record=record
+listgrid.pagination.records=records
+listgrid.header.record=\ Record
+listgrid.header.records=\ Records
+listgrid.manualFetch=(Click Fetch to check for records)
 
 listgrid.no.records=(No records found)
 listgrid.prompt.search=(Use list grid search or filtering to retrieve records)

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/entityForm.html
@@ -99,11 +99,11 @@
                                                 <div class="titlebar-title">
                                                     <span th:unless="${#strings.isEmpty(listGrid.friendlyName)}" class="listgrid-friendly-name" th:utext="#{${listGrid.friendlyName}}"></span>
                                                     <th:block th:unless="${listGrid.manualFetch}">
-                                                        <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-                                                        <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+                                                        <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+                                                        <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
                                                     </th:block>
                                                     <th:block th:if="${listGrid.manualFetch}">
-                                                        <span class="listgrid-total-records" th:text="'(Click Fetch to check for records)'"></span>
+                                                        <span class="listgrid-total-records" th:text="#{listgrid.manualFetch}"></span>
                                                     </th:block>
                                                 </div>
                                                 <th:block th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:block>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -282,9 +282,10 @@
                 <span class="low-index" th:unless="${records}">0</span>
                 -
                 <span class="high-index" th:text="${listGrid.startIndex + #lists.size(listGrid.records)}" />
-                <span th:text="${'of'}"/>
+                <span th:text="#{listgrid.pagination.of}"/>
                 <span class="total-records" th:text="${#lists.size(listGrid.records)}" />
-                <span th:text="${'records'}"/>
+                <span th:if="${#lists.size(listGrid.records) == 1}" th:text="#{listgrid.pagination.record}"/>
+                <span th:unless="${#lists.size(listGrid.records) == 1}" th:text="#{listgrid.pagination.records}"/>
             </span>
         </span>
     </div>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/partials/entityFormFields.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/partials/entityFormFields.html
@@ -55,11 +55,11 @@
         <div class="fieldgroup-listgrid-wrapper-header" th:classappend="${#lists.isEmpty(listGrid.records)} ? 'hidden-body'">
             <span th:unless="${#strings.isEmpty(listGrid.friendlyName)}" class="listgrid-friendly-name" th:utext="#{${listGrid.friendlyName}}"></span>
             <th:block th:unless="${listGrid.manualFetch}">
-                <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-                <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+                <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+                <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
             </th:block>
             <th:block th:if="${listGrid.manualFetch}">
-                <span class="listgrid-total-records" th:text="'(Click Fetch to check for records)'"></span>
+                <span class="listgrid-total-records" th:text="#{listgrid.manualFetch}"></span>
             </th:block>
             <th:blockv th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:blockv>
         </div>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/collectionListGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/collectionListGrid.html
@@ -3,8 +3,8 @@
     <div class="fieldgroup-listgrid-wrapper-header titlebar" th:classappend="${#lists.isEmpty(listGrid.records)} ? 'hidden-body'">
         <div class="titlebar-title">
             <span th:unless="${#strings.isEmpty(listGrid.friendlyName)}" class="listgrid-friendly-name" th:utext="#{${listGrid.friendlyName}}"></span>
-            <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-            <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+            <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+                    <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
         </div>
         <th:block th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:block>
     </div>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/adornedSelectEntity.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/adornedSelectEntity.html
@@ -13,8 +13,8 @@
             <div class="fieldgroup-listgrid-wrapper-header titlebar" style="display: block;">
                 <div class="titlebar-title">
                     <span th:unless="${#strings.isEmpty(listGrid.friendlyName)}" th:classappend="${listGrid.hideFriendlyName} ? hidden : ''" class="listgrid-friendly-name" th:text="#{${listGrid.friendlyName}}"></span>
-                    <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-                    <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+                    <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+                    <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
                 </div>
                 <th:block th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:block>
             </div>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/simpleSelectEntity.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/simpleSelectEntity.html
@@ -16,8 +16,8 @@
             <div class="fieldgroup-listgrid-wrapper-header titlebar" style="display: block;">
                 <div class="titlebar-title">
                     <span th:unless="${#strings.isEmpty(listGrid.friendlyName)}" th:classappend="${listGrid.hideFriendlyName} ? hidden : ''" class="listgrid-friendly-name" th:text="#{${listGrid.friendlyName}}"></span>
-                    <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-                    <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+                    <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+                    <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
                 </div>
                 <th:block th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:block>
             </div>

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/translationListGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/views/modal/translationListGrid.html
@@ -6,8 +6,8 @@
 
     <div class="fieldgroup-listgrid-wrapper-header titlebar" th:classappend="${#lists.isEmpty(listGrid.records)} ? 'hidden-body'">
         <div class="titlebar-title">
-            <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Record)'"></span>
-            <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + ' Records)'"></span>
+            <span class="listgrid-total-records" th:if="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.record} + ')'"></span>
+            <span class="listgrid-total-records" th:unless="${listGrid.totalRecords} == 1" th:text="'(' + ${listGrid.totalRecords} + #{listgrid.header.records} + ')'"></span>
         </div>
         <th:block th:include="components/listGridToolbar" th:with="listGrid=${listGrid}"></th:block>
     </div>


### PR DESCRIPTION
There's currently missing translations in the admin and the text is hardcoded in English in the templates. Additionally there are places in the admin where the JS hardcodes English. This PR fixes a lot of the main places where i18n support is missing.

https://github.com/BroadleafCommerce/QA/issues/3267