### PR TITLE
CSRF token exception is not handled by Spring Boot error handling when deploying as a .war file

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/AdminSecurityFilter.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/AdminSecurityFilter.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -35,13 +35,11 @@ import java.io.IOException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * This class attempts the work flow of the CsrfFilter, but in the event of a Csrf token mismatch 
+ * This class attempts the work flow of the CsrfFilter, but in the event of a Csrf token mismatch
  * (Session reset for example) the User will be redirected to login, if not session reset User is sent to previous location.
  * This class also handles stale state detection for the admin. This can occur when an admin page form is submitted
  * and the system detects that key state has changed since the time the page was originally rendered.
@@ -60,35 +58,33 @@ import javax.servlet.http.HttpServletResponse;
  *   ...
  * }
  *
- *     
+ *
  * @author trevorleffert, Jeff Fischer
  */
 @Component("blAdminCsrfFilter")
 public class AdminSecurityFilter extends SecurityFilter {
 
     private static final Log LOG = LogFactory.getLog(AdminSecurityFilter.class);
-    
+
     @Autowired(required = false)
     @Qualifier("blAdminAuthenticationFailureHandler")
     protected AuthenticationFailureHandler failureHandler;
-    
+
     @Override
-    public void doFilter(ServletRequest baseRequest, ServletResponse baseResponse, FilterChain chain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest baseRequest, HttpServletResponse baseResponse, FilterChain chain) throws IOException, ServletException {
         try {
-            super.doFilter(baseRequest, baseResponse, chain);
+            super.doFilterInternal(baseRequest, baseResponse, chain);
         } catch (ServletException e) {
             if (e.getCause() instanceof StaleStateServiceException) {
                 LOG.debug("Stale state detected", e);
-                ((HttpServletResponse) baseResponse).setStatus(HttpServletResponse.SC_CONFLICT);
+                baseResponse.setStatus(HttpServletResponse.SC_CONFLICT);
                 baseResponse.getWriter().write("Stale State Detected\n");
                 baseResponse.getWriter().write(e.getMessage() + "\n");
             } else if (e.getCause() instanceof ServiceException) {
-                HttpServletRequest baseHttpRequest = (HttpServletRequest) baseRequest;
                 //if authentication is null and CSRF token is invalid, must be session time out
                 if (SecurityContextHolder.getContext().getAuthentication() == null && failureHandler != null) {
-                    baseHttpRequest.setAttribute("sessionTimeout", true);
-                    failureHandler.onAuthenticationFailure((HttpServletRequest) baseRequest, (HttpServletResponse)
-                            baseResponse, new SessionAuthenticationException("Session Time Out"));
+                    baseRequest.setAttribute("sessionTimeout", true);
+                    failureHandler.onAuthenticationFailure(baseRequest, baseResponse, new SessionAuthenticationException("Session Time Out"));
                 } else {
                     throw e;
                 }

--- a/common/src/main/java/org/broadleafcommerce/common/security/handler/SecurityFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/security/handler/SecurityFilter.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -27,15 +27,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -54,7 +52,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author Jeff Fischer
  */
-public class SecurityFilter extends GenericFilterBean {
+public class SecurityFilter extends OncePerRequestFilter {
 
     protected static final Log LOG = LogFactory.getLog(SecurityFilter.class);
 
@@ -69,9 +67,7 @@ public class SecurityFilter extends GenericFilterBean {
     protected List<String> excludedRequestPatterns;
 
     @Override
-    public void doFilter(ServletRequest baseRequest, ServletResponse baseResponse, FilterChain chain) throws IOException, ServletException {
-        HttpServletRequest request = (HttpServletRequest) baseRequest;
-        HttpServletResponse response = (HttpServletResponse) baseResponse;
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         boolean excludedRequestFound = false;
         if (excludedRequestPatterns != null && excludedRequestPatterns.size() > 0) {
@@ -107,7 +103,7 @@ public class SecurityFilter extends GenericFilterBean {
             }
         }
 
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
     }
 
     public List<String> getExcludedRequestPatterns() {
@@ -129,4 +125,5 @@ public class SecurityFilter extends GenericFilterBean {
     public void setExcludedRequestPatterns(List<String> excludedRequestPatterns) {
         this.excludedRequestPatterns = excludedRequestPatterns;
     }
+
 }


### PR DESCRIPTION
In non-embedded deployments (deploying a .war file) CSRF token exceptions were bubbling a stack trace all the way back up to the browser. This was skipping the normal Spring Boot BasicErrorFilter handling because the SecurityFilter happened a 2nd time within the filter chain and threw a duplicate exception.

Generally, this happens like the following:

1. The `ErrorPageFilter` is hooked into the filter chain with the highest precedence. This simply wraps the rest of the filter chain with a `try/catch`
2. The `ErrorPageFIlter` has a configurable set of exception classes that can then forward to particular URLs. By default, this sends forwards to `/error`
3. The `BasicErrorController` is already hooked up from Spring and maps to `/error`

All of this is working correctly based on the docs from [Spring Boot on error handling](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-error-handling). The root of the problem is this though:

1. Exception is thrown in the `SecurityFilter` for the CSRF token validation
2. Exception is correctly handled by the try/catch in `ErrorPageFilter`
3. The `ErrorPageFilter` sends a `forward()` to `/error` back through the filter chain
4. Since `SecurityFilter` extends from `GenericFilterBean`, `SecurityFilter` runs again. It sees that it's a POST, does another check for the CSRF token, throws exception

Since `ErrorPageFilter` does not have another try/catch around the `forward()` (nor should it) you get the exception bubbled back up to the client side.

The fix is simply to have the `SecurityFilter` extend from `OncePerRequestFilter` to handle this `forward()` case.

Resolves BroadleafCommerce/QA#3241