### PR TITLE
Fix ClassCastException in the RatingsProcessor

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RatingsProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RatingsProcessor.java
@@ -59,7 +59,8 @@ public class RatingsProcessor extends AbstractBroadleafVariableModifierProcessor
 
     @Override
     public Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context) {
-        String itemId = String.valueOf(context.parseExpression(tagAttributes.get("itemId")));
+        Object obj = context.parseExpression(tagAttributes.get("itemId"));
+        String itemId = obj.toString();
         RatingSummary ratingSummary = ratingService.readRatingSummary(itemId, RatingType.PRODUCT);
         Map<String, Object> newModelVars = new HashMap<>();
         if (ratingSummary != null) {


### PR DESCRIPTION
Fixed an issue in the RatingsProcessor where after getting the parsed result the generic result was being casted to an unknown type. I suspect this has to do with the generic nature of how the `BroadleafTemplateContext` returns results for parsing therefore the parsing and `String.valueOf` was broken apart so to explicitly tell the `BroadleafTemplateContex`t to return an `Object` and then we call `toString` to turn the `Object` (which should normally be a `Long`) into a `String`. This issue also seemed to only be happening when running with newer versions of Java.

Fixes https://github.com/BroadleafCommerce/QA/issues/3323