### PR TITLE
When searching, removing "system" parameters (e.g. blLocale) so they do not influence the primary search parameter

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafCategoryController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/catalog/BroadleafCategoryController.java
@@ -91,6 +91,7 @@ public class BroadleafCategoryController extends BroadleafAbstractController imp
             String fieldName = request.getParameter("facetField");
             List<String> activeFieldFilters = new ArrayList<String>();
             Map<String, String[]> parameters = new HashMap<String, String[]>(request.getParameterMap());
+            parameters.remove("blLocaleCode");
             
             for (Iterator<Entry<String,String[]>> iter = parameters.entrySet().iterator(); iter.hasNext();){
                 Map.Entry<String, String[]> entry = iter.next();


### PR DESCRIPTION
BroadleafCommerce/QA#3314
fix search with non default locale