### PR TITLE
Add methods to skip cache when retrieving order, fix potential synchronization problems with sending order persisted events

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDao.java
@@ -28,6 +28,8 @@ import java.util.List;
 public interface OrderDao {
 
     Order readOrderById(Long orderId);
+
+    Order readOrderByIdIgnoreCache(Long orderId);
     
     List<Order> readOrdersByIds(List<Long> orderIds);
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -37,25 +37,15 @@ import org.broadleafcommerce.core.payment.domain.OrderPayment;
 import org.broadleafcommerce.core.payment.domain.PaymentTransaction;
 import org.broadleafcommerce.profile.core.dao.CustomerDao;
 import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.ejb.AvailableSettings;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.UUID;
+import java.util.*;
 
 import javax.annotation.Resource;
-import javax.persistence.EntityExistsException;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import javax.persistence.*;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -85,6 +75,13 @@ public class OrderDaoImpl implements OrderDao {
     @Override
     public Order readOrderById(final Long orderId) {
         return em.find(OrderImpl.class, orderId);
+    }
+
+    @Override
+    public Order readOrderByIdIgnoreCache(final Long orderId) {
+        Map<String, Object> m = new HashMap<>();
+        m.put(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS);
+        return em.find(OrderImpl.class, orderId, m);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderPersistedEntityListener.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderPersistedEntityListener.java
@@ -53,7 +53,7 @@ public class OrderPersistedEntityListener {
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
                 @Override
-                public void afterCommit() {
+                public void afterCompletion(int status) {
                     ApplicationContextHolder.getApplicationContext().publishEvent(new OrderPersistedEvent((Order) entity));
                 }
             });

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderPersistedEntityListener.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderPersistedEntityListener.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -19,6 +19,7 @@ package org.broadleafcommerce.core.order.domain;
 
 import org.broadleafcommerce.common.util.ApplicationContextHolder;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -31,7 +32,7 @@ import javax.persistence.PostUpdate;
  * necessary in order to update the current order in the application
  *
  * @author Phillip Verheyden (phillipuniverse)
- * 
+ *
  * @see {@link ApplicationEventPublisher#publishEvent(org.springframework.context.ApplicationEvent)}
  * @see {@link OrderPersistedEvent}
  * @see {@link org.broadleafcommerce.core.web.order.CartStateRefresher}
@@ -43,7 +44,7 @@ public class OrderPersistedEntityListener {
      * Invoked on both the PostPersist and PostUpdate. The default implementation is to simply publish a Spring event
      * to the ApplicationContext to allow an event listener to respond appropriately (like resetting the current cart
      * in CartState)
-     * 
+     *
      * @param entity the newly-persisted Order
      * @see OrderPersistedEvent
      */
@@ -54,10 +55,12 @@ public class OrderPersistedEntityListener {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
                 @Override
                 public void afterCompletion(int status) {
-                    ApplicationContextHolder.getApplicationContext().publishEvent(new OrderPersistedEvent((Order) entity));
+                    if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                        ApplicationContextHolder.getApplicationContext().publishEvent(new OrderPersistedEvent((Order) entity));
+                    }
                 }
             });
         }
     }
-    
+
 }


### PR DESCRIPTION
BroadleafCommerce/QA#3287

Fixed issue with statuses for Order. Like for Fulfillment orders when Solr reindex get object from cache with old data.