### PR TITLE
Re-add RTL support to Redactor after the library was upgrade

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -643,6 +643,8 @@ var BLCAdmin = (function($) {
                     tabKey: true,
                     tabsAsSpaces: 4,
                     deniedTags: [],
+                    direction: $('html').attr('dir') || 'ltr',
+                    lang: $('html').attr('lang') || 'en',
                     initCallback: function() {
                         // reset the redactor contents to ensure correct rendering
                         this.code.set(this.code.get());


### PR DESCRIPTION
This change re-adds right-to-left language support via the construction of the Redactor object in the Broadleaf admin. This change was originally done in redactor.js but after the library was upgraded the change was lost.