### PR TITLE
Use extended class name instead of ceiling class in Map Metadata

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/MapFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/MapFieldMetadataProvider.java
@@ -556,7 +556,7 @@ public class MapFieldMetadataProvider extends AdvancedCollectionFieldMetadataPro
                 Class<?> clazz = (Class<?>) pType.getActualTypeArguments()[1];
                 Class<?>[] entities = dynamicEntityDao.getAllPolymorphicEntitiesFromCeiling(clazz);
                 if (!ArrayUtils.isEmpty(entities)) {
-                    metadata.setValueClassName(entities[entities.length-1].getName());
+                    metadata.setValueClassName(entities[0].getName());
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue where the types of values of maps annotated with `@AdminPresentationMap` were not having the extensions loaded because the ceiling entity was being used instead of the extended entity.