### PR TITLE
Use error level logging when error occurs in checkout flow

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafCheckoutController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafCheckoutController.java
@@ -240,9 +240,7 @@ public class BroadleafCheckoutController extends AbstractCheckoutController {
     }
 
     public void handleProcessingException(Exception e, RedirectAttributes redirectAttributes) throws PaymentException {
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("A Processing Exception Occurred finalizing the order. Adding Error to Redirect Attributes.");
-        }
+        LOG.error("A Processing Exception Occurred finalizing the order. Adding Error to Redirect Attributes.", e);
 
         redirectAttributes.addAttribute(PaymentGatewayAbstractController.PAYMENT_PROCESSING_ERROR,
                 PaymentGatewayAbstractController.getProcessingErrorMessage());


### PR DESCRIPTION
Exceptions from the checkout flow were being hidden by default. They will now be logged as errors.