### PR TITLE
Upgrade Solr client to 7.3.1 and remove remaining support for Sku indexing via solr.index.use.sku

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -109,10 +109,6 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
     public static String PRODUCT_OPTION_FIELD_PREFIX = "productOption";
     public static String INVENTORY_ONLY_CRITERIA = "onlyInventoryProperties";
 
-
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Value("${use.to.one.lookup.sku.product.option.value:false}")
     protected boolean useToOneLookupSkuProductOptionValue = false;
 
@@ -827,9 +823,6 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
      * @return <b>null</b> if successfully validation, the error entity otherwise
      */
     protected Entity validateUniqueProductOptionValueCombination(Product product, List<Property> productOptionProperties, Sku currentSku) {
-        if(useSku) {
-            return null;
-        }
         //do not attempt POV validation if no PO properties were passed in
         if (CollectionUtils.isNotEmpty(productOptionProperties)) {
             List<Long> productOptionValueIds = new ArrayList<>();

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/ProductHandlerMapping.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/ProductHandlerMapping.java
@@ -59,9 +59,6 @@ public class ProductHandlerMapping extends BLCAbstractHandlerMapping {
     @Resource(name = "blCatalogService")
     protected CatalogService catalogService;
 
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Value("${request.uri.encoding}")
     public String charEncoding;
 
@@ -89,10 +86,6 @@ public class ProductHandlerMapping extends BLCAbstractHandlerMapping {
     }
 
     public boolean shouldSkipExecution(HttpServletRequest request) throws ServletRequestBindingException {
-        if (useSku) {
-            return true;
-        }
-
         if (allowCategoryResolutionUsingIdParam()
                 && ServletRequestUtils.getLongParameter(request, "categoryId") != null) {
             return true;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/SkuHandlerMapping.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/catalog/SkuHandlerMapping.java
@@ -21,7 +21,6 @@ import org.broadleafcommerce.common.util.BLCRequestUtils;
 import org.broadleafcommerce.common.web.BLCAbstractHandlerMapping;
 import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.catalog.service.CatalogService;
-import org.springframework.beans.factory.annotation.Value;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
@@ -49,15 +48,8 @@ public class SkuHandlerMapping extends BLCAbstractHandlerMapping {
     @Resource(name = "blCatalogService")
     private CatalogService catalogService;
 
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Override
     protected Object getHandlerInternal(HttpServletRequest request) throws Exception {
-        if (!useSku) {
-            return null;
-        }
-
         String requestURIWithoutContext = BLCRequestUtils.getRequestURIWithoutContext(request);
         if (requestURIWithoutContext != null) {
             Sku sku = catalogService.findSkuByURI(requestURIWithoutContext);

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
@@ -68,9 +68,6 @@ public class BroadleafCartController extends AbstractCartController {
 
     protected static String ALL_PRODUCTS_ATTRIBUTE_NAME = "blcAllDisplayedProducts";
 
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Value("${automatically.add.complete.items}")
     protected boolean automaticallyAddCompleteItems;
 
@@ -302,11 +299,7 @@ public class BroadleafCartController extends AbstractCartController {
         
         if (isAjaxRequest(request)) {
             Map<String, Object> extraData = new HashMap<>();
-            if(useSku) {
-                extraData.put("skuId", itemRequest.getSkuId());
-            } else {
-                extraData.put("productId", itemRequest.getProductId());
-            }
+            extraData.put("productId", itemRequest.getProductId());
             extraData.put("cartItemCount", cart.getItemCount());
             model.addAttribute("blcextradata", new ObjectMapper().writeValueAsString(extraData));
             return getCartView();
@@ -345,11 +338,7 @@ public class BroadleafCartController extends AbstractCartController {
         if (isAjaxRequest(request)) {
             Map<String, Object> extraData = new HashMap<>();
             extraData.put("cartItemCount", cart.getItemCount());
-            if(useSku) {
-                extraData.put("skuId", itemRequest.getSkuId());
-            } else {
-                extraData.put("productId", itemRequest.getProductId());
-            }
+            extraData.put("productId", itemRequest.getProductId());
             model.addAttribute("blcextradata", new ObjectMapper().writeValueAsString(extraData));
             return getCartView();
         } else {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
@@ -299,6 +299,7 @@ public class BroadleafCartController extends AbstractCartController {
         
         if (isAjaxRequest(request)) {
             Map<String, Object> extraData = new HashMap<>();
+            extraData.put("skuId", itemRequest.getSkuId());
             extraData.put("productId", itemRequest.getProductId());
             extraData.put("cartItemCount", cart.getItemCount());
             model.addAttribute("blcextradata", new ObjectMapper().writeValueAsString(extraData));
@@ -338,6 +339,7 @@ public class BroadleafCartController extends AbstractCartController {
         if (isAjaxRequest(request)) {
             Map<String, Object> extraData = new HashMap<>();
             extraData.put("cartItemCount", cart.getItemCount());
+            extraData.put("skuId", itemRequest.getSkuId());
             extraData.put("productId", itemRequest.getProductId());
             model.addAttribute("blcextradata", new ObjectMapper().writeValueAsString(extraData));
             return getCartView();

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafCategoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafCategoryController.java
@@ -28,7 +28,6 @@ import org.broadleafcommerce.common.web.controller.BroadleafAbstractController;
 import org.broadleafcommerce.common.web.deeplink.DeepLinkService;
 import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.Product;
-import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.search.domain.SearchCriteria;
 import org.broadleafcommerce.core.search.domain.SearchResult;
 import org.broadleafcommerce.core.search.service.SearchService;
@@ -40,11 +39,17 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.*;
-import java.util.Map.Entry;
 
 /**
  * This class works in combination with the CategoryHandlerMapping which finds a category based upon
@@ -57,7 +62,6 @@ public class BroadleafCategoryController extends BroadleafAbstractController imp
     protected static String defaultCategoryView = "catalog/category";
     protected static String CATEGORY_ATTRIBUTE_NAME = "category";  
     protected static String PRODUCTS_ATTRIBUTE_NAME = "products";  
-    protected static String SKUS_ATTRIBUTE_NAME = "skus";
     protected static String FACETS_ATTRIBUTE_NAME = "facets";  
     protected static String PRODUCT_SEARCH_RESULT_ATTRIBUTE_NAME = "result";  
     protected static String ACTIVE_FACETS_ATTRIBUTE_NAME = "activeFacets";  
@@ -121,7 +125,6 @@ public class BroadleafCategoryController extends BroadleafAbstractController imp
             
             model.addObject(CATEGORY_ATTRIBUTE_NAME, category);
             model.addObject(PRODUCTS_ATTRIBUTE_NAME, result.getProducts());
-            model.addObject(SKUS_ATTRIBUTE_NAME, result.getSkus());
             model.addObject(FACETS_ATTRIBUTE_NAME, result.getFacets());
             model.addObject(PRODUCT_SEARCH_RESULT_ATTRIBUTE_NAME, result);
             if (request.getParameterMap().containsKey("q")) {
@@ -132,10 +135,6 @@ public class BroadleafCategoryController extends BroadleafAbstractController imp
                 model.addObject(ALL_PRODUCTS_ATTRIBUTE_NAME, new HashSet<Product>(result.getProducts()));
             }
             
-            if (result.getSkus() != null) {
-                model.addObject(ALL_SKUS_ATTRIBUTE_NAME, new HashSet<Sku>(result.getSkus()));
-            }
-
             addDeepLink(model, deepLinkService, category);
             
             String templatePath = null;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafSearchController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafSearchController.java
@@ -23,7 +23,6 @@ import org.broadleafcommerce.common.security.service.ExploitProtectionService;
 import org.broadleafcommerce.common.util.UrlUtil;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.catalog.domain.Product;
-import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.search.domain.SearchCriteria;
 import org.broadleafcommerce.core.search.domain.SearchResult;
 import org.broadleafcommerce.core.search.redirect.domain.SearchRedirect;
@@ -68,7 +67,6 @@ public class BroadleafSearchController extends AbstractCatalogController {
     protected static String searchView = "catalog/search";
     
     protected static String PRODUCTS_ATTRIBUTE_NAME = "products";
-    protected static String SKUS_ATTRIBUTE_NAME = "skus";
     protected static String FACETS_ATTRIBUTE_NAME = "facets";  
     protected static String PRODUCT_SEARCH_RESULT_ATTRIBUTE_NAME = "result";  
     protected static String ACTIVE_FACETS_ATTRIBUTE_NAME = "activeFacets";  
@@ -127,7 +125,6 @@ public class BroadleafSearchController extends AbstractCatalogController {
                 facetService.setActiveFacetResults(result.getFacets(), request);
                 
                 model.addAttribute(PRODUCTS_ATTRIBUTE_NAME, result.getProducts());
-                model.addAttribute(SKUS_ATTRIBUTE_NAME, result.getSkus());
                 model.addAttribute(FACETS_ATTRIBUTE_NAME, result.getFacets());
                 model.addAttribute(PRODUCT_SEARCH_RESULT_ATTRIBUTE_NAME, result);
                 model.addAttribute(ORIGINAL_QUERY_ATTRIBUTE_NAME, query);
@@ -135,9 +132,6 @@ public class BroadleafSearchController extends AbstractCatalogController {
                     model.addAttribute(ALL_PRODUCTS_ATTRIBUTE_NAME, new HashSet<Product>(result.getProducts()));
                 }
 
-                if (result.getSkus() != null) {
-                    model.addAttribute(ALL_SKUS_ATTRIBUTE_NAME, new HashSet<Sku>(result.getSkus()));
-                }
             }
             
         }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
@@ -41,7 +41,6 @@ import org.broadleafcommerce.presentation.model.BroadleafTemplateElement;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateModel;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.web.core.CustomerState;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -76,9 +75,6 @@ import javax.annotation.Resource;
 @ConditionalOnTemplating
 public class UncacheableDataProcessor extends AbstractBroadleafTagReplacementProcessor {
     
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Resource(name = "blInventoryService")
     protected InventoryService inventoryService;
 
@@ -196,18 +192,13 @@ public class UncacheableDataProcessor extends AbstractBroadleafTagReplacementPro
                 if (item instanceof SkuAccessor) {
                     Sku sku = ((SkuAccessor) item).getSku();
                     if (sku != null && sku.getProduct() != null && item.getParentOrderItem() == null) {
-                        if (useSku) {
-                            cartItemIdsWithoutOptions.add(sku.getId());
+                        Product product = sku.getProduct();
+                        List<ProductOptionXref> optionXrefs = product.getProductOptionXrefs();
+                        if (optionXrefs == null || optionXrefs.isEmpty()) {
+                            cartItemIdsWithoutOptions.add(product.getId());
                         } else {
-                            Product product = sku.getProduct();
-                            List<ProductOptionXref> optionXrefs = product.getProductOptionXrefs();
-                            if (optionXrefs == null || optionXrefs.isEmpty()) {
-                                cartItemIdsWithoutOptions.add(product.getId());
-                            } else {
-                                cartItemIdsWithOptions.add(product.getId());
-                            } 
+                            cartItemIdsWithOptions.add(product.getId());
                         }
-                        
                     }
                 }
             }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
@@ -42,7 +42,6 @@ import org.broadleafcommerce.core.order.service.workflow.add.extension.ValidateA
 import org.broadleafcommerce.core.workflow.ActivityMessages;
 import org.broadleafcommerce.core.workflow.BaseActivity;
 import org.broadleafcommerce.core.workflow.ProcessContext;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -57,9 +56,6 @@ import javax.annotation.Resource;
 public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<CartOperationRequest>> {
 
     public static final int ORDER = 1000;
-    
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
     
     @Resource(name = "blOrderService")
     protected OrderService orderService;
@@ -157,11 +153,8 @@ public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<Cart
     protected Sku determineSku(Product product, Long skuId, Map<String, String> attributeValues, ActivityMessages messages) throws RequiredAttributeNotProvidedException {
         Sku sku = null;
         
-        //If sku browsing is enabled, product option data will not be available.
-        if (!useSku) {
-            // Check whether the sku is correct given the product options.
-            sku = findMatchingSku(product, attributeValues, messages);
-        }
+        // Check whether the sku is correct given the product options.
+        sku = findMatchingSku(product, attributeValues, messages);
 
         if (sku == null && skuId != null) {
             sku = catalogService.findSkuById(skuId);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchResult.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchResult.java
@@ -19,7 +19,6 @@ package org.broadleafcommerce.core.search.domain;
 
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.broadleafcommerce.core.catalog.domain.Product;
-import org.broadleafcommerce.core.catalog.domain.Sku;
 
 import java.util.List;
 
@@ -31,7 +30,6 @@ import java.util.List;
 public class SearchResult {
     
     protected List<Product> products;
-    protected List<Sku> skus;
     protected List<SearchFacetDTO> facets;
     
     protected Integer totalResults;
@@ -46,14 +44,6 @@ public class SearchResult {
 
     public void setProducts(List<Product> products) {
         this.products = products;
-    }
-
-    public List<Sku> getSkus() {
-        return skus;
-    }
-
-    public void setSkus(List<Sku> skus) {
-        this.skus = skus;
     }
 
     public List<SearchFacetDTO> getFacets() {
@@ -89,7 +79,7 @@ public class SearchResult {
     }
     
     public Integer getStartResult() {
-        return ((products == null || products.size() == 0) && (skus == null || skus.size() == 0)) ? 0 : ((page - 1) * pageSize) + 1;
+        return (products == null || products.size() == 0) ? 0 : ((page - 1) * pageSize) + 1;
     }
     
     public Integer getEndResult() {
@@ -97,7 +87,7 @@ public class SearchResult {
     }
     
     public Integer getTotalPages() {
-        return ((products == null || products.size() == 0) && (skus == null || skus.size() == 0)) ? 1 : (int) Math.ceil(totalResults * 1.0 / pageSize);
+        return (products == null || products.size() == 0) ? 1 : (int) Math.ceil(totalResults * 1.0 / pageSize);
     }
 
     public QueryResponse getQueryResponse() {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
@@ -68,6 +68,9 @@ public class SolrConfiguration implements InitializingBean {
     //This is the default number of shards that should be created if a SolrCloud collection is created via API
     protected Integer solrCloudNumShards = null;
 
+    //This is the default number of replicas that should be created if a SolrCloud collection is created via API
+    protected Integer solrCloudNumReplicas = null;
+
     protected String solrHomePath = null;
     
     @Value("${solr.index.site.collections:false}")
@@ -109,6 +112,14 @@ public class SolrConfiguration implements InitializingBean {
 
     public void setSolrCloudNumShards(Integer solrCloudNumShards) {
         this.solrCloudNumShards = solrCloudNumShards;
+    }
+    
+    public Integer getSolrCloudNumReplicas() {
+        return solrCloudNumReplicas;
+    }
+    
+    public void setSolrCloudNumReplicas(Integer solrCloudNumReplicas) {
+        this.solrCloudNumReplicas = solrCloudNumReplicas;
     }
 
     public String getSolrHomePath() {
@@ -523,16 +534,14 @@ public class SolrConfiguration implements InitializingBean {
                         break;
                     }
                 }
-                // TODO SOLRUPGRADE How many replicas? Before we didn't specify
-                CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, 0).process(primary);
+                CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, solrCloudNumReplicas).process(primary);
                 CollectionAdminRequest.createAlias(primary.getDefaultCollection(), collectionName).process(primary);
             } else {
                 //Aliases can be mapped to collections that don't exist.... Make sure the collection exists
                 String collectionName = aliasCollectionMap.get(primary.getDefaultCollection());
                 collectionName = collectionName.split(",")[0];
                 if (!collectionNames.contains(collectionName)) {
-                    // TODO SOLRUPGRADE How many replicas? Before we didn't specify
-                    CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, 0).process(primary);
+                    CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, solrCloudNumReplicas).process(primary);
                 }
             }
 
@@ -555,8 +564,7 @@ public class SolrConfiguration implements InitializingBean {
                         break;
                     }
                 }
-                // TODO SOLRUPGRADE How many replicas? Before we didn't specify
-                CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, 0).process(primary);
+                CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, solrCloudNumReplicas).process(primary);
                 CollectionAdminRequest.createAlias(reindex.getDefaultCollection(), collectionName).process(primary);
 
             } else {
@@ -564,8 +572,7 @@ public class SolrConfiguration implements InitializingBean {
                 String collectionName = aliasCollectionMap.get(reindex.getDefaultCollection());
                 collectionName = collectionName.split(",")[0];
                 if (!collectionNames.contains(collectionName)) {
-                    // TODO SOLRUPGRADE How many replicas? Before we didn't specify
-                    CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, 0).process(primary);
+                    CollectionAdminRequest.createCollection(collectionName, solrCloudConfigName, solrCloudNumShards, solrCloudNumReplicas).process(primary);
                 }
             }
         }
@@ -611,8 +618,7 @@ public class SolrConfiguration implements InitializingBean {
     protected void createCollectionIfNotExist(CloudSolrClient client, String collectionName) {
         if (!client.getZkStateReader().getClusterState().hasCollection(collectionName)) {
             try {
-                // TODO SOLRUPGRADE How many replicas? Before we didn't specify
-                CollectionAdminRequest.createCollection(collectionName, getSolrCloudConfigName(), getSolrCloudNumShards(), 0)
+                CollectionAdminRequest.createCollection(collectionName, getSolrCloudConfigName(), getSolrCloudNumShards(), getSolrCloudNumReplicas())
                         .setMaxShardsPerNode(getSolrCloudNumShards()).process(client);
             } catch (SolrServerException e) {
                 throw ExceptionHelper.refineException(e);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperService.java
@@ -100,7 +100,7 @@ public interface SolrHelperService {
     public String getIdFieldName();
     
     /**
-     * @return either <b>"productId"</b> (99% of cases) or <b>"skuId"</b> if the <i>solr.index.use.sku</i> system property is true
+     * @return the id field name. Usually "productId"
      */
     public String getIndexableIdFieldName();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -172,10 +172,8 @@ public class SolrHelperServiceImpl implements SolrHelperService {
                 reindexCollectionName = reindexCollectionName.split(",")[0];
 
                 //Essentially "swap cores" here by reassigning the aliases
-                new CollectionAdminRequest.CreateAlias().setAliasName(primaryCloudClient.getDefaultCollection())
-                        .setAliasedCollections(reindexCollectionName).process(primaryCloudClient);
-                new CollectionAdminRequest.CreateAlias().setAliasName(reindexCloudClient.getDefaultCollection())
-                        .setAliasedCollections(primaryCollectionName).process(reindexCloudClient);
+                CollectionAdminRequest.createAlias(primaryCloudClient.getDefaultCollection(), reindexCollectionName).process(primaryCloudClient);
+                CollectionAdminRequest.createAlias(reindexCloudClient.getDefaultCollection(), primaryCollectionName).process(reindexCloudClient);
             } catch (Exception e) {
                 LOG.error("An exception occured swapping cores.", e);
                 throw new ServiceException("Unable to swap SolrCloud collections after a full reindex.", e);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -129,9 +129,6 @@ public class SolrHelperServiceImpl implements SolrHelperService {
     @Resource(name = "blIndexFieldDao")
     protected IndexFieldDao indexFieldDao;
 
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Value(value = "${using.solr.server:true}")
     protected boolean isSolrConfigured;
 
@@ -283,7 +280,7 @@ public class SolrHelperServiceImpl implements SolrHelperService {
 
     @Override
     public String getPrimaryDocumentType() {
-        return (useSku) ? FieldEntity.SKU.getType() : FieldEntity.PRODUCT.getType();
+        return FieldEntity.PRODUCT.getType();
     }
 
     @Override
@@ -331,11 +328,7 @@ public class SolrHelperServiceImpl implements SolrHelperService {
 
     @Override
     public String getIndexableIdFieldName() {
-        if (useSku) {
-            return "skuId";
-        } else {
-            return "productId";
-        }
+        return "productId";
     }
 
     @Override
@@ -972,11 +965,7 @@ public class SolrHelperServiceImpl implements SolrHelperService {
         ExtensionResultStatusType status = searchExtensionManager.getProxy().getSearchableIndexFields(fields);
 
         if (ExtensionResultStatusType.NOT_HANDLED.equals(status)) {
-            if (useSku) {
-                fields = indexFieldDao.readSearchableFieldsByEntityType(FieldEntity.SKU);
-            } else {
-                fields = indexFieldDao.readSearchableFieldsByEntityType(FieldEntity.PRODUCT);
-            }
+            fields = indexFieldDao.readSearchableFieldsByEntityType(FieldEntity.PRODUCT);
         }
 
         return fields;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexService.java
@@ -23,7 +23,6 @@ import org.apache.solr.common.SolrInputDocument;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.locale.domain.Locale;
 import org.broadleafcommerce.core.catalog.domain.Indexable;
-import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.search.domain.IndexField;
 
 import java.io.IOException;
@@ -225,22 +224,6 @@ public interface SolrIndexService {
      */
     public void performCachedOperation(SolrIndexCachedOperation.CacheOperation cacheOperation) throws ServiceException;
     
-    /**
-     * <p>
-     * Filters out Skus that shouldn't be indexed if any of the following are true:
-     * 
-     * <p>
-     * <ol>
-     *  <li>If it's inactive</li>
-     *  <li>If it's a default Sku and shouldn't be sold without product options</li>
-     *  <li>If it's a default Sku for a Product Bundle</li>
-     * </ol>
-     * 
-     * @param skus
-     * @return a new list based on the given set of <b>skus</b> that only contains Skus that should be indexed
-     */
-    public List<Sku> filterIndexableSkus(List<Sku> skus);
-
     /**
      * Iterates through the fields for this indexable and indexes any SearchField's or SearchFacet's.
      *  @param document

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexService.java
@@ -18,7 +18,6 @@
 package org.broadleafcommerce.core.search.service.solr.index;
 
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
 import org.broadleafcommerce.common.exception.ServiceException;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
 import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
@@ -75,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -525,7 +527,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     
     @Override
     public SolrInputDocument buildDocument(final Indexable indexable, List<IndexField> fields, List<Locale> locales) {
-        final SolrInputDocument document = new SolrInputDocument(new String[0]);
+        final SolrInputDocument document = new SolrInputDocument(new LinkedHashMap<String,SolrInputField>());
 
         attachBasicDocumentFields(indexable, document);
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -525,7 +525,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     
     @Override
     public SolrInputDocument buildDocument(final Indexable indexable, List<IndexField> fields, List<Locale> locales) {
-        final SolrInputDocument document = new SolrInputDocument();
+        final SolrInputDocument document = new SolrInputDocument(new String[0]);
 
         attachBasicDocumentFields(indexable, document);
 

--- a/core/broadleaf-framework/src/main/resources/config/bc/fw/common.properties
+++ b/core/broadleaf-framework/src/main/resources/config/bc/fw/common.properties
@@ -29,9 +29,6 @@ solr.cloud.defaultNumShards=2
 # When creating a collection in SolrCloud, you can specify the configuration by name as it is stored in Zookeeper
 solr.cloud.configName=blc
 
-# This indicates if we should be indexing / browsing by Sku instead of by Product (experimental)
-solr.index.use.sku=false
-
 # --------------------------------
 # These properties affect the way that documents are committed to Solr. The following 4 default values are reasonable 
 # for doing bulk indexing, but may not be affective when updating Solr incrementally or often.

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/checkout/service/workflow/ValidateProductOptionsActivitySpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/checkout/service/workflow/ValidateProductOptionsActivitySpec.groovy
@@ -65,21 +65,6 @@ class ValidateProductOptionsActivitySpec extends BaseCheckoutActivitySpec {
         mockProductOptionValidationService = Spy(ProductOptionValidationServiceImpl)
     }
 
-    def "Test that validation is skipped when useSku is set"() {
-        setup:
-        activity = new ValidateProductOptionsActivity().with {
-            useSku = true
-            productOptionValidationService = mockProductOptionValidationService
-            it
-        }
-
-        when: "I execute the ValidateProductOptionsActivity"
-        context = activity.execute(context)
-
-        then: "No validation steps should be taken, and the ProductOptionValidationService should never be used"
-        0 * mockProductOptionValidationService._
-    }
-
     def "Test that exception is thrown when attributeValues for a DiscreteOrder Item when ProductOptions are required are not provided"() {
         setup:
 
@@ -96,7 +81,6 @@ class ValidateProductOptionsActivitySpec extends BaseCheckoutActivitySpec {
         context.seedData.order.setOrderItems(orderItems)
 
         activity = new ValidateProductOptionsActivity().with {
-            useSku = false
             productOptionValidationService = mockProductOptionValidationService
             it
         }
@@ -130,7 +114,6 @@ class ValidateProductOptionsActivitySpec extends BaseCheckoutActivitySpec {
         context.seedData.order.setOrderItems(orderItems)
 
         activity = new ValidateProductOptionsActivity().with {
-            useSku = false
             productOptionValidationService = mockProductOptionValidationService
             it
         }
@@ -162,7 +145,6 @@ class ValidateProductOptionsActivitySpec extends BaseCheckoutActivitySpec {
 
 
         activity = new ValidateProductOptionsActivity().with {
-            useSku = false
             productOptionValidationService = mockProductOptionValidationService
             it
         }

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/search/service/solr/SolrIndexServiceSpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/search/service/solr/SolrIndexServiceSpec.groovy
@@ -61,74 +61,10 @@ class SolrIndexServiceSpec extends Specification {
         service.indexFieldDao = mockFieldDao
         service.transactionManager = mockTransactionManager
         service.productDao = mockProductDao
-        service.skuDao = mockSkuDao
         service.localeService = mockLocaleService
         service.shs = mockShs
         service.extensionManager = mockExtensionManager
         service.sandBoxHelper = mockSandBoxHelper
     }
     
-    def "Test that Categories are being properly associated to skus when creating the solr index"(){
-        setup:
-        mockFieldDao.readFieldsByEntityType(FieldEntity.SKU) >> new ArrayList<Field>()
-        
-        service.buildDocument(*_) >> null
-        service.useSku = true;
-
-        SkuImpl testSku1 = Mock(SkuImpl)
-        SkuImpl testSku2 = Mock(SkuImpl)
-        ProductImpl testProduct1 = Mock(ProductImpl)
-        ProductImpl testProduct2 = Mock(ProductImpl)
-        
-        testProduct1.getId() >> 1
-        testProduct2.getId() >> 2
-        
-        testSku1.getProduct() >> testProduct1
-        testSku2.getProduct() >> testProduct2
-        
-        List<Sku> skus = [testSku1, testSku2]
-        
-        List<Long> productIds = [1, 2]
-     
-        when:
-        service.buildIncrementalIndex(skus, mockSolrClient)
-        
-        then:
-        1 * mockSolrIndexDao.populateProductCatalogStructure(productIds, _)
-        
-    }
-    
-    def "Test that Categories are being properly associated to skus when creating the solr index for out of order skus"(){
-        setup:
-        mockFieldDao.readFieldsByEntityType(FieldEntity.SKU) >> new ArrayList<Field>()
-        
-        service.buildDocument(*_) >> null
-        service.useSku = true;
-
-        SkuImpl testSku1 = Mock(SkuImpl)
-        SkuImpl testSku2 = Mock(SkuImpl)
-        SkuImpl testSku3 = Mock(SkuImpl)
-        ProductImpl testProduct1 = Mock(ProductImpl)
-        ProductImpl testProduct2 = Mock(ProductImpl)
-        ProductImpl testProduct3 = Mock(ProductImpl)
-        
-        testProduct1.getId() >> 1
-        testProduct2.getId() >> 2
-        testProduct3.getId() >> 3
-        
-        testSku1.getProduct() >> testProduct1
-        testSku2.getProduct() >> testProduct2
-        testSku3.getProduct() >> testProduct3
-        
-        List<Sku> skus = [testSku3, testSku1, testSku2]
-        
-        List<Long> productIds = [3, 1, 2]
-     
-        when:
-        service.buildIncrementalIndex(skus, mockSolrClient)
-        
-        then:
-        1 * mockSolrIndexDao.populateProductCatalogStructure(productIds, _)
-        
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -808,7 +808,7 @@
             <dependency>
                 <artifactId>solr-solrj</artifactId>
                 <groupId>org.apache.solr</groupId>
-                <version>5.3.1</version>
+                <version>7.3.0</version>
                 <exclusions>
                     <!-- This brings in a very old version of Woodstox, we are manually including this above, next to the
                         Jackson dependencies -->


### PR DESCRIPTION
This change accomplishes 2 main things
- Upgrade Solr version to 7.3.0
- Remove `solr.index.use.sku`
    - This was removed since our sku browsing support is not what it should be so we're simply going to remove what support we have and start over

#### Things changed for compilation based on API changes from Solr 5.3 to 7.3
  - Creating a collection
    - Was: `new CollectionAdminRequest.Create().setCollectionName(collectionName).setNumShards(numShards).setConfigName(solrConfigName)`
    - Now: `CollectionAdminRequest.create(collectionName, solrConfigName, numShards, numReplicas)`
  - Creating a collection alias
    - Was: `new CollectionAdminRequest.CreateAlias().setAliasName(reindex.getDefaultCollection()).setAliasedCollections(collectionName)`
    - Now: `CollectionAdminRequest.createAlias(aliasName, collectionName)`
- CloudSolrClient contructors changed
    - Now it takes a CloudSolrClient#Builder object