### PR TITLE
 Fixed an incompatible cast in the equals method of ProratedOrderItemAdjustmentImpl

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
@@ -200,7 +200,7 @@ public class ProratedOrderItemAdjustmentImpl implements ProratedOrderItemAdjustm
         if (!getClass().isAssignableFrom(obj.getClass())) {
             return false;
         }
-        OrderItemAdjustmentImpl other = (OrderItemAdjustmentImpl) obj;
+        ProratedOrderItemAdjustmentImpl other = (ProratedOrderItemAdjustmentImpl) obj;
 
         if (id != null && other.id != null) {
             return id.equals(other.id);


### PR DESCRIPTION
BroadleafCommerce/QA#3340 

- Fix the cast in the equals method