### PR TITLE
Allow an input to manually specify that its changes should be tracked on modification in the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -554,7 +554,11 @@
          * @returns {boolean}
          */
         checkIfShouldTrackChanges : function(el) {
-
+            // if changes are explcitly tracked on this input, track it
+            if ($(el).data('track-changes')) {
+                return true;
+            }
+            
             // if this element is in an OMS tab, we don't want to track
             if (el !== undefined && $(el).closest('.oms-tab').length) {
                 return false;


### PR DESCRIPTION
Previously if the input was apart of a modal (even if it was on the normal save product page) then it would never trigger the save button enabling if saved. This allows using a `data-track-changes="true"` attribute on the input itself to trigger save button being enabled.