### PR TITLE
Move Tika dependency to CMS only, and remove the MimeUtils dependency

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -242,10 +242,6 @@
             <artifactId>geronimo-jms_1.1_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.medsea.mimeutil</groupId>
-            <artifactId>mime-util</artifactId>
-	    </dependency>
-        <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -1183,25 +1183,6 @@
                 <version>1.8.13</version>
             </dependency>
             <dependency>
-                <groupId>eu.medsea.mimeutil</groupId>
-                <artifactId>mime-util</artifactId>
-                <version>2.1.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
                 <version>1.17</version>


### PR DESCRIPTION
Originated at https://github.com/BroadleafCommerce/BroadleafCommerce/pull/1854#issuecomment-384110546