### PR TITLE
Fixed bug where rules based on Locale couldn't be promoted

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/OrderFieldServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/rulebuilder/service/OrderFieldServiceImpl.java
@@ -53,7 +53,7 @@ public class OrderFieldServiceImpl extends AbstractRuleBuilderFieldService {
                 .build());
         fields.add(new FieldData.Builder()
                 .label("rule_localeCode")
-                .name("locale")
+                .name("locale.localeCode")
                 .operators(RuleOperatorType.TEXT)
                 .options(RuleOptionType.EMPTY_COLLECTION)
                 .type(SupportedFieldType.STRING)


### PR DESCRIPTION
This fixes an issue where you couldn't create rules based on the locale of the Order. The error occurred when you tried to promote the rule since it saw the rule as "locale" which is an complex object and not a String therefore it treated it like a FK lookup and did `Long.parseLong(<rule value>)`. However that, the rule value was a string so that would give you a parse error. To fix this issue the rule name needed to be `locale.localeCode` since the rule value was matched against the localeCode (which is a String) instead of the complex object `locale`.