### PR TITLE
Delegate to the Spring Boot default multipart limits for file uploads

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/NonAutoconfigMultiPartConfiguration.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/NonAutoconfigMultiPartConfiguration.java
@@ -16,15 +16,16 @@
  * #L%
  */
 /**
- * 
+ *
  */
 package org.broadleafcommerce.cms.admin.web.controller;
 
+import org.broadleafcommerce.cms.file.service.StaticAssetStorageServiceImpl;
 import org.broadleafcommerce.common.config.PostAutoConfiguration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -36,12 +37,12 @@ import org.springframework.web.servlet.DispatcherServlet;
  */
 @PostAutoConfiguration
 public class NonAutoconfigMultiPartConfiguration {
-    
+
     @Bean(name = DispatcherServlet.MULTIPART_RESOLVER_BEAN_NAME)
     @ConditionalOnMissingBean
-    public MultipartResolver multipartResolver(@Value("${asset.server.max.uploadable.file.size}") long blcMaxFileSize ) {
+    public MultipartResolver multipartResolver(Environment env) {
         CommonsMultipartResolver resolver = new CommonsMultipartResolver();
-        resolver.setMaxUploadSize(blcMaxFileSize);
+        resolver.setMaxUploadSize(env.getProperty("asset.server.max.uploadable.file.size", long.class, StaticAssetStorageServiceImpl.DEFAULT_ASSET_UPLOAD_SIZE));
         return resolver;
     }
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/file/StaticAssetViewController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/file/StaticAssetViewController.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- *
+ * 
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%

--- a/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
+++ b/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
@@ -51,10 +51,6 @@ asset.use.filesystem.storage=true
 # for implementations of this size, distributed file system options should be considered.
 asset.server.max.generated.file.system.directories=2
 
-# The maximum file size that can be uploaded (10 Meg)
-# Implementors should tune this according to their needs.
-asset.server.max.uploadable.file.size=10000000
-
 # The number of bytes from the input stream that will be read at a time
 asset.server.file.buffer.size=8192
 


### PR DESCRIPTION
Spring boot uses the `spring.http.multipart.max-file-size` property to configure file upload size in the DispatcherServlet. If this limit is not set, then there is no hope for the admin asset uploads to ever get to the underlying storage service in the first place. Thus, for general asset uploads, it does not make sense to require an _additional_ property for `asset.server.max.uploadable.file.size` (which is Broadleaf-specific) be set to to further enforce these upload limits.

For backwards compatibility, if this `asset.server.max.uploadable.file.size` is found to be set in the environment (via properties file or other means), we will use it both within the StaticAssetStorageService as well as when we create the`MultipartConfigElement` to restrict asset upload sizes. This has been removed from the Broadleaf properties files to allow for null checks for determining if the property was actually set by a user or not.

Related to #1831 which kicked off the majority of these changes to begin with.