### PR TITLE
Handle Spring 4.3.16 bean creation changes in tests

### DIFF
--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/DummyProcessContextFactory.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/DummyProcessContextFactory.java
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.workflow;
+
+import org.broadleafcommerce.core.workflow.DefaultProcessContextImpl;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.broadleafcommerce.core.workflow.ProcessContextFactory;
+import org.broadleafcommerce.core.workflow.WorkflowException;
+
+public class DummyProcessContextFactory implements ProcessContextFactory<Object, Object> {
+
+    @Override
+    public ProcessContext<Object> createContext(Object preSeedData) throws WorkflowException {
+        ProcessContext<Object> context = new DefaultProcessContextImpl<>();
+        context.setSeedData(preSeedData);
+        return context;
+    }
+    
+}

--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/ExceptionActivity.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/ExceptionActivity.java
@@ -1,0 +1,32 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.workflow;
+
+import org.broadleafcommerce.core.workflow.BaseActivity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+
+import java.util.List;
+
+public class ExceptionActivity extends BaseActivity<ProcessContext<List<String>>> {
+
+    @Override
+    public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
+        throw new RuntimeException();
+    }
+    
+}

--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/NestedActivity.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/NestedActivity.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.workflow;
+
+import org.broadleafcommerce.core.workflow.BaseActivity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.broadleafcommerce.core.workflow.SequenceProcessor;
+import org.broadleafcommerce.core.workflow.WorkflowException;
+
+import java.util.List;
+
+public class NestedActivity extends BaseActivity<ProcessContext<List<String>>> {
+
+    protected SequenceProcessor workflow;
+    
+    public NestedActivity(SequenceProcessor workflow) {
+        this.workflow = workflow;
+    }
+
+    @Override
+    public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
+        try {
+            workflow.doActivities(context.getSeedData());
+        } catch (WorkflowException e) {
+            context.getSeedData().add("NestedActivityException");
+            throw e;
+        }
+        return context;
+    }
+    
+}

--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/RollbackTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/RollbackTest.java
@@ -20,15 +20,8 @@
  */
 package org.broadleafcommerce.common.workflow;
 
-import org.broadleafcommerce.core.workflow.Activity;
-import org.broadleafcommerce.core.workflow.BaseActivity;
-import org.broadleafcommerce.core.workflow.DefaultProcessContextImpl;
-import org.broadleafcommerce.core.workflow.ProcessContext;
-import org.broadleafcommerce.core.workflow.ProcessContextFactory;
 import org.broadleafcommerce.core.workflow.SequenceProcessor;
 import org.broadleafcommerce.core.workflow.WorkflowException;
-import org.broadleafcommerce.core.workflow.state.RollbackFailureException;
-import org.broadleafcommerce.core.workflow.state.RollbackHandler;
 import org.broadleafcommerce.test.TestNGSiteIntegrationSetup;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,7 +29,6 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Resource;
 
@@ -69,80 +61,5 @@ public class RollbackTest extends TestNGSiteIntegrationSetup {
             "RollbackActivity1");
         Assert.assertTrue(exceptionThrown);
         Assert.assertEquals(results, expected, "Rollback occurred out of order");
-    }
-    
-    public static class SimpleActivity extends BaseActivity<ProcessContext<List<String>>> {
-
-        protected String name;
-
-        public SimpleActivity(String name) {
-            this.name = name;
-        }
-        
-        public String getName() {
-            return name;
-        }
-        
-        @Override
-        public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
-            context.getSeedData().add(name);
-            return context;
-        }
-        
-        @Override
-        public boolean getAutomaticallyRegisterRollbackHandler() {
-            return true;
-        }
-        
-    }
-    
-    public static class SimpleRollbackHandler implements RollbackHandler<ProcessContext<List<String>>> {
-
-        @Override
-        public void rollbackState(Activity<ProcessContext<List<String>>> activity, ProcessContext<List<String>> processContext, Map<String, Object> stateConfiguration) throws RollbackFailureException {
-            processContext.getSeedData().add("Rollback" + ((SimpleActivity) activity).getName());
-        }
-        
-    }
-    
-    public static class NestedActivity extends BaseActivity<ProcessContext<List<String>>> {
-
-        protected SequenceProcessor workflow;
-        
-        public NestedActivity(SequenceProcessor workflow) {
-            this.workflow = workflow;
-        }
-
-        @Override
-        public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
-            try {
-                workflow.doActivities(context.getSeedData());
-            } catch (WorkflowException e) {
-                context.getSeedData().add("NestedActivityException");
-                throw e;
-            }
-            return context;
-        }
-        
-    }
-    
-    public static class ExceptionActivity extends BaseActivity<ProcessContext<List<String>>> {
-
-        @Override
-        public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
-            throw new RuntimeException();
-        }
-        
-    }
-
-    public static class DummyProcessContextFactory implements ProcessContextFactory<Object, Object> {
-
-        @Override
-        public ProcessContext<Object> createContext(Object preSeedData) throws WorkflowException {
-            ProcessContext<Object> context = new DefaultProcessContextImpl<>();
-            context.setSeedData(preSeedData);
-            return context;
-        }
-        
     }
 }

--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/SimpleActivity.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/SimpleActivity.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.workflow;
+
+import org.broadleafcommerce.core.workflow.BaseActivity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+
+import java.util.List;
+
+public class SimpleActivity extends BaseActivity<ProcessContext<List<String>>> {
+
+    protected String name;
+
+    public SimpleActivity(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    @Override
+    public ProcessContext<List<String>> execute(ProcessContext<List<String>> context) throws Exception {
+        context.getSeedData().add(name);
+        return context;
+    }
+    
+    @Override
+    public boolean getAutomaticallyRegisterRollbackHandler() {
+        return true;
+    }
+    
+}

--- a/integration/src/test/java/org/broadleafcommerce/common/workflow/SimpleRollbackHandler.java
+++ b/integration/src/test/java/org/broadleafcommerce/common/workflow/SimpleRollbackHandler.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * BroadleafCommerce Integration
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.workflow;
+
+import org.broadleafcommerce.core.workflow.Activity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.broadleafcommerce.core.workflow.state.RollbackFailureException;
+import org.broadleafcommerce.core.workflow.state.RollbackHandler;
+
+import java.util.List;
+import java.util.Map;
+
+public class SimpleRollbackHandler implements RollbackHandler<ProcessContext<List<String>>> {
+
+    @Override
+    public void rollbackState(Activity<ProcessContext<List<String>>> activity, ProcessContext<List<String>> processContext, Map<String, Object> stateConfiguration) throws RollbackFailureException {
+        processContext.getSeedData().add("Rollback" + ((SimpleActivity) activity).getName());
+    }
+    
+}

--- a/integration/src/test/resources/bl-applicationContext-test.xml
+++ b/integration/src/test/resources/bl-applicationContext-test.xml
@@ -116,37 +116,37 @@
     
     <bean id="testRollbackWorkflow" class="org.broadleafcommerce.core.workflow.SequenceProcessor">
         <property name="processContextFactory">
-            <bean class="org.broadleafcommerce.common.workflow.RollbackTest.DummyProcessContextFactory"/>
+            <bean class="org.broadleafcommerce.common.workflow.DummyProcessContextFactory"/>
         </property>
         <property name="activities">
             <list>
-                <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleActivity">
+                <bean class="org.broadleafcommerce.common.workflow.SimpleActivity">
                     <constructor-arg value="Activity1"></constructor-arg>
                     <property name="rollbackHandler">
-                        <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleRollbackHandler" />
+                        <bean class="org.broadleafcommerce.common.workflow.SimpleRollbackHandler" />
                     </property>
                 </bean>
-                <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleActivity">
+                <bean class="org.broadleafcommerce.common.workflow.SimpleActivity">
                     <constructor-arg value="Activity2"></constructor-arg>
                     <property name="rollbackHandler">
-                        <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleRollbackHandler" />
+                        <bean class="org.broadleafcommerce.common.workflow.SimpleRollbackHandler" />
                     </property>
                 </bean>
-                <bean class="org.broadleafcommerce.common.workflow.RollbackTest.NestedActivity">
+                <bean class="org.broadleafcommerce.common.workflow.NestedActivity">
                     <constructor-arg name="workflow">
                         <bean class="org.broadleafcommerce.core.workflow.SequenceProcessor">
                             <property name="processContextFactory">
-                                <bean class="org.broadleafcommerce.common.workflow.RollbackTest.DummyProcessContextFactory"/>
+                                <bean class="org.broadleafcommerce.common.workflow.DummyProcessContextFactory"/>
                             </property>
                             <property name="activities">
                                 <list>
-                                    <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleActivity">
+                                    <bean class="org.broadleafcommerce.common.workflow.SimpleActivity">
                                         <constructor-arg value="ActivityA"></constructor-arg>
                                         <property name="rollbackHandler">
-                                            <bean class="org.broadleafcommerce.common.workflow.RollbackTest.SimpleRollbackHandler" />
+                                            <bean class="org.broadleafcommerce.common.workflow.SimpleRollbackHandler" />
                                         </property>
                                     </bean>
-                                    <bean class="org.broadleafcommerce.common.workflow.RollbackTest.ExceptionActivity" />
+                                    <bean class="org.broadleafcommerce.common.workflow.ExceptionActivity" />
                                 </list>
                             </property>
                             <property name="defaultErrorHandler" ref="blSilentErrorHandler"/>


### PR DESCRIPTION
Spring 4.3.16+ now loads outer classes when determining appropriate constructor parameters for static inner classes. Since these classes were manually registered as beans and they also were within classes whose hierarchies dependend on TestNG, this caused all integration tests to fail when TestNG was not on the classpath.

This simply moves those classes out to their own files so they can exist without any TestNG dependencies.

Originally caused by 5f4913c0cd32595322d26c703d90513bf10a3ed9.

## More Details
With the latest 4.3.16.RELEASE of Spring, if you were including the Broadleaf integration test annotations (like `@BroadleafSiteIntegrationTest`) but running with JUnit, you would get an exception like this:

```console
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'testRollbackWorkflow' defined in class path resource [bl-applicationContext-test.xml]: Initialization of bean failed; nested exception is java.lang.NoClassDefFoundError: org/testng/IHookable
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:564)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:761)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:867)
	at org.springframework.context.support.AbstractApplicationContext.__refresh(AbstractApplicationContext.java:543)
	at org.springframework.context.support.AbstractApplicationContext.jrLockAndRefresh(AbstractApplicationContext.java)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java)
	at org.springframework.test.context.web.AbstractGenericWebContextLoader.loadContext(AbstractGenericWebContextLoader.java:134)
	at org.springframework.test.context.web.AbstractGenericWebContextLoader.loadContext(AbstractGenericWebContextLoader.java:61)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:108)
	at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:251)
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:98)
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:116)
	... 38 more
Caused by: java.lang.NoClassDefFoundError: org/testng/IHookable
        ...
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:338)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.getDeclaringClass0(Native Method)
	at java.lang.Class.getDeclaringClass(Class.java:1235)
	at java.lang.Class.getEnclosingClass(Class.java:1277)
	at java.lang.Class.getSimpleBinaryName(Class.java:1443)
	at java.lang.Class.isMemberClass(Class.java:1433)
	at org.springframework.core.MethodParameter.getParameterAnnotations(MethodParameter.java:493)
	at org.springframework.core.convert.TypeDescriptor.<init>(TypeDescriptor.java:88)
	at org.springframework.beans.TypeConverterDelegate.convertIfNecessary(TypeConverterDelegate.java:109)
	at org.springframework.beans.TypeConverterSupport.doConvert(TypeConverterSupport.java:64)
	at org.springframework.beans.TypeConverterSupport.convertIfNecessary(TypeConverterSupport.java:47)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:704)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:189)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1197)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1099)
```

There was a side effect when I upgraded Spring to `4.3.16.RELEASE`. Specifically, [this commit](https://github.com/spring-projects/spring-framework/commit/5f6b04251e1643d7ba22fcff708fcf196a36dcc6#diff-2facb1f4a67064ac5ac96099b6c75c9aR493) broke me.

What happens is:

1. In `bl-applicationContext-test.xml`](https://github.com/BroadleafCommerce/BroadleafCommerce/blob/e69b9d4a79181d7f05cc860aeb0ef330843ba85f/integration/src/test/resources/bl-applicationContext-test.xml#L117-L159) testRollbackWorkflow) we create the `testRollbackWorkflow` bean
2. Some of the activities within this bean reference a [static inner class](https://github.com/BroadleafCommerce/BroadleafCommerce/blob/e69b9d4a79181d7f05cc860aeb0ef330843ba85f/integration/src/test/java/org/broadleafcommerce/common/workflow/RollbackTest.java#L74). The class that these static classes are inside is actually a `TestNG` integration test itself that extends from `IHookable`.
3. The change from Juergen to Spring affects how the bean is instantiated. When `RollbackTest.SimpleActivity` is instantiated by Spring (to create the activity bean for the workflow), the change now does a `this.constructor.getDeclaringClass()`, which causes the outer `RollbackTest` class to be loaded, which then causes the `IHookable` class to be loaded, which is a class in `TestNG`

This means that anybody trying to use Broadleaf integration tests (and the `bl-applicationContext-test.xml`) without TestNG on the classpath is broken.

The fix is to simply move these activities to not be a static inner class. In general, the lesson here is to not instantiate beans from inner classes within specific test framework subclasses. Not really too much of an issue any more since the go-forward pattern is annotation-based (with `@Test`) but something to be cognizant of.