### PR TITLE
Always keep translations disabled on adds

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/OpenAdminMessages.properties
@@ -317,6 +317,7 @@ errorDuplicateSandBoxName=The SandBox name must be unique
 constraintViolationError=Could not remove because other objects relate
 
 translation.record.exists.for.locale=Another translation already exists for this locale
+translation.available.on.edit=(Available on edit)
 
 sc_conflict=Http Status 409  - The request could not be completed due to a conflict with the current state of the target resource, likely due to stale state. Please try resetting the state using this link.
 page_reset=Reset

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1388,7 +1388,7 @@ $(document).ready(function() {
 
     //moved show-translations to an initializationHandler so it gets fired for modals as well 
     BLCAdmin.addInitializationHandler(function($container) {
-        $('a.show-translations').removeClass('disabled');
+        $('a.show-translations:not(.always-disabled)').removeClass('disabled');
      });
     
     $(window).resize(function() {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/fieldTranslation.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/fieldTranslation.html
@@ -1,22 +1,26 @@
 <th:block th:if="${field.translatable and hideTranslations != 'true'}">
-    <th:block th:if="${df}">
+    <th:block th:if="${df}" th:with="disable=${df.translationId == null}">
         <a class="show-translations disabled"
-           th:classappend="${df.translationId == null} ? 'disabled'"
+           th:classappend="${disable} ? 'always-disabled'"
            th:href="@{/translation(ceilingEntity=${df.translationCeilingEntity},
                                    entityId=${df.translationId},
                                    propertyName=${field.translationFieldName},
                                    isRte=${field.fieldType == 'HTML' || field.fieldType == 'HTML_BASIC'})}">
-            <i class="blc-icon-globe" style="color: #94AF39; vertical-align: middle;"></i><span th:utext="#{Translation}"></span>
+            <i class="blc-icon-globe" style="color: #94AF39; vertical-align: middle;"></i>
+            <span th:utext="#{Translation}"></span>
+            <span th:if="${disable}" th:text="#{translation.available.on.edit}"></span>
         </a>
     </th:block>
-    <th:block th:unless="${df}">
+    <th:block th:unless="${df}" th:with="disable=${entityForm.translationId == null}">
         <a class="show-translations disabled"
-           th:classappend="${entityForm.translationId == null} ? 'disabled'"
+           th:classappend="${disable} ? 'always-disabled'"
            th:href="@{/translation(ceilingEntity=${entityForm.translationCeilingEntity},
                                    entityId=${entityForm.translationId},
                                    propertyName=${field.translationFieldName},
                                    isRte=${field.fieldType == 'HTML' || field.fieldType == 'HTML_BASIC'})}">
-            <i class="blc-icon-globe" style="color: #94AF39; vertical-align: middle;"></i><span th:utext="#{Translation}"></span>
+            <i class="blc-icon-globe" style="color: #94AF39; vertical-align: middle;"></i>
+            <span th:utext="#{Translation}"></span>
+            <span th:if="${disable}" th:text="#{translation.available.on.edit}"></span>
         </a>
     </th:block>
 </th:block>


### PR DESCRIPTION
This behavior went through a few different changes. First, we conditionally disabled translations on add in BroadleafCommerce/BroadleafCommercePrivate#908. Then, we realized that even on edits it was possible to click the translations link too quickly and get a display without some styling. This was "fixed" in BroadleafCommerce/BroadleafCommercePrivate/pull/919. However, that essentially reverts the change in BroadleafCommerce/BroadleafCommercePrivate#908 because now _all_ translation links get un-disabled, no matter if they are on the 'Add' or 'Edit'. Finally, this underwent another change to work with modals in #1828.

This PR basically re-fixes the original BroadleafCommerce/BroadleafCommercePrivate#908 change to only activate translations if there is a backing id, which usually is in the case of an edit. This also includes a helpful message to indicate why the translations link is disabled.