### PR TITLE
Add externalId to Customer core domain

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityProfile.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/messages/GeneratedMessagesEntityProfile.properties
@@ -55,6 +55,7 @@ CustomerImpl_Customer_Id=Id
 CustomerImpl_UserName=UserName
 CustomerImpl_First_Name=First Name
 CustomerImpl_Last_Name=Last Name
+CustomerImpl_Customer_ExternalId=External ID
 CustomerImpl_Email_Address=Email Address
 CustomerImpl_Challenge_Question=Challenge Question
 CustomerImpl_Customer_Receive_Email=Receive Email

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDao.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDao.java
@@ -17,16 +17,15 @@
  */
 package org.broadleafcommerce.profile.core.dao;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.broadleafcommerce.profile.core.domain.Customer;
+
+import java.util.List;
 
 public interface CustomerDao {
 
     public Customer readCustomerById(Long id);
 
-    public Customer readCustomerByExternalId(String id);
+    public Customer readCustomerByExternalId(String externalId);
 
     public List<Customer> readCustomersByIds(List<Long> ids);
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDaoImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDaoImpl.java
@@ -53,12 +53,12 @@ public class CustomerDaoImpl implements CustomerDao {
     }
 
     @Override
-    public Customer readCustomerByExternalId(String id) {
+    public Customer readCustomerByExternalId(String externalId) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
         CriteriaQuery<Customer> criteria = builder.createQuery(Customer.class);
         Root<? extends Customer> customer = criteria.from(entityConfiguration.lookupEntityClass(Customer.class.getName(), Customer.class));
         criteria.select(customer);
-        criteria.where(builder.equal(customer.get("externalId"), id));
+        criteria.where(builder.equal(customer.get("externalId"), externalId));
 
         TypedQuery<Customer> query = em.createQuery(criteria);
         query.setHint(QueryHints.HINT_CACHEABLE, false);

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/Customer.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/Customer.java
@@ -69,6 +69,10 @@ public interface Customer extends Serializable, MultiTenantCloneable<Customer> {
 
     public void setEmailAddress(String emailAddress);
 
+    public String getExternalId();
+
+    public void setExternalId(String externalId);
+
     public ChallengeQuestion getChallengeQuestion();
 
     public void setChallengeQuestion(ChallengeQuestion challengeQuestion);

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAdminPresentation.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAdminPresentation.java
@@ -92,6 +92,7 @@ public interface CustomerAdminPresentation {
         public static final int LAST_NAME = 2000;
         public static final int EMAIL = 3000;
         public static final int USERNAME = 4000;
+        public static final int EXTERNAL_ID = 5000;
 
         public static final int ADDRESSES = 1000;
         public static final int PHONES = 2000;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
@@ -137,6 +137,12 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
             prominent = true, gridOrder = 3000)
     protected String lastName;
 
+    @Column(name = "EXTERNAL_ID")
+    @AdminPresentation(friendlyName = "CustomerImpl_Customer_ExternalId",
+            group = GroupName.Customer, order = FieldOrder.EXTERNAL_ID,
+            visibility = VisibilityEnum.GRID_HIDDEN)
+    protected String externalId;
+
     @ManyToOne(targetEntity = ChallengeQuestionImpl.class)
     @JoinColumn(name = "CHALLENGE_QUESTION_ID")
     @Index(name = "CUSTOMER_CHALLENGE_INDEX", columnNames = { "CHALLENGE_QUESTION_ID" })
@@ -324,6 +330,16 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
     @Override
     public void setEmailAddress(String emailAddress) {
         this.emailAddress = emailAddress;
+    }
+
+    @Override
+    public String getExternalId() {
+        return externalId;
+    }
+
+    @Override
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
     }
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
@@ -105,10 +105,6 @@ public class CustomerServiceImpl implements CustomerService {
     protected List<PasswordUpdatedHandler> passwordResetHandlers = new ArrayList<PasswordUpdatedHandler>();
     protected List<PasswordUpdatedHandler> passwordChangedHandlers = new ArrayList<PasswordUpdatedHandler>();
 
-    //will be externalId field weaved to Customer entity or not
-    @Value("${enable.weave.customer.externalId:false}")
-    protected boolean enableCustomerExternalId = false;
-
     @Override
     @Transactional(TransactionUtils.DEFAULT_TRANSACTION_MANAGER)
     public Customer saveCustomer(Customer customer) {
@@ -276,12 +272,7 @@ public class CustomerServiceImpl implements CustomerService {
 
     @Override
     public Customer readCustomerByExternalId(String userExternalId) {
-        if (enableCustomerExternalId) {
-            return customerDao.readCustomerByExternalId(userExternalId);
-        }else{
-            LOG.error("attempt to find customer by externalId while property enable.weave.customer.externalId is false. Import module is responsible for weaving externalId field to customer");
-            return null;
-        }
+        return customerDao.readCustomerByExternalId(userExternalId);
     }
 
     public void setCustomerDao(CustomerDao customerDao) {


### PR DESCRIPTION
[Discussed in Trello](https://trello.com/c/qdB4rmk4/65-move-customer-external-id-to-the-core-domain-instead-of-import) - Previously weaved on in Import based on property as of BroadleafCommerce/BroadleafCommerce#1600

Our other key importable entities contain their externalId in the core domain (Sku, Category), so this change does the same for Customer. The property previously used to activate the externalId was also removed, since the externalId will always be present.

Related to BroadleafCommerce/Import#61