### PR TITLE
Changed the Google Closure Compiler artifact to the unshaded version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -362,7 +362,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.javascript</groupId>
-            <artifactId>closure-compiler</artifactId>
+            <artifactId>closure-compiler-unshaded</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
@@ -68,7 +68,7 @@ import java.util.List;
 @ConditionalOnClass(name = "com.google.javascript.jscomp.Compiler")
 public class GoogleClosureJavascriptMinificationServiceImpl implements JavascriptMinificationService {
 
-    @Value("${minify.closure.compiler.warningLevel:SILENT}")
+    @Value("${minify.closure.compiler.warningLevel:QUIET}")
     protected String warningLevel;
     
     protected CompilerOptions.LanguageMode languageIn;

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <broadleaf-presentation.version>1.0.2-GA</broadleaf-presentation.version>
         <lombok.version>1.16.18</lombok.version>
         <database.starter.version>1.0.1-GA</database.starter.version>
-        <closure.compiler.version>v20180204</closure.compiler.version>
+        <closure.compiler.version>v20180506</closure.compiler.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:BroadleafCommerce/BroadleafCommerce.git</connection>
@@ -1601,7 +1601,7 @@
             </dependency>
             <dependency>
                 <groupId>com.google.javascript</groupId>
-                <artifactId>closure-compiler</artifactId>
+                <artifactId>closure-compiler-unshaded</artifactId>
                 <version>${closure.compiler.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The default Google Closure Compiler dependency is a shaded version where all of its transitive dependencies are built into the Google Closure Compiler dependency. This prevents us from properly using Maven to manage the transitive dependencies. Additionally updated the version to the latest.