### PR TITLE
Resolve the StaticAssetView immediately from the asset controller without going through the view resolver chain

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/file/StaticAssetViewController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/file/StaticAssetViewController.java
@@ -29,9 +29,11 @@ import org.broadleafcommerce.common.classloader.release.ThreadLocalManager;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.BroadleafSiteResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.mvc.AbstractController;
 
 import java.io.FileNotFoundException;
@@ -64,6 +66,9 @@ public class StaticAssetViewController extends AbstractController {
 
     @Autowired
     protected Environment env;
+
+    @Autowired
+    protected ApplicationContext appCtx;
 
     @PostConstruct
     protected void init() {
@@ -137,7 +142,8 @@ public class StaticAssetViewController extends AbstractController {
         context.setNonPersistentSite(siteResolver.resolveSite(new ServletWebRequest(request, response)));
         try {
             Map<String, String> model = staticAssetStorageService.getCacheFileModel(fullUrl, convertParameterMap(request.getParameterMap()));
-            return new ModelAndView(viewResolverName, model);
+            View assetView = appCtx.getBean(viewResolverName, View.class);
+            return new ModelAndView(assetView, model);
         } catch (AssetNotFoundException e) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return null;


### PR DESCRIPTION
Since the static asset server can handle a multitude of different files and different content types, there is no way to know until the asset is actually loaded. Because of this, Spring cannot detect what the content type is unless the PathExtensionContentNegotiationStrategy is enabled. If that ContentNegotiationStrategy is disabled, then it is more than likely that the Thymeleaf view will be resolved since browsers will send a text/html as an Accepts header. Since we already know what view we want to load straight from the controller, we might as well simply load it there.

In later versions of Spring Boot (2.0.0+) the PathExtensionContentNegotiationStrategy is disabled by default since there were multiple security vulnerabilities discovered in that strategy