### PR TITLE
URL encode square brackets in facet range filters to support Tomcat 8.5.31

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/SearchFacetDTOServiceImpl.java
@@ -135,7 +135,7 @@ public class SearchFacetDTOServiceImpl implements SearchFacetDTOService {
 
     @Override
     public String getValue(SearchFacetResultDTO result) {
-        return result.getValueKey();
+        return result.getUnencodedValueKey();
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetResultDTO.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetResultDTO.java
@@ -17,7 +17,9 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.net.URLEncoder;
 
 /**
  * @author Andre Azzolini (apazzolini)
@@ -84,6 +86,16 @@ public class SearchFacetResultDTO {
     }
     
     public String getValueKey() {
+        String value = getUnencodedValueKey();
+
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return value;
+        }
+    }
+
+    public String getUnencodedValueKey() {
         String value = getValue();
         
         if (value == null) {


### PR DESCRIPTION
Added support for Tomcat 8.5.31 by url encoding the facet range value so that `[` and `]` are valid url encodings that are accepted by the new version of Tomcat.

To reproduce this error prior to this chagne
- Have facets with ranges (price facet in the default data)
- Select a price range
- Observe below error

```
java.lang.IllegalArgumentException: Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986
    at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:479)
    at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:687)
    at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
    at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)
    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1468)
    at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
    at java.lang.Thread.run(Thread.java:748)
```

Additionally this change introduces a new method on SearchFacetResultDTO to return the unencoded value so that when checking the request parameters in Java (url unencoded) we're able to correctly check against the proper unencoded version.