### PR TITLE
Added missing admin presentation on fulfillmentOption fields

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
@@ -400,6 +400,9 @@ FulfillmentOptionImpl_fulfillmentType=Fulfillment Type
 FulfillmentOptionImpl_useFlatRates=Use Flat Rates
 FulfillmentOptionImpl_longDescription=Long Description
 FulfillmentOptionImpl_name=Name
+FulfillmentOptionImpl_taxCode=Tax Code
+FulfillmentOptionImpl_taxable=Is Taxable?
+FixedPriceFulfillmentOptionImpl_price=Price
 
 CategoryImpl_General_Tab=General
 CategoryImpl_Subcategories_Tab=Subcategories

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
@@ -27,10 +27,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
-import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.core.order.service.type.FulfillmentType;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -51,16 +48,9 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FULFILLMENT_OPTION")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
-@AdminPresentationMergeOverrides(
-    {
-        @AdminPresentationMergeOverride(name = "", mergeEntries =
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
-                                            booleanOverrideValue = true))
-    }
-)
-@AdminPresentationClass(friendlyName = "Base Fulfillment Option")
+@AdminPresentationClass(friendlyName = "Fulfillment Option")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class FulfillmentOptionImpl implements FulfillmentOption {
@@ -98,12 +88,20 @@ public class FulfillmentOptionImpl implements FulfillmentOption {
     protected Boolean useFlatRates = true;
 
     @Column(name = "FULFILLMENT_TYPE", nullable = false)
+    @AdminPresentation(friendlyName = "FulfillmentOptionImpl_fulfillmentType",
+                       order = Presentation.FieldOrder.FULFILLMENT_TYPE,
+                       fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+                       broadleafEnumeration = "org.broadleafcommerce.core.order.service.type.FulfillmentType")
     protected String fulfillmentType;
 
-    @Column(name = "TAX_CODE", nullable = true)
+    @Column(name = "TAX_CODE")
+    @AdminPresentation(friendlyName = "FulfillmentOptionImpl_taxCode",
+                       order = Presentation.FieldOrder.TAX_CODE)
     protected String taxCode;
 
     @Column(name = "TAXABLE")
+    @AdminPresentation(friendlyName = "FulfillmentOptionImpl_taxable",
+                       order = Presentation.FieldOrder.TAXABLE)
     protected Boolean taxable = false;
 
     @Override
@@ -215,6 +213,9 @@ public class FulfillmentOptionImpl implements FulfillmentOption {
             public static final int NAME = 1000;
             public static final int DESCRIPTION = 2000;
             public static final int FLATRATES = 9000;
+            public static final int FULFILLMENT_TYPE = 10000;
+            public static final int TAX_CODE = 1100;
+            public static final int TAXABLE = 12000;
         }
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FixedPriceFulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FixedPriceFulfillmentOptionImpl.java
@@ -17,6 +17,8 @@
  */
 package org.broadleafcommerce.core.order.fulfillment.domain;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -29,6 +31,8 @@ import org.broadleafcommerce.core.order.domain.FulfillmentOptionImpl;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
@@ -36,7 +40,6 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.math.BigDecimal;
 
 /**
  * 
@@ -49,9 +52,10 @@ import java.math.BigDecimal;
 @AdminPresentationClass(friendlyName = "Fixed Price Fulfillment")
 public class FixedPriceFulfillmentOptionImpl extends FulfillmentOptionImpl implements FixedPriceFulfillmentOption {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Column(name = "PRICE", precision=19, scale=5, nullable=false)
+    @AdminPresentation(friendlyName = "FixedPriceFulfillmentOptionImpl_price", order = Presentation.FieldOrder.DESCRIPTION + 1000)
     protected BigDecimal price;
     
     @ManyToOne(targetEntity = BroadleafCurrencyImpl.class)
@@ -77,6 +81,34 @@ public class FixedPriceFulfillmentOptionImpl extends FulfillmentOptionImpl imple
     @Override
     public void setCurrency(BroadleafCurrency currency) {
         this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || !getClass().isAssignableFrom(o.getClass())) {
+            return false;
+        }
+
+        final FixedPriceFulfillmentOptionImpl that = (FixedPriceFulfillmentOptionImpl) o;
+
+        return new EqualsBuilder()
+                .appendSuper(super.equals(o))
+                .append(getPrice(), that.getPrice())
+                .append(getCurrency(), that.getCurrency())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .appendSuper(super.hashCode())
+                .append(getPrice())
+                .append(getCurrency())
+                .toHashCode();
     }
 
     @Override


### PR DESCRIPTION
Fixed various missing methods and annotations for FulfillmentOptionImpl and FixedPriceFulfillmentOptionImpl. Also removed metadata override that made all fields read only. Since we don't expose the entity in the admin by default, there's no reason for that, and it makes it more complicated if clients want to manage fulfillmentOptions in the admin.