### PR TITLE
Fixed bug where hidden modals on the page prevented clearing entity form state on submission

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -193,6 +193,10 @@
                         data: BLCAdmin.serializeArray($form)
                     };
                 }
+                
+                options.error = function() {
+                    BLCAdmin.entityForm.hideActionSpinner();
+                }
                 BLC.ajax(options, function (data) {
                     BLCAdmin.entityForm.hideActionSpinner();
 
@@ -208,7 +212,7 @@
                             clearOtherAlerts: true
                         });
 
-                        if (!$('.modal:not(#expire-message)').length && $('.entity-form').length) {
+                        if (!$form.closest('.modal').length) {
                             if (BLCAdmin.entityForm.status) {
                                 BLCAdmin.entityForm.status.clearEntityFormChanges();
                             }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -193,10 +193,6 @@
                         data: BLCAdmin.serializeArray($form)
                     };
                 }
-                
-                options.error = function() {
-                    BLCAdmin.entityForm.hideActionSpinner();
-                }
                 BLC.ajax(options, function (data) {
                     BLCAdmin.entityForm.hideActionSpinner();
 


### PR DESCRIPTION
In the success handler when submitting an entity form via ajax we were preventing the entity form change state from being cleared if there were any modals on the page. The intent was to not clear state of the underlying entity form if a modal form was being submitted. However, by simply checking for any modals on the page, we prevented the normal behavior when there are benign, hidden modals on the page. This changes now makes it so that we're specifically checking that the form being submitted is contained by a modal which is more definitive that we aren't submitting the main entity form for the page.