### PR TITLE
Introduce Minimum Order Quantity Validation for Skus

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/skuMinOrderQuantity.js
+++ b/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/skuMinOrderQuantity.js
@@ -1,0 +1,6 @@
+(function($, BLCAdmin) {
+
+    var className = 'org.broadleafcommerce.core.catalog.domain.Sku';
+    BLCAdmin.addDependentFieldHandler(className, '#field-hasMinOrderQuantity', '#field-minOrderQuantity', 'true');
+
+})(jQuery, BLCAdmin);

--- a/admin/broadleaf-admin-module/src/main/resources/bl-admin-applicationContext.xml
+++ b/admin/broadleaf-admin-module/src/main/resources/bl-admin-applicationContext.xml
@@ -279,6 +279,7 @@
                 <value>admin/catalog/productOptions.js</value>
                 <value>admin/catalog/offer.js</value>
                 <value>admin/catalog/category.js</value>
+                <value>admin/catalog/skuMinOrderQuantity.js</value>
                 <value>admin/customers/customer.js</value>
                 <value>admin/users/adminUser.js</value>
             </list>

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @Component("blGreaterThanMinValueValidator")
 public class GreaterThanMinValueValidator extends ValidationConfigurationBasedPropertyValidator {
 
-    protected final String INVALID_VALUE_MESSAGE = "Entered value must be less than %s.";
+    protected final String INVALID_VALUE_MESSAGE = "Entered value must be greater than %s.";
     protected final String VALUE_NON_NUMBER_MESSAGE = "Value is not a number.";
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
@@ -1,0 +1,54 @@
+package org.broadleafcommerce.openadmin.server.service.persistence.validation;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
+import org.broadleafcommerce.openadmin.dto.Entity;
+import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Map;
+
+/**
+ * @author Chris Kittrell (ckittrell)
+ */
+@Component("blGreaterThanMinValueValidator")
+public class GreaterThanMinValueValidator extends ValidationConfigurationBasedPropertyValidator {
+
+    protected final String INVALID_VALUE_MESSAGE = "Entered value must be less than %s.";
+    protected final String VALUE_NON_NUMBER_MESSAGE = "Value is not a number.";
+
+    @Override
+    public PropertyValidationResult validate(Entity entity,
+                                             Serializable instance,
+                                             Map<String, FieldMetadata> entityFieldMetadata,
+                                             Map<String, String> validationConfiguration,
+                                             BasicFieldMetadata propertyMetadata,
+                                             String propertyName,
+                                             String value) {
+        BigDecimal minValue = getMinValue(validationConfiguration);
+
+        if (StringUtils.isBlank(value)) {
+            return new PropertyValidationResult(true);
+        }
+
+        try {
+            BigDecimal newValue = new BigDecimal(value);
+
+            if (minValue.compareTo(newValue) > 0) {
+                return new PropertyValidationResult(false, String.format(INVALID_VALUE_MESSAGE, minValue));
+            }
+        } catch (NumberFormatException e) {
+            return new PropertyValidationResult(false, VALUE_NON_NUMBER_MESSAGE);
+        }
+
+        return new PropertyValidationResult(true);
+    }
+
+    private BigDecimal getMinValue(Map<String, String> validationConfiguration) throws NumberFormatException {
+        String minValue = validationConfiguration.get("minValue");
+
+        return new BigDecimal(minValue);
+    }
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/GreaterThanMinValueValidator.java
@@ -17,7 +17,6 @@ import java.util.Map;
 public class GreaterThanMinValueValidator extends ValidationConfigurationBasedPropertyValidator {
 
     protected final String INVALID_VALUE_MESSAGE = "Entered value must be greater than %s.";
-    protected final String VALUE_NON_NUMBER_MESSAGE = "Value is not a number.";
 
     @Override
     public PropertyValidationResult validate(Entity entity,
@@ -40,7 +39,7 @@ public class GreaterThanMinValueValidator extends ValidationConfigurationBasedPr
                 return new PropertyValidationResult(false, String.format(INVALID_VALUE_MESSAGE, minValue));
             }
         } catch (NumberFormatException e) {
-            return new PropertyValidationResult(false, VALUE_NON_NUMBER_MESSAGE);
+            return new PropertyValidationResult(false);
         }
 
         return new PropertyValidationResult(true);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityFramework.properties
@@ -99,6 +99,8 @@ SkuImpl_Dimensions_Group=Dimensions
 SkuImpl_Fulfillment_Group=Fulfillment
 SkuImpl_Container_Group=Container Details
 SkuImpl_Other_Group=Other
+SkuImpl_hasMinOrderQuantity=Does this Sku require a minimum quantity to be purchased?
+SkuImpl_minOrderQuantity=Minimum Quantity per Order
 
 UpSaleProductImpl_Upsale_Promotion_Message=Upsale Promotion Message
 SkuAttributeImpl_Attribute_Name=Attribute Name

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMinOrderQuantity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMinOrderQuantity.java
@@ -1,0 +1,30 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.catalog.domain;
+
+public interface SkuMinOrderQuantity {
+
+    boolean hasMinOrderQuantity();
+
+    void setHasMinOrderQuantity(Boolean hasMinOrderQuantity);
+
+    Integer getMinOrderQuantity();
+
+    void setMinOrderQuantity(Integer minOrderQuantity);
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/WeaveSkuMinOrderQuantity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/WeaveSkuMinOrderQuantity.java
@@ -23,7 +23,7 @@ import org.broadleafcommerce.common.presentation.ValidationConfiguration;
 
 import javax.persistence.Column;
 
-public class WeaveSkuMinOrderQuantityImpl implements SkuMinOrderQuantity {
+public class WeaveSkuMinOrderQuantity implements SkuMinOrderQuantity {
 
     @Column(name = "HAS_MIN_ORDER_QUANTITY")
     @AdminPresentation(friendlyName = "SkuImpl_hasMinOrderQuantity",
@@ -38,7 +38,7 @@ public class WeaveSkuMinOrderQuantityImpl implements SkuMinOrderQuantity {
         group = SkuAdminPresentation.GroupName.Advanced, order = 2000,
         validationConfigurations = {
             @ValidationConfiguration(validationImplementation = "blGreaterThanMinValueValidator",
-                    configurationItems = { @ConfigurationItem(itemName = "minValue", itemValue = "1") }
+                    configurationItems = { @ConfigurationItem(itemName = "minValue", itemValue = "0") }
             )
         },
         defaultValue = "1")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/WeaveSkuMinOrderQuantityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/WeaveSkuMinOrderQuantityImpl.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.catalog.domain;
+
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.ConfigurationItem;
+import org.broadleafcommerce.common.presentation.ValidationConfiguration;
+
+import javax.persistence.Column;
+
+public class WeaveSkuMinOrderQuantityImpl implements SkuMinOrderQuantity {
+
+    @Column(name = "HAS_MIN_ORDER_QUANTITY")
+    @AdminPresentation(friendlyName = "SkuImpl_hasMinOrderQuantity",
+        tab = SkuAdminPresentation.TabName.Advanced, tabOrder = SkuAdminPresentation.TabOrder.Advanced,
+        group = SkuAdminPresentation.GroupName.Advanced, order = 1000,
+        defaultValue = "false")
+    protected Boolean hasMinOrderQuantity = Boolean.FALSE;
+
+    @Column(name = "MIN_ORDER_QUANTITY")
+    @AdminPresentation(friendlyName = "SkuImpl_minOrderQuantity",
+        tab = SkuAdminPresentation.TabName.Advanced, tabOrder = SkuAdminPresentation.TabOrder.Advanced,
+        group = SkuAdminPresentation.GroupName.Advanced, order = 2000,
+        validationConfigurations = {
+            @ValidationConfiguration(validationImplementation = "blGreaterThanMinValueValidator",
+                    configurationItems = { @ConfigurationItem(itemName = "minValue", itemValue = "1") }
+            )
+        },
+        defaultValue = "1")
+    protected Integer minOrderQuantity;
+
+
+    @Override
+    public boolean hasMinOrderQuantity() {
+        return (hasMinOrderQuantity == null)? Boolean.FALSE : hasMinOrderQuantity;
+    }
+
+    @Override
+    public void setHasMinOrderQuantity(Boolean hasMinOrderQuantity) {
+        this.hasMinOrderQuantity = hasMinOrderQuantity;
+    }
+
+    @Override
+    public Integer getMinOrderQuantity() {
+        return (minOrderQuantity == null)? 1 : minOrderQuantity;
+    }
+
+    @Override
+    public void setMinOrderQuantity(Integer minOrderQuantity) {
+        this.minOrderQuantity = minOrderQuantity;
+    }
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.service.workflow.add;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang.StringUtils;
@@ -39,6 +39,7 @@ import org.broadleafcommerce.core.order.service.call.OrderItemRequestDTO;
 import org.broadleafcommerce.core.order.service.exception.RequiredAttributeNotProvidedException;
 import org.broadleafcommerce.core.order.service.workflow.CartOperationRequest;
 import org.broadleafcommerce.core.order.service.workflow.add.extension.ValidateAddRequestActivityExtensionManager;
+import org.broadleafcommerce.core.order.service.workflow.service.OrderItemRequestValidationService;
 import org.broadleafcommerce.core.workflow.ActivityMessages;
 import org.broadleafcommerce.core.workflow.BaseActivity;
 import org.broadleafcommerce.core.workflow.ProcessContext;
@@ -57,9 +58,12 @@ import javax.annotation.Resource;
 public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<CartOperationRequest>> {
 
     public static final int ORDER = 1000;
-    
+
     @Value("${solr.index.use.sku}")
     protected boolean useSku;
+
+    @Resource(name = "blOrderItemRequestValidationService")
+    protected OrderItemRequestValidationService orderItemRequestValidationService;
     
     @Resource(name = "blOrderService")
     protected OrderService orderService;
@@ -106,12 +110,17 @@ public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<Cart
             context.stopProcess();
         } else if (orderItemQuantity < 0) {
             throw new IllegalArgumentException("Quantity cannot be negative");
+        } else if (!orderItemRequestValidationService.satisfiesMinQuantityCondition(orderItemRequestDTO, context)) {
+            throw new IllegalArgumentException("This item requires a minimum quantity of " +
+                    orderItemRequestValidationService.getMinQuantity(orderItemRequestDTO, context));
         } else if (request.getOrder() == null) {
             throw new IllegalArgumentException("Order is required when adding item to order");
         } else {
+            // TODO: In the next minor release, refactor this to leverage OrderItemRequestValidationService. Leaving as-is to maintain the API for now.
             Product product = determineProduct(orderItemRequestDTO);
             Sku sku;
             try {
+                // TODO: In the next minor release, refactor this to leverage OrderItemRequestValidationService. Leaving as-is to maintain the API for now.
                 sku = determineSku(product, orderItemRequestDTO.getSkuId(), orderItemRequestDTO.getItemAttributes(),
                     (ActivityMessages) context);
             } catch (RequiredAttributeNotProvidedException e) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationService.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.order.service.workflow.service;
+
+import org.broadleafcommerce.core.catalog.domain.Product;
+import org.broadleafcommerce.core.catalog.domain.Sku;
+import org.broadleafcommerce.core.order.service.call.OrderItemRequestDTO;
+import org.broadleafcommerce.core.order.service.exception.RequiredAttributeNotProvidedException;
+import org.broadleafcommerce.core.order.service.workflow.CartOperationRequest;
+import org.broadleafcommerce.core.workflow.ActivityMessages;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+
+import java.util.Map;
+
+public interface OrderItemRequestValidationService {
+
+    boolean satisfiesMinQuantityCondition(OrderItemRequestDTO orderItemRequestDTO, ProcessContext<CartOperationRequest> context);
+
+    Integer getMinQuantity(OrderItemRequestDTO orderItemRequestDTO, ProcessContext<CartOperationRequest> context);
+
+    Product determineProduct(OrderItemRequestDTO orderItemRequestDTO);
+
+    Sku determineSku(OrderItemRequestDTO orderItemRequestDTO, ActivityMessages messages) throws RequiredAttributeNotProvidedException;
+
+    Sku determineSku(Product product, Long skuId, Map<String, String> attributeValues, ActivityMessages messages) throws RequiredAttributeNotProvidedException;
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationServiceImpl.java
@@ -1,0 +1,210 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.order.service.workflow.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.broadleafcommerce.core.catalog.domain.Product;
+import org.broadleafcommerce.core.catalog.domain.ProductOption;
+import org.broadleafcommerce.core.catalog.domain.ProductOptionXref;
+import org.broadleafcommerce.core.catalog.domain.Sku;
+import org.broadleafcommerce.core.catalog.domain.SkuMinOrderQuantity;
+import org.broadleafcommerce.core.catalog.service.CatalogService;
+import org.broadleafcommerce.core.order.service.ProductOptionValidationService;
+import org.broadleafcommerce.core.order.service.call.OrderItemRequestDTO;
+import org.broadleafcommerce.core.order.service.exception.RequiredAttributeNotProvidedException;
+import org.broadleafcommerce.core.order.service.workflow.CartOperationRequest;
+import org.broadleafcommerce.core.workflow.ActivityMessages;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.Resource;
+
+@Component("blOrderItemRequestValidationService")
+public class OrderItemRequestValidationServiceImpl implements OrderItemRequestValidationService {
+
+    @Resource(name = "blCatalogService")
+    protected CatalogService catalogService;
+
+    @Resource(name = "blProductOptionValidationService")
+    protected ProductOptionValidationService productOptionValidationService;
+
+    @Autowired
+    protected Environment env;
+
+    @Override
+    public boolean satisfiesMinQuantityCondition(OrderItemRequestDTO orderItemRequestDTO, ProcessContext<CartOperationRequest> context) {
+        if (minOrderQuantityCheckIsEnabled()) {
+            Sku sku = determineSku(orderItemRequestDTO, (ActivityMessages) context);
+
+            if (sku instanceof SkuMinOrderQuantity) {
+                boolean hasMinOrderQuantity = ((SkuMinOrderQuantity) sku).hasMinOrderQuantity();
+
+                if (hasMinOrderQuantity) {
+                    Integer requestedQuantity = orderItemRequestDTO.getQuantity();
+                    Integer minOrderQuantity = ((SkuMinOrderQuantity) sku).getMinOrderQuantity();
+
+                    return requestedQuantity >= minOrderQuantity;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public Integer getMinQuantity(OrderItemRequestDTO orderItemRequestDTO, ProcessContext<CartOperationRequest> context) {
+        if (minOrderQuantityCheckIsEnabled()) {
+            Sku sku = determineSku(orderItemRequestDTO, (ActivityMessages) context);
+
+            if (sku instanceof SkuMinOrderQuantity) {
+                return ((SkuMinOrderQuantity) sku).getMinOrderQuantity();
+            }
+        }
+
+        return 1;
+    }
+
+    @Override
+    public Product determineProduct(OrderItemRequestDTO orderItemRequestDTO) {
+        Product product = null;
+        // Validate that if the user specified a productId, it is a legitimate productId
+        if (orderItemRequestDTO.getProductId() != null) {
+            product = catalogService.findProductById(orderItemRequestDTO.getProductId());
+
+            if (product == null) {
+                throw new IllegalArgumentException("Product was specified but no matching product was found with the productId ("
+                                                   + orderItemRequestDTO.getProductId() + ")");
+            }
+        }
+
+        return product;
+    }
+
+    @Override
+    public Sku determineSku(OrderItemRequestDTO orderItemRequestDTO, ActivityMessages messages) throws RequiredAttributeNotProvidedException {
+        Product product = determineProduct(orderItemRequestDTO);
+
+        return determineSku(product, orderItemRequestDTO.getSkuId(), orderItemRequestDTO.getItemAttributes(), messages);
+    }
+
+    @Override
+    public Sku determineSku(Product product, Long skuId, Map<String, String> attributeValues, ActivityMessages messages) throws RequiredAttributeNotProvidedException {
+        Sku sku = null;
+
+        //If sku browsing is enabled, product option data will not be available.
+        if (!shouldUseSku()) {
+            // Check whether the sku is correct given the product options.
+            sku = findMatchingSku(product, attributeValues, messages);
+        }
+
+        if (sku == null && skuId != null) {
+            sku = catalogService.findSkuById(skuId);
+        }
+
+        if (sku == null && product != null) {
+            // Set to the default sku
+            if (canSellDefaultSku(product)) {
+                sku = product.getDefaultSku();
+            } else {
+                throw new RequiredAttributeNotProvidedException("Unable to find non-default sku matching given options and cannot sell default sku", null);
+            }
+        }
+
+        return sku;
+    }
+
+    protected boolean canSellDefaultSku(Product product) {
+        return CollectionUtils.isEmpty(product.getAdditionalSkus()) || product.getCanSellWithoutOptions();
+    }
+
+    protected Sku findMatchingSku(Product product, Map<String, String> attributeValues, ActivityMessages messages) throws RequiredAttributeNotProvidedException {
+        Map<String, String> attributesRelevantToFindMatchingSku = new HashMap<>();
+
+        // Verify that required product-option values were set.
+        if (product != null) {
+            for (ProductOptionXref productOptionXref : ListUtils.emptyIfNull(product.getProductOptionXrefs())) {
+                ProductOption productOption = productOptionXref.getProductOption();
+                String attributeName = productOption.getAttributeName();
+                String attributeValue = attributeValues.get(attributeName);
+                boolean isRequired = productOption.getRequired();
+                boolean hasStrategy = productOptionValidationService.hasProductOptionValidationStrategy(productOption);
+                boolean isAddOrNoneTypes = productOptionValidationService.isAddOrNoneType(productOption);
+
+                if (shouldValidateWithException(isRequired, isAddOrNoneTypes, attributeValue, hasStrategy)) {
+                    productOptionValidationService.validate(productOption, attributeValue);
+                }
+
+                if (hasStrategy && !isAddOrNoneTypes) {
+                    // we need to validate; however, we will not error out
+                    productOptionValidationService.validateWithoutException(productOption, attributeValue, messages);
+                }
+
+                if (productOption.getUseInSkuGeneration()) {
+                    attributesRelevantToFindMatchingSku.put(attributeName, attributeValue);
+                }
+            }
+
+            return findMatchingSku(product, attributesRelevantToFindMatchingSku);
+        }
+
+        return null;
+    }
+
+    protected boolean shouldValidateWithException(boolean isRequired, boolean isAddOrNoneType, String attributeValue, boolean hasStrategy) {
+        return (!hasStrategy || isAddOrNoneType) && (isRequired || StringUtils.isNotEmpty(attributeValue));
+    }
+
+    protected Sku findMatchingSku(Product product, Map<String, String> attributeValuesForSku) {
+        Sku matchingSku = null;
+        List<Long> possibleSkuIds = new ArrayList<>();
+
+        for (Entry<String, String> entry : MapUtils.emptyIfNull(attributeValuesForSku).entrySet()) {
+            possibleSkuIds = productOptionValidationService.findSkuIdsForProductOptionValues(product.getId(), entry.getKey(), entry.getValue(), possibleSkuIds);
+
+            if (CollectionUtils.isEmpty(possibleSkuIds)) {
+                break;
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(possibleSkuIds)) {
+            matchingSku = catalogService.findSkuById(possibleSkuIds.iterator().next());
+        }
+
+        return matchingSku;
+    }
+
+    protected boolean minOrderQuantityCheckIsEnabled() {
+        return env.getProperty("enable.sku.minOrderQuantity.field", boolean.class, false);
+    }
+
+    protected boolean shouldUseSku() {
+        return env.getProperty("solr.index.use.sku", boolean.class, false);
+    }
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
@@ -22,6 +22,7 @@ import org.broadleafcommerce.core.order.domain.OrderItem;
 import org.broadleafcommerce.core.order.service.OrderItemService;
 import org.broadleafcommerce.core.order.service.call.OrderItemRequestDTO;
 import org.broadleafcommerce.core.order.service.workflow.CartOperationRequest;
+import org.broadleafcommerce.core.order.service.workflow.service.OrderItemRequestValidationService;
 import org.broadleafcommerce.core.workflow.BaseActivity;
 import org.broadleafcommerce.core.workflow.ProcessContext;
 import org.springframework.stereotype.Component;
@@ -35,6 +36,9 @@ public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<C
     
     @Resource(name = "blOrderItemService")
     protected OrderItemService orderItemService;
+
+    @Resource(name = "blOrderItemRequestValidationService")
+    protected OrderItemRequestValidationService orderItemRequestValidationService;
     
     public ValidateUpdateRequestActivity() {
         setOrder(ORDER);
@@ -53,6 +57,11 @@ public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<C
         // Throw an exception if the user tried to update an item to a negative quantity
         if (orderItemRequestDTO.getQuantity() < 0) {
             throw new IllegalArgumentException("Quantity cannot be negative");
+        }
+
+        if (!orderItemRequestValidationService.satisfiesMinQuantityCondition(orderItemRequestDTO, context)) {
+            throw new IllegalArgumentException("This item requires a minimum quantity of " +
+                    orderItemRequestValidationService.getMinQuantity(orderItemRequestDTO, context));
         }
 
         // Throw an exception if the user did not specify an order to add the item to

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
@@ -190,7 +190,7 @@
         <property name="sourceMap">
             <map>
                 <entry key="optionalOfferUsesFields" value="org.broadleafcommerce.core.offer.weave.WeaveLegacyOfferUses"/>
-                <entry key="optionalSkuMinOrderQuantityField" value="org.broadleafcommerce.core.catalog.domain.WeaveSkuMinOrderQuantityImpl"/>
+                <entry key="optionalSkuMinOrderQuantityField" value="org.broadleafcommerce.core.catalog.domain.WeaveSkuMinOrderQuantity"/>
             </map>
         </property>
     </bean>

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
@@ -190,6 +190,7 @@
         <property name="sourceMap">
             <map>
                 <entry key="optionalOfferUsesFields" value="org.broadleafcommerce.core.offer.weave.WeaveLegacyOfferUses"/>
+                <entry key="optionalSkuMinOrderQuantityField" value="org.broadleafcommerce.core.catalog.domain.WeaveSkuMinOrderQuantityImpl"/>
             </map>
         </property>
     </bean>
@@ -206,10 +207,16 @@
         <property name="conditionalProperty" value="enable.optional.offer.uses.fields"/>
     </bean>
 
+    <bean id="blSkuMinOrderQuantityConditionalDirectCopyTransformerMember" class="org.broadleafcommerce.common.weave.ConditionalDirectCopyTransformMemberDto">
+        <property name="templateTokens" value="optionalSkuMinOrderQuantityField"/>
+        <property name="conditionalProperty" value="enable.sku.minOrderQuantity.field"/>
+    </bean>
+
     <bean id="blFrameworkConditionalDirectCopyTransformers" class="org.springframework.beans.factory.config.MapFactoryBean">
         <property name="sourceMap">
             <map>
                 <entry key="org.broadleafcommerce.core.offer.domain.OfferImpl" value-ref="blOfferUsesConditionalDirectCopyTransformerMember" />
+                <entry key="org.broadleafcommerce.core.catalog.domain.SkuImpl" value-ref="blSkuMinOrderQuantityConditionalDirectCopyTransformerMember" />
             </map>
         </property>
     </bean>

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/order/service/workflow/add/ValidateAddRequestActivitySpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/order/service/workflow/add/ValidateAddRequestActivitySpec.groovy
@@ -24,11 +24,8 @@ import org.broadleafcommerce.core.order.service.OrderItemService
 import org.broadleafcommerce.core.order.service.OrderService
 import org.broadleafcommerce.core.order.service.ProductOptionValidationService
 import org.broadleafcommerce.core.order.service.call.NonDiscreteOrderItemRequestDTO
-import org.broadleafcommerce.core.order.service.workflow.CartOperationRequest
 import org.broadleafcommerce.core.order.service.workflow.add.ValidateAddRequestActivity
-
-
-
+import org.broadleafcommerce.core.order.service.workflow.service.OrderItemRequestValidationService
 /**
  * execute:
  * <ol>
@@ -55,13 +52,17 @@ class ValidateAddRequestActivitySpec extends BaseAddItemActivitySpec {
     OrderItemService mockOrderItemService = Mock()
     CatalogService mockCatalogService = Mock()
     ProductOptionValidationService mockProductOptionValidationService = Mock()
+    OrderItemRequestValidationService mockOrderItemRequestValidationService = Mock()
 
     def setup() {
+        mockOrderItemRequestValidationService.satisfiesMinQuantityCondition(*_) >> true
+
         activity = Spy(ValidateAddRequestActivity).with {
             orderService = mockOrderService
             orderItemService = mockOrderItemService
             catalogService = mockCatalogService
             productOptionValidationService = mockProductOptionValidationService
+            orderItemRequestValidationService = mockOrderItemRequestValidationService
             it
         }
     }


### PR DESCRIPTION
For the `5.2.5` version of this feature, the `enable.sku.minOrderQuantity.field` must be set to `true` to opt in since there are domain updates for the `BLC_SKU` table.

This feature allows you to specify the minimum allowable quantity for a Sku to be in your cart. For instance, if you set the minimum quantity to 10, then customers must add at least 10 of these items to their cart and cannot update the quantity of this item to be less than 10.