### PR TITLE
Modal's tabs are not populated when modal displays more then once

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -393,7 +393,7 @@ $(document).ready(function() {
         var isVisitedBefore = BLCAdmin.entityForm.visitedTabs.contains($tab);
         if (!isVisitedBefore) BLCAdmin.entityForm.visitedTabs.add($tab);
 
-        if (!isVisitedBefore && !$tab.hasClass('first-tab') && currentAction.indexOf('/add') === -1) {
+        if (!isVisitedBefore && !$tab.hasClass('first-tab') && currentAction.search(/\/add($|\W)/) === -1) {
             showTabSpinner($tab, $tabBody);
 
      		BLC.ajax({


### PR DESCRIPTION
BroadleafCommerce/QA#3243
Fix modal tabs loading

It didn't work because URL `/admin/product/100/additionalSkus/112/1/ProductImpl_Pricing_Tab` contains `/additionalSkus` in path, so `currentAction.indexOf('/add')` didn't return `-1`. I added regexp for it, so it will check `/add`, `/add?`, `/add/`, etc., but prevents checking something like `/additionalSkus`.