### PR TITLE
Fixes the issue where adding condition on cart rules break the page.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -844,8 +844,8 @@
 
                             var valueString = undefined;
                             if (valArray != null) {
-                                for(var i = 0; i < valArray.length; i++){
-                                    var val = ruleBuilder.getFieldValueById(ruleDTO.id, valArray[i]);
+                                for(var j = 0; j < valArray.length; j++){
+                                    var val = ruleBuilder.getFieldValueById(ruleDTO.id, valArray[j]);
 
                                     if (allRules[key] === undefined) {
                                         allRules[key] = ['<strong>' + val + '</strong>'];


### PR DESCRIPTION
Using same variable (var i) for two different loops causes the variable to be updated at both places. This results in infinite loop and makes the page unresponsive. Using different variable (var j) fixes the problem.

https://github.com/BroadleafCommerce/QA/issues/3292