### PR TITLE
Include the alt text of the static assets on the CMS Pages.

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
@@ -125,7 +125,8 @@ public class AdminAssetUploadController extends AdminAbstractController {
 
         responseMap.put("adminDisplayAssetUrl", request.getContextPath() + assetUrl);
         responseMap.put("assetUrl", assetUrl);
-        
+        responseMap.put("altText", staticAsset.getAltText());
+
         if (staticAsset instanceof ImageStaticAssetImpl) {
             responseMap.put("image", Boolean.TRUE);
             responseMap.put("assetThumbnail", assetUrl + "?smallAdminThumbnail");

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
@@ -55,8 +55,9 @@
             $redactor.on('assetInfoSelected', function(event, fields) {
                 currentRedactor.selection.restore();
                 var assetUrl =   fields['assetUrl'];
+                var altText = fields['altText'];
                 if (assetUrl.charAt(0) == "/") assetUrl = assetUrl.substr(1);
-                var $img = $('<img>', { 'src' : assetUrl });
+                var $img = $('<img>', { 'src' : assetUrl, 'alt': altText });
                 currentRedactor.insert.html($img.outerHTML());
                 BLCAdmin.hideCurrentModal();
             });

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -222,6 +222,12 @@
                 fields['selectedRow'] = $tr;
             }
 
+            var $selectedAssetImg = $('.asset-item.active .image-wrapper img');
+
+            if ($selectedAssetImg.length) {
+                fields['altText'] = $selectedAssetImg.attr('alt');
+            }
+
             return fields;
         },
 


### PR DESCRIPTION
BroadleafCommerce/QA#3343
Include the alt text of the static assets on the CMS Pages.