### PR TITLE
Bundle Dependency Management Enhancements and Preloading

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- *
+ * 
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -22,64 +22,71 @@ import org.springframework.core.io.Resource;
 import java.util.List;
 
 /**
- * This service is responsible for interaction with the {@link ResourceBundleProcessor} to generate
- * bundles for static resources.
- * 
+ * This service is responsible for interaction with
+ * {@link org.broadleafcommerce.common.web.processor.ResourceBundleProcessor} and
+ * {@link org.broadleafcommerce.common.web.processor.ResourcePreloadProcessor} to generate bundles for static resources.
  * @author Andre Azzolini (apazzolini)
  * @author Brian Polster (bpolster)
  */
 public interface ResourceBundlingService {
 
     /**
-     * Returns a newly rebuilt bundled resource given that the passed requestedBundleName had previously been built and cached/persisted via 
-     * the {@code resolveBundleResourceName} method
-     * 
-     * @param requestedBundleName
-     * @return
+     * Returns a newly rebuilt bundled resource given that the passed requestedBundleName had previously been built and cached/persisted via
+     * the {@code resolveBundleResourceName} method.
+     * @param requestedBundleName the requested bundle name
+     * @return the rebuilt bundled resource
      */
-    public Resource rebuildBundledResource(String requestedBundleName);
+    Resource rebuildBundledResource(String requestedBundleName);
 
     /**
      * Returns a file name representing a versioned copy of the bundle.
-     * 
      * <p>
-     * First computes the bundle version by checking examining the files in the bundle.
-     *
-     * <p>
-     * If the bundle does not exist, this method will make a call to create it.  
-     *  
-     * @param requestedBundleName
-     * @return 
+     * First computes the bundle version by examining the files in the bundle. If the bundle does not exist, this method
+     * will create it.
+     * @param requestedBundleName the requested bundle name
+     * @param mappingPrefix       the path prefix for the bundle
+     * @param files               the files the bundle should contain
+     * @return the bundle's resource name
      */
-    public String resolveBundleResourceName(String requestedBundleName, String mappingPrefix, List<String> files);
+    String resolveBundleResourceName(String requestedBundleName, String mappingPrefix, List<String> files);
 
+    /**
+     * Returns a file name representing a versioned copy of the bundle with the <code>bundleAppend</code> text appended
+     * to the end of the bundle.
+     * <p>
+     * First computes the bundle version by examining the files in the bundle. If the bundle does not exist, this method
+     * will create it.
+     * @param requestedBundleName the requested bundle name
+     * @param mappingPrefix       the path prefix for the bundle
+     * @param files               the files the bundle should contain
+     * @param bundleAppend        the text to append at the end of the bundle
+     * @return the bundle's resource name
+     */
     String resolveBundleResourceName(String requestedBundleName, String mappingPrefix, List<String> files, String bundleAppend);
 
     /**
      * Returns a Resource for passed in versionedBundleResourceName.
-     * 
+     * <p>
      * If the bundle does not exist, this method will attempt to create it by using the list
-     * of files that were registered with the initial call to {@link #getBundleResourceName(String, List)}
-     * 
-     * @param versionedBundleResourceName
-     * @return 
+     * of files that were registered with the initial call to
+     * {@link #resolveBundleResourceName(String, String, List)} (String, List)}
+     * @param versionedBundleResourceName the versioned bundle resource name
+     * @return the bundle resource
      */
     Resource resolveBundleResource(String versionedBundleResourceName);
 
     /**
-     * Through configuration, you can provide additional files that will be automatically included
-     * for any bundle.   
-     * 
-     * @param bundleName
-     * @return
+     * Through configuration, you can provide additional files that will be automatically included for any bundle. This
+     * method gets the list of configured additional files.
+     * @param bundleName the name of the bundle to get additional files for
+     * @return list of additional files
      */
     List<String> getAdditionalBundleFiles(String bundleName);
 
     /**
-     * Returns true if the passed in name represents a versionedBundle 
-     * 
-     * @param versionedBundleName
-     * @return
+     * Tells if the given versioned bundle exists
+     * @param versionedBundleName the versioned bundle name
+     * @return true if the bundle exists, false otherwise
      */
     boolean checkForRegisteredBundleFile(String versionedBundleName);
 

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
@@ -17,14 +17,16 @@
  */
 package org.broadleafcommerce.common.resource.service;
 
+import org.broadleafcommerce.common.web.processor.ResourceBundleProcessor;
+import org.broadleafcommerce.common.web.processor.ResourcePreloadProcessor;
 import org.springframework.core.io.Resource;
 
 import java.util.List;
 
 /**
  * This service is responsible for interaction with
- * {@link org.broadleafcommerce.common.web.processor.ResourceBundleProcessor} and
- * {@link org.broadleafcommerce.common.web.processor.ResourcePreloadProcessor} to generate bundles for static resources.
+ * {@link ResourceBundleProcessor} and
+ * {@link ResourcePreloadProcessor} to generate bundles for static resources.
  * @author Andre Azzolini (apazzolini)
  * @author Brian Polster (bpolster)
  */
@@ -32,7 +34,7 @@ public interface ResourceBundlingService {
 
     /**
      * Returns a newly rebuilt bundled resource given that the passed requestedBundleName had previously been built and cached/persisted via
-     * the {@code resolveBundleResourceName} method.
+     * the {@link #resolveBundleResourceName(String, String, List)} method.
      * @param requestedBundleName the requested bundle name
      * @return the rebuilt bundled resource
      */
@@ -69,7 +71,7 @@ public interface ResourceBundlingService {
      * <p>
      * If the bundle does not exist, this method will attempt to create it by using the list
      * of files that were registered with the initial call to
-     * {@link #resolveBundleResourceName(String, String, List)} (String, List)}
+     * {@link #resolveBundleResourceName(String, String, List)}
      * @param versionedBundleResourceName the versioned bundle resource name
      * @return the bundle resource
      */

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/ResourceBundlingService.java
@@ -53,6 +53,8 @@ public interface ResourceBundlingService {
      */
     public String resolveBundleResourceName(String requestedBundleName, String mappingPrefix, List<String> files);
 
+    String resolveBundleResourceName(String requestedBundleName, String mappingPrefix, List<String> files, String bundleAppend);
+
     /**
      * Returns a Resource for passed in versionedBundleResourceName.
      * 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.web.processor;
 
 import java.util.ArrayList;
@@ -207,9 +224,10 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
      * again later without the files attribute.
      * @param attributeFiles the files that were on the attribute (and any additional files to include)
      * @param resourceTagAttributes the attributes that were on the original resource tag
+     * @param context the context of the original resource tag
      * @return list of files to use as resources
      */
-    protected List<String> postProcessUnbundledFileList(List<String> attributeFiles, ResourceTagAttributes resourceTagAttributes) {
+    protected List<String> postProcessUnbundledFileList(List<String> attributeFiles, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
 
         final List<String> filesOnRequest = resourcesRequest.getFilesForBundleName(resourceTagAttributes.name());
 
@@ -220,7 +238,12 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
         } else {
             // store these files on the request in case they're requested again
             // so we can pull them without the template having to have the files attribute again
-            resourcesRequest.saveFilesForBundleName(resourceTagAttributes.name(), attributeFiles);
+
+            List<String> fullFileUrls = new ArrayList<>(attributeFiles.size());
+            for (String file : attributeFiles) {
+                fullFileUrls.add(getFullUnbundledFileName(file, resourceTagAttributes, context));
+            }
+            resourcesRequest.saveFilesForBundleName(resourceTagAttributes.name(), fullFileUrls);
 
             return attributeFiles;
         }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -106,7 +106,8 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
             .defer(Boolean.parseBoolean(tagAttributes.get("defer")))
             .includeAsyncDeferUnbundled(Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
             .dependencyEvent(tagAttributes.get("bundle-dependency-event"))
-            .files(tagAttributes.get("files"));
+            .files(tagAttributes.get("files"))
+            .preloadWhenUnbundled(Boolean.parseBoolean(tagAttributes.get("preload-when-unbundled")));
     }
 
     /**

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -294,10 +294,12 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
 
         if (!hasSavedResources) {
             if (resourceTagAttributes.mappingPrefix() == null) {
-                throw new IllegalArgumentException("A 'mapping-prefix' attribute is required for " + getPrefix() + ":" + getName() + " tags");
+                throw new IllegalArgumentException("A 'mapping-prefix' attribute is required for "
+                        + getPrefix() + ":" + getName() + " tags when they first appear on the template");
             }
             if (StringUtils.isEmpty(resourceTagAttributes.files())) {
-                throw new IllegalArgumentException("A 'files' attribute is required for " + getPrefix() + ":" + getName() + " tags");
+                throw new IllegalArgumentException("A 'files' attribute is required for "
+                        + getPrefix() + ":" + getName() + " tags when they first appear on the template");
             }
         }
     }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -1,0 +1,109 @@
+package org.broadleafcommerce.common.web.processor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.resource.service.ResourceBundlingService;
+import org.broadleafcommerce.common.web.processor.attributes.ResourceTagAttributes;
+import org.broadleafcommerce.presentation.dialect.AbstractBroadleafTagReplacementProcessor;
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Jacob Mitash
+ */
+public abstract class AbstractResourceProcessor extends AbstractBroadleafTagReplacementProcessor {
+
+    @Resource
+    protected Environment environment;
+
+    @Resource(name = "blResourceBundlingService")
+    protected ResourceBundlingService bundlingService;
+
+    /**
+     * Tells if bundling is enabled
+     * @return true if enabled, false otherwise
+     */
+    protected boolean getBundleEnabled() {
+        return Boolean.parseBoolean(environment.getProperty("bundle.enabled"));
+    }
+
+    /**
+     * Gets a list of the requested files for bundling
+     * @param rawFiles comma separated list of files
+     * @return list of requested files with space trimmed
+     */
+    protected List<String> getRequestedFiles(String rawFiles) {
+        final String[] splitFiles = rawFiles.split(",");
+        List<String> files = new ArrayList<>(splitFiles.length);
+
+        for (String file : splitFiles) {
+            files.add(file.trim());
+        }
+
+        return files;
+    }
+
+    /**
+     * Builds the tag attributes of the bundle tag
+     * @param tagAttributes the original attributes of the bundle tag
+     * @return a {@link ResourceTagAttributes} containing the original bundle tag attributes
+     */
+    protected ResourceTagAttributes buildResourceTagAttributes(Map<String, String> tagAttributes) {
+        return new ResourceTagAttributes()
+            .name(tagAttributes.get("name"))
+            .mappingPrefix(tagAttributes.get("mapping-prefix"))
+            .async(tagAttributes.containsKey("async"))
+            .defer(tagAttributes.containsKey("defer"))
+            .includeAsyncDeferUnbundled(tagAttributes.containsKey("includeAsyncDeferUnbundled") && Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
+            .dependencyEvent(tagAttributes.get("bundle-dependency-event"))
+            .files(tagAttributes.get("files"));
+    }
+
+    /**
+     * Gets the full path of an unbundled file.
+     * @param fileName the file name to parse
+     * @param resourceTagAttributes the tag attributes of the original bundle tag (<code>fileName</code> will be used instead of <code>src</code>)
+     * @param context the template context
+     * @return the full path of the unbundled file
+     */
+    protected String getFullUnbundledFileName(String fileName, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
+        return context.parseExpression("@{'" + resourceTagAttributes.mappingPrefix() + fileName.trim() + "'}");
+    }
+
+    /**
+     * Adds the context path to the bundleUrl.    We don't use the Thymeleaf "@" syntax or any other mechanism to
+     * encode this URL as the resolvers could have a conflict.
+     *
+     * For example, resolving a bundle named "style.css" that has a file also named "style.css" creates problems as
+     * the TF or version resolvers both want to version this file.
+     *
+     * @param bundleName the path of the bundle to add
+     * @param context the context of the original bundle tag
+     *
+     * @return the full bundle URL
+     */
+    protected String getBundleUrl(String bundleName, BroadleafTemplateContext context) {
+        String bundleUrl = bundleName;
+
+        if (!StringUtils.startsWith(bundleUrl, "/")) {
+            bundleUrl = "/" + bundleUrl;
+        }
+
+        HttpServletRequest request = context.getRequest();
+        String contextPath = "";
+        if (request != null) {
+            contextPath = request.getContextPath();
+        }
+        if (StringUtils.isNotEmpty(contextPath)) {
+            bundleUrl = contextPath + bundleUrl;
+        }
+
+        return bundleUrl;
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -16,7 +16,9 @@ import org.broadleafcommerce.presentation.model.BroadleafTemplateModel;
 import org.springframework.core.env.Environment;
 
 /**
- * @author Jacob Mitash
+ * An abstract tag replacement processor that provides methods to help get resource/bundle information
+ *
+ * @author Jacob Mitash (jmitash)
  */
 public abstract class AbstractResourceProcessor extends AbstractBroadleafTagReplacementProcessor {
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -93,9 +93,9 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
         return new ResourceTagAttributes()
             .name(tagAttributes.get("name"))
             .mappingPrefix(tagAttributes.get("mapping-prefix"))
-            .async(tagAttributes.containsKey("async"))
-            .defer(tagAttributes.containsKey("defer"))
-            .includeAsyncDeferUnbundled(tagAttributes.containsKey("includeAsyncDeferUnbundled") && Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
+            .async(Boolean.parseBoolean(tagAttributes.get("async")))
+            .defer(Boolean.parseBoolean(tagAttributes.get("defer")))
+            .includeAsyncDeferUnbundled(Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
             .dependencyEvent(tagAttributes.get("bundle-dependency-event"))
             .files(tagAttributes.get("files"));
     }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -124,7 +124,7 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
             .async(Boolean.parseBoolean(tagAttributes.get("async")))
             .defer(Boolean.parseBoolean(tagAttributes.get("defer")))
             .includeAsyncDeferUnbundled(Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
-            .dependencyEvent(tagAttributes.get("bundle-dependency-event"))
+            .bundleDependencyEvent(tagAttributes.get("bundle-dependency-event"))
             .files(tagAttributes.get("files"))
             .bundleCompletedEvent(tagAttributes.get("bundle-completed-event"));
     }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -125,7 +125,6 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
             .includeAsyncDeferUnbundled(Boolean.parseBoolean(tagAttributes.get("includeAsyncDeferUnbundled")))
             .dependencyEvent(tagAttributes.get("bundle-dependency-event"))
             .files(tagAttributes.get("files"))
-            .preloadWhenUnbundled(Boolean.parseBoolean(tagAttributes.get("preload-when-unbundled")))
             .bundleCompletedEvent(tagAttributes.get("bundle-completed-event"));
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -114,7 +114,10 @@ import org.springframework.stereotype.Component;
  * <ul>
  *     <li>name - (required) the final name prefix of the bundle</li>
  *     <li>mapping-prefix - (required) the prefix appended to the final tag output whether that be</li>
- *     <li>files - (required) a comma-separated list of files that should be bundled together</li>
+ *     <li>
+ *         files - (required) a comma-separated list of files that should be bundled together. May be excluded
+ *         in some cases. See note at bottom.
+ *     </li>
  *     <li>async - (optional) true to set <code>async="true"</code> on the resulting tags</li>
  *     <li>defer - (optional) true to set <code>defer="true"</code> on JS or to add non-render-blocking CSS</li>
  *     <li>

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -135,6 +135,7 @@ import org.springframework.stereotype.Component;
  * </ul>
  * @author apazzolini
  * @author bpolster
+ * @author Jacob Mitash (jmitash)
  * @see ResourceBundlingService
  */
 @Component("blResourceBundleProcessor")
@@ -336,6 +337,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
     /**
      * @deprecated Use {@link #getScriptAttributes(ResourceTagAttributes)} instead
      */
+    @Deprecated
     protected Map<String, String> getScriptAttributes(String src, boolean async, boolean defer) {
         ResourceTagAttributes resourceTagAttributes = new ResourceTagAttributes()
                 .src(src)
@@ -367,6 +369,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
     /**
      * @deprecated Use {@link #getLinkAttributes(ResourceTagAttributes)} instead
      */
+    @Deprecated
     protected Map<String, String> getLinkAttributes(String src) {
         return getLinkAttributes(new ResourceTagAttributes().src(src));
     }
@@ -381,8 +384,5 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         attributes.put("rel", "stylesheet");
         attributes.put("href", tagAttributes.src());
         return attributes;
-    }
-
-    static {
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -17,23 +17,17 @@
  */
 package org.broadleafcommerce.common.web.processor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.resource.service.ResourceBundlingService;
 import org.broadleafcommerce.common.web.processor.attributes.ResourceTagAttributes;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafTagReplacementProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateElement;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateModel;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 
@@ -153,51 +147,22 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
     public int getPrecedence() {
         return 10000;
     }
-    
+
     @Override
-    public BroadleafTemplateModel getReplacementModel(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context) {
-        ResourceTagAttributes resourceTagAttributes = buildResourceTagAttributes(tagAttributes);
-
-        List<String> files = getRequestedFiles(resourceTagAttributes.files());
-
-        List<String> additionalBundleFiles = bundlingService.getAdditionalBundleFiles(resourceTagAttributes.name());
-        if (additionalBundleFiles != null) {
-            files.addAll(additionalBundleFiles);
-        }
-
-        BroadleafTemplateModel model = context.createModel();
-        if (getBundleEnabled()) {
-            buildReplacementModelBundled(resourceTagAttributes, files, context, model);
-        } else {
-            buildReplacementModelUnbundled(resourceTagAttributes, files, context, model);
-        }
-
-        return model;
-    }
-
-    /**
-     * Adds the unbundled files to replacement model
-     * @param attributes the original bundle tag attributes
-     * @param files the list of files to add to the model
-     * @param context the context of the original bundle tag
-     * @param model the model to add the script to
-     */
-    protected void buildReplacementModelUnbundled(ResourceTagAttributes attributes, List<String> files, BroadleafTemplateContext context, BroadleafTemplateModel model) {
+    protected BroadleafTemplateModel buildModelUnbundled(List<String> files, ResourceTagAttributes attributes, BroadleafTemplateContext context) {
+        final BroadleafTemplateModel model = context.createModel();
         for (String fileName : files) {
             ResourceTagAttributes unbundledAttributes = new ResourceTagAttributes(attributes)
                     .src(getFullUnbundledFileName(fileName, attributes, context));
             addElementToModel(unbundledAttributes, context, model);
         }
+
+        return model;
     }
 
-    /**
-     * Adds the bundle to replacement model
-     * @param attributes the original bundle tag attributes
-     * @param files the list of files to add to the model
-     * @param context the context of the original bundle tag
-     * @param model the model to add the script to
-     */
-    protected void buildReplacementModelBundled(ResourceTagAttributes attributes, List<String> files, BroadleafTemplateContext context, BroadleafTemplateModel model) {
+    @Override
+    protected BroadleafTemplateModel buildModelBundled(List<String> files, ResourceTagAttributes attributes, BroadleafTemplateContext context) {
+        final BroadleafTemplateModel model = context.createModel();
         final String bundleResourceName = bundlingService.resolveBundleResourceName(attributes.name(),
                 attributes.mappingPrefix(),
                 files);
@@ -206,6 +171,8 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         attributes.src(bundleUrl);
 
         addElementToModel(attributes, context, model);
+
+        return model;
     }
 
     /**

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -207,7 +207,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
             }
 
             // add bundle complete script if needed/supported
-            final BroadleafTemplateElement bundleCompleteElement = buildUnbundledSyncBundleCompletedEventElement(attributes, context);
+            final BroadleafTemplateElement bundleCompleteElement = buildUnbundledSyncCompletedEventElement(attributes, context);
             if (bundleCompleteElement != null) {
                 model.addElement(bundleCompleteElement);
             }
@@ -302,7 +302,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
                 model.addElement(element);
             }
         } else {
-            model.addElement(context.createNonVoidElement("link", getLinkAttributes(attributes), true));
+            model.addElement(context.createNonVoidElement("link", getNormalCssAttributes(attributes), true));
         }
     }
 
@@ -319,10 +319,8 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         deferredCssAttributes.put("href", attributes.src());
         elements.add(context.createStandaloneElement("link", deferredCssAttributes, true));
 
-        Map<String, String> normalCssAttributes = new HashMap<>(this.normalCssAttributes);
-        normalCssAttributes.put("href", attributes.src());
         BroadleafTemplateNonVoidElement noScriptElement = context.createNonVoidElement("noscript");
-        noScriptElement.addChild(context.createStandaloneElement("link", normalCssAttributes, true));
+        noScriptElement.addChild(context.createStandaloneElement("link", getNormalCssAttributes(attributes), true));
         elements.add(noScriptElement);
 
         return elements;
@@ -455,21 +453,20 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
     }
 
     /**
-     * @deprecated Use {@link #getLinkAttributes(ResourceTagAttributes)} instead
+     * @deprecated Use {@link #getNormalCssAttributes(ResourceTagAttributes)} instead
      */
     @Deprecated
     protected Map<String, String> getLinkAttributes(String src) {
-        return getLinkAttributes(new ResourceTagAttributes().src(src));
+        return getNormalCssAttributes(new ResourceTagAttributes().src(src));
     }
 
     /**
-     * Builds a map of the attributes to put on a &lt;link&gt; tag
+     * Builds a map of normal (non-deferred) attributes to put on a CSS &lt;link&gt; tag
      * @param tagAttributes the attributes on the original bundle tag
      * @return map of attributes to put on the link tag
      */
-    protected Map<String, String> getLinkAttributes(ResourceTagAttributes tagAttributes) {
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put("rel", "stylesheet");
+    protected Map<String, String> getNormalCssAttributes(ResourceTagAttributes tagAttributes) {
+        Map<String, String> attributes = new HashMap<>(normalCssAttributes);
         attributes.put("href", tagAttributes.src());
         return attributes;
     }
@@ -510,7 +507,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
      * @param context the context of the bundle tag
      * @return the script element or null if not supported
      */
-    protected BroadleafTemplateElement buildUnbundledSyncBundleCompletedEventElement(ResourceTagAttributes attributes, BroadleafTemplateContext context) {
+    protected BroadleafTemplateElement buildUnbundledSyncCompletedEventElement(ResourceTagAttributes attributes, BroadleafTemplateContext context) {
         if (getBundleEnabled() || useAsyncJavaScript(attributes) || attributes.bundleCompletedEvent() == null) {
             return null;
         }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -326,27 +326,34 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         methodName = methodName.replaceAll("-", "_");
         methodName = methodName.replaceAll("\\.", "_");
 
-        String script = "<script>\n" +
-                "if (typeof(" + dependencyEvent + "Event) !== 'undefined'){" +
-                "$(function() {" +
-                "handle" + methodName + "();" +
-                "});" +
+        String script =
+                "<script>" +
+                "function runOnReady(callback, event) {" +
+                "    var watchEvent = typeof(event) == 'undefined' ? 'DOMContentLoaded' : event;" +
+                "    if (document.readyState != 'loading' && !event) {" +
+                "        callback();" +
+                "    } else {" +
+                "        document.addEventListener(watchEvent, callback);" +
+                "    }" +
+                "}; " +
+                "" +
+                "if (typeof(" + dependencyEvent + "Event) !== 'undefined') {" +
+                "    runOnReady(handle" + methodName + ");" +
                 "} else {" +
-                "document.body.addEventListener('" + dependencyEvent + "'," +
-                "function (elem) {" +
-                "$(function() {" +
-                "handle" + methodName + "();" +
-                "});" +
-                "}, false" +
-                ");" +
-                "}" +
+                "    runOnReady(function() {" +
+                "            runOnReady(handle" + methodName + ");" +
+                "        }," +
+                "        '" + dependencyEvent + "');" +
+                "} " +
+                "" +
                 "function handle" + methodName + "() {" +
-                "var script= document.createElement('script');" +
-                "script.type= 'text/javascript';" +
-                "script.src= '" + attributes.src() + "';" +
-                "document.body.append(script);" +
-                "}" +
-                "\n</script>";
+                "    var script = document.createElement('script');" +
+                "    script.type = 'text/javascript';" +
+                "    script.src = '" + attributes.src() + "';" +
+                "    document.body.append(script);" +
+                "};" +
+                "</script>";
+
         BroadleafTemplateElement linkedData = context.createTextElement(script);
         model.addElement(linkedData);
     }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -17,13 +17,6 @@
  */
 package org.broadleafcommerce.common.web.processor;
 
-import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.resource.service.ResourceBundlingService;
 import org.broadleafcommerce.common.web.processor.attributes.ResourceTagAttributes;
@@ -33,6 +26,13 @@ import org.broadleafcommerce.presentation.model.BroadleafTemplateElement;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateModel;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateNonVoidElement;
 import org.springframework.stereotype.Component;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -198,7 +198,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
 
         final List<String> files = postProcessUnbundledFileList(attributeFiles, attributes, context);
 
-        if (StringUtils.isEmpty(attributes.dependencyEvent())) {
+        if (StringUtils.isEmpty(attributes.bundleDependencyEvent())) {
             // add files one by one
             for (String file : files) {
                 ResourceTagAttributes unbundledAttributes = new ResourceTagAttributes(attributes)
@@ -228,7 +228,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         final String bundleUrl = getBundleUrl(bundleResourcePath, context);
         attributes.src(bundleUrl);
 
-        if (StringUtils.isEmpty(attributes.dependencyEvent())) {
+        if (StringUtils.isEmpty(attributes.bundleDependencyEvent())) {
             addElementToModel(attributes, context, model);
         } else {
             // Since the bundle needs to be added to the DOM after the dependency event, the only thing we add
@@ -256,7 +256,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
                 .src(src)
                 .async(async)
                 .defer(defer)
-                .dependencyEvent(dependencyEvent);
+                .bundleDependencyEvent(dependencyEvent);
         addElementToModel(tagAttributes, context, model);
     }
 
@@ -335,7 +335,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
                 .src(src)
                 .async(async)
                 .defer(defer)
-                .dependencyEvent(dependencyEvent);
+                .bundleDependencyEvent(dependencyEvent);
         addDependencyRestrictionToModel(Collections.singletonList(src), attributes, context, model);
     }
 
@@ -347,7 +347,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
      */
     protected void addDependencyRestrictionToModel(List<String> files, ResourceTagAttributes attributes, BroadleafTemplateContext context, BroadleafTemplateModel model) {
         final String functionName = cleanUpJavaScriptName(attributes.name());
-        final String dependencyEvent = attributes.dependencyEvent();
+        final String dependencyEvent = attributes.bundleDependencyEvent();
 
         List<String> formattedFiles = new ArrayList<>(files.size());
         for (String file : files) {
@@ -485,7 +485,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
         super.validateTagAttributes(attributes);
 
         if (!attributes.name().endsWith(".js")) {
-            if (attributes.dependencyEvent() != null) {
+            if (attributes.bundleDependencyEvent() != null) {
                 throw new InvalidParameterException("A 'bundle-dependency-event' attribute was specified but is only " +
                         "supported for JavaScript bundles.");
             }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -1,0 +1,143 @@
+package org.broadleafcommerce.common.web.processor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.broadleafcommerce.common.web.processor.attributes.ResourceTagAttributes;
+import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+import org.broadleafcommerce.presentation.model.BroadleafTemplateElement;
+import org.broadleafcommerce.presentation.model.BroadleafTemplateModel;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds &lt;link&gt; tags to the model that preload resources.
+ * <p>
+ * This is useful in combination with bundling where one bundle might depend on another and must wait for the other to
+ * finish before it can be added to the DOM. Since the script isn't immediately in the DOM, the browser doesn't download
+ * the resource until it's added to the DOM, increasing the time before the bundle can be used.
+ * <p>
+ * This processor adds preload link tags which tell the browser to preload (download) a resource even though it isn't
+ * yet in the DOM. Doing so decreases the latency when the script is ready to execute.
+ *
+ * @author Jacob Mitash
+ */
+@Component("blResourcePreloadProcessor")
+@ConditionalOnTemplating
+public class ResourcePreloadProcessor extends AbstractResourceProcessor {
+
+    @Override
+    public String getName() {
+        return "bundlepreload";
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 10000;
+    }
+
+    @Override
+    public BroadleafTemplateModel getReplacementModel(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context) {
+        ResourceTagAttributes resourceTagAttributes = buildResourceTagAttributes(tagAttributes);
+
+        List<String> files = getRequestedFiles(resourceTagAttributes.files());
+
+        BroadleafTemplateModel model;
+        if (getBundleEnabled()) {
+            model = buildModelBundled(files, resourceTagAttributes, context);
+        } else {
+            model = buildModelUnbundled(files, resourceTagAttributes, context);
+        }
+
+        return model;
+    }
+
+    /**
+     * Builds a model for the bundled resource
+     * @param files list of files to build the bundle of
+     * @param resourceTagAttributes the tag attributes of the &lt;blc:bundlepreload&gt; tag
+     * @param context the context of the bundlepreload tag
+     * @return a model containing a preload link for the bundled files
+     */
+    protected BroadleafTemplateModel buildModelBundled(List<String> files, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
+        BroadleafTemplateModel model = context.createModel();
+
+        final String bundleResourceName = bundlingService.resolveBundleResourceName(resourceTagAttributes.name(),
+                resourceTagAttributes.mappingPrefix(),
+                files);
+
+        final String bundleUrl = getBundleUrl(bundleResourceName, context);
+
+        BroadleafTemplateElement bundlePreload = buildPreloadElement(bundleUrl, context);
+        model.addElement(bundlePreload);
+
+        return model;
+    }
+
+    /**
+     * Builds a model for the unbundled resources
+     * @param files the list of files to build preload links for
+     * @param resourceTagAttributes the tag attributes of the &lt;blc:bundlepreload&gt; tag
+     * @param context the context of the bundlepreload tag
+     * @return a model containing preload links for the unbundled files
+     */
+    protected BroadleafTemplateModel buildModelUnbundled(List<String> files, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
+        BroadleafTemplateModel model = context.createModel();
+
+        for (final String file : files) {
+            final String fullFileName = getFullUnbundledFileName(file, resourceTagAttributes, context);
+            BroadleafTemplateElement element = buildPreloadElement(fullFileName, context);
+            model.addElement(element);
+        }
+
+        return model;
+    }
+
+    /**
+     * Builds a preload link for the given path
+     * @param href the path of the file to create the link with
+     * @param context the context of the bundlepreload tag
+     * @return a link element linking to the given resource
+     */
+    protected BroadleafTemplateElement buildPreloadElement(String href, BroadleafTemplateContext context) {
+        final String as = getAs(href);
+        Map<String, String> attributes = getPreloadAttributes(href, as);
+
+        return context.createStandaloneElement("link", attributes, true);
+    }
+
+    /**
+     * Builds a map of the attributes that should be put on the &lt;link&gt; tag.
+     * @param href the href of the resource to preload
+     * @param as the value the "as" attribute should have or null if it shouldn't be included
+     * @return a map of attributes to place on the link tag
+     */
+    protected Map<String, String> getPreloadAttributes(String href, String as) {
+        Map<String, String> attributes = new HashMap<>();
+
+        attributes.put("href", href);
+        attributes.put("rel", "preload");
+        if (as != null) {
+            attributes.put("as", as);
+        }
+
+        return attributes;
+    }
+
+    /**
+     * Gets the "as" attribute for the link based off of the file name
+     * @param file the name of the file
+     * @return an appropriate "as" value or null if none was found
+     */
+    protected String getAs(String file) {
+        if (file.endsWith(".js")) {
+            return "script";
+        } else if (file.endsWith(".css")) {
+            return "style";
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -87,8 +87,7 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
         }
 
         for (final String file : files) {
-            final String fullFileName = getFullUnbundledFileName(file, resourceTagAttributes, context);
-            BroadleafTemplateElement element = buildPreloadElement(fullFileName, context);
+            BroadleafTemplateElement element = buildPreloadElement(file, context);
             model.addElement(element);
         }
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -43,7 +43,8 @@ import org.springframework.stereotype.Component;
  * more information. This helps with not having to duplicate the bundle information across the &lt;blc:bundlepreload&gt;
  * and &lt;blc:bundle&gt; tags.
  * <p>
- * The &lt;bundlepreload&gt; accepts all the parameters that {@link ResourceBundleProcessor} accepts including one more:
+ * The &lt;bundlepreload&gt; accepts all the parameters that {@link ResourceBundleProcessor} accepts, but will only ever
+ * use them if they are relevant to generating the bundle.
  * <br/>
  *
  * @author Jacob Mitash
@@ -80,11 +81,6 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
         BroadleafTemplateModel model = context.createModel();
 
         final List<String> files = postProcessUnbundledFileList(attributeFiles, resourceTagAttributes, context);
-
-        if (!getBundleEnabled() && !resourceTagAttributes.preloadWhenUnbundled()) {
-            //this needs to run after the post process so that the files can be updated on the request
-            return model;
-        }
 
         for (final String file : files) {
             BroadleafTemplateElement element = buildPreloadElement(file, context);

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.web.processor;
 
 import java.util.HashMap;
@@ -62,7 +79,7 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
     protected BroadleafTemplateModel buildModelUnbundled(List<String> attributeFiles, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
         BroadleafTemplateModel model = context.createModel();
 
-        final List<String> files = postProcessUnbundledFileList(attributeFiles, resourceTagAttributes);
+        final List<String> files = postProcessUnbundledFileList(attributeFiles, resourceTagAttributes, context);
 
         if (!getBundleEnabled() && !resourceTagAttributes.preloadWhenUnbundled()) {
             //this needs to run after the post process so that the files can be updated on the request

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -25,6 +25,9 @@ import org.springframework.stereotype.Component;
  * looking it up with the bundle name. See {@link org.broadleafcommerce.common.web.request.ResourcesRequest} for
  * more information. This helps with not having to duplicate the bundle information across the &lt;blc:bundlepreload&gt;
  * and &lt;blc:bundle&gt; tags.
+ * <p>
+ * The &lt;bundlepreload&gt; accepts all the parameters that {@link ResourceBundleProcessor} accepts including one more:
+ * <br/>
  *
  * @author Jacob Mitash
  */
@@ -55,12 +58,16 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
         return model;
     }
 
-
     @Override
     protected BroadleafTemplateModel buildModelUnbundled(List<String> attributeFiles, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
         BroadleafTemplateModel model = context.createModel();
 
         final List<String> files = postProcessUnbundledFileList(attributeFiles, resourceTagAttributes);
+
+        if (!getBundleEnabled() && !resourceTagAttributes.preloadWhenUnbundled()) {
+            //this needs to run after the post process so that the files can be updated on the request
+            return model;
+        }
 
         for (final String file : files) {
             final String fullFileName = getFullUnbundledFileName(file, resourceTagAttributes, context);

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourcePreloadProcessor.java
@@ -38,28 +38,6 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
     }
 
     @Override
-    public BroadleafTemplateModel getReplacementModel(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context) {
-        ResourceTagAttributes resourceTagAttributes = buildResourceTagAttributes(tagAttributes);
-
-        List<String> files = getRequestedFiles(resourceTagAttributes.files());
-
-        BroadleafTemplateModel model;
-        if (getBundleEnabled()) {
-            model = buildModelBundled(files, resourceTagAttributes, context);
-        } else {
-            model = buildModelUnbundled(files, resourceTagAttributes, context);
-        }
-
-        return model;
-    }
-
-    /**
-     * Builds a model for the bundled resource
-     * @param files list of files to build the bundle of
-     * @param resourceTagAttributes the tag attributes of the &lt;blc:bundlepreload&gt; tag
-     * @param context the context of the bundlepreload tag
-     * @return a model containing a preload link for the bundled files
-     */
     protected BroadleafTemplateModel buildModelBundled(List<String> files, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
         BroadleafTemplateModel model = context.createModel();
 
@@ -75,13 +53,7 @@ public class ResourcePreloadProcessor extends AbstractResourceProcessor {
         return model;
     }
 
-    /**
-     * Builds a model for the unbundled resources
-     * @param files the list of files to build preload links for
-     * @param resourceTagAttributes the tag attributes of the &lt;blc:bundlepreload&gt; tag
-     * @param context the context of the bundlepreload tag
-     * @return a model containing preload links for the unbundled files
-     */
+    @Override
     protected BroadleafTemplateModel buildModelUnbundled(List<String> files, ResourceTagAttributes resourceTagAttributes, BroadleafTemplateContext context) {
         BroadleafTemplateModel model = context.createModel();
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -14,6 +14,7 @@ public class ResourceTagAttributes {
     private boolean includeAsyncDeferUnbundled;
     private String dependencyEvent;
     private String files;
+    private boolean preloadWhenUnbundled;
 
     /**
      * Construct a {@link ResourceTagAttributes} with all default values.
@@ -35,6 +36,7 @@ public class ResourceTagAttributes {
         this.includeAsyncDeferUnbundled = toCopy.includeAsyncDeferUnbundled;
         this.dependencyEvent = toCopy.dependencyEvent;
         this.files = toCopy.files;
+        this.preloadWhenUnbundled = toCopy.preloadWhenUnbundled;
     }
 
     public String src() {
@@ -108,6 +110,15 @@ public class ResourceTagAttributes {
 
     public ResourceTagAttributes files(String files) {
         this.files = files;
+        return this;
+    }
+
+    public boolean preloadWhenUnbundled() {
+        return preloadWhenUnbundled;
+    }
+
+    public ResourceTagAttributes preloadWhenUnbundled(boolean preloadWhenUnbundled) {
+        this.preloadWhenUnbundled = preloadWhenUnbundled;
         return this;
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -18,8 +18,11 @@
 package org.broadleafcommerce.common.web.processor.attributes;
 
 /**
- * Builder class that holds attributes relevant to resources.
+ * Builder class that holds attributes relevant to resources, namely those that go on &lt;blc:bundle&gt; and
+ * &lt;blc:bundlepreload&gt; tags.
  *
+ * @see org.broadleafcommerce.common.web.processor.ResourcePreloadProcessor
+ * @see org.broadleafcommerce.common.web.processor.ResourceBundleProcessor
  * @author Jacob Mitash
  */
 public class ResourceTagAttributes {
@@ -32,6 +35,7 @@ public class ResourceTagAttributes {
     private String dependencyEvent;
     private String files;
     private boolean preloadWhenUnbundled;
+    private String bundleCompletedEvent;
 
     /**
      * Construct a {@link ResourceTagAttributes} with all default values.
@@ -54,6 +58,7 @@ public class ResourceTagAttributes {
         this.dependencyEvent = toCopy.dependencyEvent;
         this.files = toCopy.files;
         this.preloadWhenUnbundled = toCopy.preloadWhenUnbundled;
+        this.bundleCompletedEvent = toCopy.bundleCompletedEvent;
     }
 
     public String src() {
@@ -102,7 +107,6 @@ public class ResourceTagAttributes {
         return this;
     }
 
-
     public boolean includeAsyncDeferUnbundled() {
         return includeAsyncDeferUnbundled;
     }
@@ -136,6 +140,15 @@ public class ResourceTagAttributes {
 
     public ResourceTagAttributes preloadWhenUnbundled(boolean preloadWhenUnbundled) {
         this.preloadWhenUnbundled = preloadWhenUnbundled;
+        return this;
+    }
+
+    public String bundleCompletedEvent() {
+        return bundleCompletedEvent;
+    }
+
+    public ResourceTagAttributes bundleCompletedEvent(String bundleCompletedEvent) {
+        this.bundleCompletedEvent = bundleCompletedEvent;
         return this;
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -32,7 +32,7 @@ public class ResourceTagAttributes {
     private boolean async;
     private boolean defer;
     private boolean includeAsyncDeferUnbundled;
-    private String dependencyEvent;
+    private String bundleDependencyEvent;
     private String files;
     private String bundleCompletedEvent;
 
@@ -54,7 +54,7 @@ public class ResourceTagAttributes {
         this.async = toCopy.async;
         this.defer = toCopy.defer;
         this.includeAsyncDeferUnbundled = toCopy.includeAsyncDeferUnbundled;
-        this.dependencyEvent = toCopy.dependencyEvent;
+        this.bundleDependencyEvent = toCopy.bundleDependencyEvent;
         this.files = toCopy.files;
         this.bundleCompletedEvent = toCopy.bundleCompletedEvent;
     }
@@ -114,12 +114,12 @@ public class ResourceTagAttributes {
         return this;
     }
 
-    public String dependencyEvent() {
-        return dependencyEvent;
+    public String bundleDependencyEvent() {
+        return bundleDependencyEvent;
     }
 
-    public ResourceTagAttributes dependencyEvent(String dependencyEvent) {
-        this.dependencyEvent = dependencyEvent;
+    public ResourceTagAttributes bundleDependencyEvent(String bundleDependencyEvent) {
+        this.bundleDependencyEvent = bundleDependencyEvent;
         return this;
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -1,0 +1,102 @@
+package org.broadleafcommerce.common.web.processor.attributes;
+
+/**
+ * Builder class that holds attributes relevant to resources.
+ *
+ * @author Jacob Mitash
+ */
+public class ResourceTagAttributes {
+    private String src;
+    private String name;
+    private String mappingPrefix;
+    private boolean async;
+    private boolean defer;
+    private boolean includeAsyncDeferUnbundled;
+    private String dependencyEvent;
+
+    /**
+     * Construct a {@link ResourceTagAttributes} with all default values.
+     */
+    public ResourceTagAttributes() {
+
+    }
+
+    /**
+     * Copy constructor for a {@link ResourceTagAttributes}.
+     * @param toCopy the attributes to copy from
+     */
+    public ResourceTagAttributes(final ResourceTagAttributes toCopy) {
+        this.src = toCopy.src;
+        this.name = toCopy.name;
+        this.mappingPrefix = toCopy.mappingPrefix;
+        this.async = toCopy.async;
+        this.defer = toCopy.defer;
+        this.includeAsyncDeferUnbundled = toCopy.includeAsyncDeferUnbundled;
+        this.dependencyEvent = toCopy.dependencyEvent;
+    }
+
+    public String src() {
+        return src;
+    }
+
+    public ResourceTagAttributes src(String src) {
+        this.src = src;
+        return this;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public ResourceTagAttributes name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String mappingPrefix() {
+        return mappingPrefix;
+    }
+
+    public ResourceTagAttributes mappingPrefix(String mappingPrefix) {
+        this.mappingPrefix = mappingPrefix;
+        return this;
+    }
+
+    public boolean async() {
+        return async;
+    }
+
+    public ResourceTagAttributes async(boolean async) {
+        this.async = async;
+        return this;
+    }
+
+
+    public boolean defer() {
+        return defer;
+    }
+
+    public ResourceTagAttributes defer(boolean defer) {
+        this.defer = defer;
+        return this;
+    }
+
+
+    public boolean includeAsyncDeferUnbundled() {
+        return includeAsyncDeferUnbundled;
+    }
+
+    public ResourceTagAttributes includeAsyncDeferUnbundled(boolean includeAsyncDeferUnbundled) {
+        this.includeAsyncDeferUnbundled = includeAsyncDeferUnbundled;
+        return this;
+    }
+
+    public String dependencyEvent() {
+        return dependencyEvent;
+    }
+
+    public ResourceTagAttributes dependencyEvent(String dependencyEvent) {
+        this.dependencyEvent = dependencyEvent;
+        return this;
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -13,6 +13,7 @@ public class ResourceTagAttributes {
     private boolean defer;
     private boolean includeAsyncDeferUnbundled;
     private String dependencyEvent;
+    private String files;
 
     /**
      * Construct a {@link ResourceTagAttributes} with all default values.
@@ -33,6 +34,7 @@ public class ResourceTagAttributes {
         this.defer = toCopy.defer;
         this.includeAsyncDeferUnbundled = toCopy.includeAsyncDeferUnbundled;
         this.dependencyEvent = toCopy.dependencyEvent;
+        this.files = toCopy.files;
     }
 
     public String src() {
@@ -97,6 +99,15 @@ public class ResourceTagAttributes {
 
     public ResourceTagAttributes dependencyEvent(String dependencyEvent) {
         this.dependencyEvent = dependencyEvent;
+        return this;
+    }
+
+    public String files() {
+        return files;
+    }
+
+    public ResourceTagAttributes files(String files) {
+        this.files = files;
         return this;
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -34,7 +34,6 @@ public class ResourceTagAttributes {
     private boolean includeAsyncDeferUnbundled;
     private String dependencyEvent;
     private String files;
-    private boolean preloadWhenUnbundled;
     private String bundleCompletedEvent;
 
     /**
@@ -57,7 +56,6 @@ public class ResourceTagAttributes {
         this.includeAsyncDeferUnbundled = toCopy.includeAsyncDeferUnbundled;
         this.dependencyEvent = toCopy.dependencyEvent;
         this.files = toCopy.files;
-        this.preloadWhenUnbundled = toCopy.preloadWhenUnbundled;
         this.bundleCompletedEvent = toCopy.bundleCompletedEvent;
     }
 
@@ -131,15 +129,6 @@ public class ResourceTagAttributes {
 
     public ResourceTagAttributes files(String files) {
         this.files = files;
-        return this;
-    }
-
-    public boolean preloadWhenUnbundled() {
-        return preloadWhenUnbundled;
-    }
-
-    public ResourceTagAttributes preloadWhenUnbundled(boolean preloadWhenUnbundled) {
-        this.preloadWhenUnbundled = preloadWhenUnbundled;
         return this;
     }
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/attributes/ResourceTagAttributes.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.web.processor.attributes;
 
 /**

--- a/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
@@ -1,0 +1,65 @@
+package org.broadleafcommerce.common.web.request;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * Keeps track of the resources needed for &lt;blc:bundle&gt; and &lt;blc:bundlepreload&gt; tags so that the list
+ * of files does not need to be duplicated across both tags.
+ * <p>
+ * If bundling is enabled and appropriate, use the {@link #getBundleForBundleName(String)} and
+ * {@link #saveBundleForBundleName(String, String)} to fetch and store the bundled file for the bundle name.
+ * <p>
+ * If not using bundling, use {@link #getFilesForBundleName(String)} and {@link #saveFilesForBundleName(String, List)}
+ * to fetch and store the files associated with the bundle name.
+ *
+ * @author Jacob Mitash
+ */
+@RequestScope
+@Component("blResourcesRequest")
+public class ResourcesRequest {
+
+    protected Map<String, String> bundlesRequested = new HashMap<>();
+
+    protected Map<String, List<String>> filesRequested = new HashMap<>();
+
+    /**
+     * Gets the bundle for the bundle name if previously used on this request
+     * @param name the name of the bundle to search for
+     * @return the bundle if found, otherwise null
+     */
+    public String getBundleForBundleName(String name) {
+        return bundlesRequested.get(name);
+    }
+
+    /**
+     * Saves the bundle with the given name to the request so it can be recalled later in the template
+     * @param name the name of the bundle to save
+     * @param bundle the path of the bundle
+     */
+    public void saveBundleForBundleName(String name, String bundle) {
+        bundlesRequested.put(name, bundle);
+    }
+
+    /**
+     * Gets the files included in a bundle if previously used on this request
+     * @param name the name of the bundle to search for
+     * @return the list of files in the bundle if found, otherwise null
+     */
+    public List<String> getFilesForBundleName(String name) {
+        return filesRequested.get(name);
+    }
+
+    /**
+     * Saves the bundle with the given name and files so it can be recalled later in the template
+     * @param name the name of the bundle to save
+     * @param files the files to include in the bundle
+     */
+    public void saveFilesForBundleName(String name, List<String> files) {
+        filesRequested.put(name, files);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.web.request;
 
 import java.util.HashMap;


### PR DESCRIPTION
Enhancements to bundle dependency management
-------------------
Referring to the `bundle-dependency-event` attribute on `<blc:bundle>` tags which will add the script to the DOM once the specified event fires:
- The dependency handling JavaScript no longer requires jQuery
- Now works with unbundled files and ensures they are executed in order (except when the files are async/deferred)

New feature: bundle complete events and dependency chaining
-------------------
Bundles can now be chained together to run in order (and asynchronously) so that their dependencies will be satisfied when they run.

A new attribute for `<blc:bundle>` tags, `bundle-completed-event`, has been introduced. This allows you to specify an event to fire when a bundle is complete. It is also compatible with `bundle-dependency-event` so that a bundle can have a dependency and fire an event when complete. The only exception is when bundling is disabled, the scripts are set to be added asynchronously, and the bundle has a `bundle-dependency-event` in which case `bundle-completed-event` is unsupported since the JavaScript can't tell when the bundle is complete.

This new attribute along with `bundle-dependecy-event` allows chaining of bundles as dependencies. For example, if `3.js` must run after `2.js` which must run after `1.js`, this can be expressed as

```
<blc:bundle name="1.js" bundle-completed-event="1Finished" async ... />
<blc:bundle name="2.js" bundle-dependency-event="1Finished" bundle-completed-event="2Finished" async ... />
<blc:bundle name="3.js" bundle-dependency-event="2Finished" async ... />
```

in which case, the bundles will run in the order of 1, 2, 3 despite being asynchronous.

Introduction of \<blc:bundlepreload\>
-------------------
The above example can introduce a problem with page speed as wherever `bundle-dependency-event` is used, the bundle is not in the DOM until the dependency is met, and only then will it be added to the DOM by the dependency-handling JavaScript. This can make the site slower as the browser won't start downloading a JavaScript file until it's added to the DOM. To counter this problem, preloading can be used to tell the browser to download a file before it is needed:
```
<link rel="preload" href="/js/dependent-bundle.js" as="script" />
```
which is the functionality that the `<blc:bundlepreload>` provides by generating these link tags for the bundle.

However, using this with bundles can be messy since the list of files would need to be duplicated for the `<blc:bundlepreload>` and `<blc:bundle>` tags. To solve this problem, the bundle (or list of files if bundling is disabled) is saved on the request whenever a `<blc:bundle>` or `<blc:bundlepreload>` tag is parsed. Any following `<blc:bundlepreload>` and `<blc:bundle>` that need the same list of files can leave off the `files` using only the `name` attribute to refer to the same bundle.

So instead of having this:
```
<blc:bundlepreload
    name="dependent-bundle.js"
    mapping-prefix="/js/"
    files="1.js,
    2.js,
    3.js,
    4.js,
    5.js,
    ...,
    100.js" />

<blc:bundle name="dependent-bundle.js"
    mapping-prefix="/js/"
    async="true"
    defer="true"
    bundle-dependency-event="dependencyEvent"
    files="1.js,
    2.js,
    3.js,
    4.js,
    5.js,
    ...,
    100.js" />
```

The attributes used to generate the bundle only need to appear on the first tag for each bundle:
```
<blc:bundlepreload
    name="dependent-bundle.js"
    mapping-prefix="/js/"
    files="1.js,
    2.js,
    3.js,
    4.js,
    5.js,
    ...,
    100.js" />

<blc:bundle name="dependent-bundle.js" async="true" defer="true" bundle-dependency-event="dependencyEvent" />
```

Note that when bundling is enabled, `bundle-completed-event`s **must** be on both the `<blc:bundlepreload>` and `<blc:bundle>` tags since it affects how the bundle is generated.

Non-render-blocking CSS Support
-------------------
CSS bundles can now be handled in a non-render-blocking fashion by setting `defer="true"`. The CSS will download asynchronously with the help of `<link rel="preload">` tags before being transformed to normal `rel="stylesheet"` when they've downloaded. A `<noscript>` fallback is included to render the CSS normally.

BroadleafCommerce/QA#3344