### PR TITLE
Error removing a child order item from the cart

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/AddWorkflowPriceOrderIfNecessaryActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/AddWorkflowPriceOrderIfNecessaryActivity.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -44,21 +44,21 @@ import javax.annotation.Resource;
 /**
  * As of Broadleaf version 3.1.0, saves of individual aspects of an Order (such as OrderItems and FulfillmentGroupItems) no
  * longer happen in their respective activities. Instead, we will now handle these saves in this activity exclusively.
- * 
+ *
  * This provides the ability for an implementation to not require a transactional wrapper around the entire workflow and
  * instead only requires it around this particular activity. This is only recommended if there are long running steps in
  * the workflow, such as an external service call to check availability.
- * 
+ *
  * @author Andre Azzolini (apazzolini)
  */
 @Component("blAddWorkflowPriceOrderIfNecessaryActivity")
 public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<ProcessContext<CartOperationRequest>> {
-    
+
     public static final int ORDER = 5000;
-    
+
     @Resource(name = "blOrderService")
     protected OrderService orderService;
-    
+
     @Resource(name = "blOrderItemService")
     protected OrderItemService orderItemService;
 
@@ -67,11 +67,11 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
 
     @Resource(name = "blOrderMultishipOptionService")
     protected OrderMultishipOptionService orderMultishipOptionService;
-    
+
     public AddWorkflowPriceOrderIfNecessaryActivity() {
         setOrder(ORDER);
     }
-    
+
     @Override
     public ProcessContext<CartOperationRequest> execute(ProcessContext<CartOperationRequest> context) throws Exception {
         CartOperationRequest request = context.getSeedData();
@@ -88,7 +88,7 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
                 }
             }
         }
-        
+
         // We potentially have some FulfillmentGroupItems that were identified in the FulfillmentGroupItemStrategy as
         // ones that should be deleted. Delete them here.
         if (CollectionUtils.isNotEmpty(request.getFgisToDelete())) {
@@ -105,18 +105,19 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
                 }
             }
         }
-        
+
         // We now need to delete any OrderItems that were marked as such, including their children, if any
         for (OrderItem oi : request.getOisToDelete()) {
             order.getOrderItems().remove(oi);
-            orderItemService.delete(oi);
-            
+
             if (oi.getParentOrderItem() != null) {
                 OrderItem parentItem = oi.getParentOrderItem();
                 parentItem.getChildOrderItems().remove(oi);
             }
+
+            orderItemService.delete(oi);
         }
-        
+
         // We need to build up a map of OrderItem to which FulfillmentGroupItems reference that particular OrderItem.
         // We'll also save the order item and build up a map of the unsaved items to their saved counterparts.
         Map<OrderItem, List<FulfillmentGroupItem>> oiFgiMap = new HashMap<>();
@@ -130,18 +131,18 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
                 while (li.hasNext()) {
                     DiscreteOrderItem doi = li.next();
                     getOiFgiMap(order, oiFgiMap, doi);
-                    DiscreteOrderItem savedDoi = (DiscreteOrderItem) orderItemService.saveOrderItem(doi); 
+                    DiscreteOrderItem savedDoi = (DiscreteOrderItem) orderItemService.saveOrderItem(doi);
                     savedOrderItems.put(doi, savedDoi);
                     li.remove();
                     doisToAdd.add(savedDoi);
                 }
-                
+
                 // After the discrete order items are saved, we can re-add the saved versions to our bundle and then
                 // save the bundle as well.
                 ((BundleOrderItem) oi).getDiscreteOrderItems().addAll(doisToAdd);
                 BundleOrderItem savedBoi = (BundleOrderItem) orderItemService.saveOrderItem(oi);
                 savedOrderItems.put(oi, savedBoi);
-                
+
                 // Lastly, we'll want to go through our saved discrete order items and update the bundle that they relate
                 // to to the saved version of the bundle.
                 for (DiscreteOrderItem doi : savedBoi.getDiscreteOrderItems()) {
@@ -152,7 +153,7 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
                 savedOrderItems.put(oi, orderItemService.saveOrderItem(oi));
             }
         }
-        
+
         // Now, we'll update the orderitems in the order to their saved counterparts
         ListIterator<OrderItem> li = order.getOrderItems().listIterator();
         List<OrderItem> oisToAdd = new ArrayList<>();
@@ -175,26 +176,26 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
                 request.setOrderItem(savedOrderItems.get(entry.getKey()));
             }
         }
-        
+
         // We need to add the new item to the parent's child order items as well.
         updateChildOrderItem(request, order);
 
         // If a custom implementation needs to handle additional saves before the parent Order is saved, this method
         // can be overridden to provide that functionality.
         preSaveOperation(request);
-        
+
         // Now that our collection items in our Order have been saved and the state of our Order is in a place where we
         // won't get a transient save exception, we are able to go ahead and save the order with optional pricing.
         order = orderService.save(order, request.isPriceOrder());
         request.setOrder(order);
-        
+
         return context;
     }
 
     /**
-     * Traverses the current OrderItem for a match to the parentOrderItemId.  
+     * Traverses the current OrderItem for a match to the parentOrderItemId.
      * If found, populates and returns true.
-     *   
+     *
      * @param request
      * @param orderItem
      * @return
@@ -239,7 +240,7 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
         }
         return parentUpdated;
     }
-    
+
     protected void getOiFgiMap(Order order, Map<OrderItem, List<FulfillmentGroupItem>> oiFgiMap, OrderItem oi) {
         List<FulfillmentGroupItem> fgis = new ArrayList<>();
 
@@ -253,11 +254,11 @@ public class AddWorkflowPriceOrderIfNecessaryActivity extends BaseActivity<Proce
 
         oiFgiMap.put(oi, fgis);
     }
-    
+
     /**
      * Intended to be overridden by a custom implementation if there is a requirement to perform additional logic or
      * saves before triggering the main Order save with pricing.
-     * 
+     *
      * @param request
      */
     protected void preSaveOperation(CartOperationRequest request) {


### PR DESCRIPTION
The issue presents itself when you have an order item with child order items (i.e. a product addon) and you try to remove just the child from the cart.

The `AddWorkflowPriceOderIfNecessaryActivity` is deleting the order item before it is removed from its parent.

This PR reorders these events so that we don't delete the order item until we're done with it.