### PR TITLE
Add Support for the Java bin RequestWriter during Solr indexing

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -49,6 +49,7 @@ import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.locale.domain.Locale;
 import org.broadleafcommerce.common.locale.service.LocaleService;
+import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.util.BLCMapUtils;
 import org.broadleafcommerce.common.util.StringUtil;
 import org.broadleafcommerce.common.util.TypedClosure;
@@ -74,6 +75,7 @@ import org.broadleafcommerce.core.search.domain.solr.FieldType;
 import org.broadleafcommerce.core.search.service.solr.index.SolrIndexServiceExtensionManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
@@ -88,6 +90,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+
 import javax.annotation.Resource;
 import javax.jms.IllegalStateException;
 
@@ -935,6 +938,12 @@ public class SolrHelperServiceImpl implements SolrHelperService {
                     propertyObject = newCollection;
                 } else {
                     propertyObject = getPropertyValueInternal(propertyObject, components, currentPosition + 1);
+                }
+            } else {
+                if (Money.class.isAssignableFrom(propertyObject.getClass())) {
+                    propertyObject = ((Money) propertyObject).getAmount().toPlainString();
+                } else if (BigDecimal.class.isAssignableFrom(propertyObject.getClass())) {
+                    propertyObject = ((BigDecimal) propertyObject).toPlainString();
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue when indexing Money objects when the HttpSolrClient's RequestWriter is the BinaryRequestWriter. Without this, fields are indexed as "price_d : 'org.broadleafcommerce.common.money.Money:3.0" instead of as a double. When using solrj 5.x this isn't typically an issue but there are situations with replication where this can occur. Furthermore this is more fool-proof and is required when using solrj 7