### PR TITLE
fix admin JS edit filter errors caused when subRules are undefined

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/vendor/query-builder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/vendor/query-builder.js
@@ -1177,7 +1177,7 @@ QueryBuilder.prototype.setRules = function(data) {
             var model;
             var subRules = item.rules;
 
-            if (subRules.length == 2) {
+            if (subRules && subRules.length == 2) {
                 var expression1 = subRules[0];
                 var expression2 = subRules[1];
 


### PR DESCRIPTION
BroadleafCommerce/QA#3315 - fix js edit filter issues caused when subRules are undefined