### PR TITLE
Fix PostgreSQL Clob error with custom PostgreSQLDialect

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
+++ b/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
@@ -22,6 +22,12 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 
 import java.sql.Types;
 
+/**
+ * This custom dialect will treat all Clob types as if they contain a string instead of an OID.
+ *
+ * https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2#changes-to-how-clob-values-are-processed-using-postgresql81dialect-and-its-subclasses
+ *
+ */
 public class BroadleafPostgreSQLDialect extends PostgreSQL95Dialect {
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
+++ b/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.dialect;
+
+import org.hibernate.dialect.PostgreSQL95Dialect;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+import java.sql.Types;
+
+public class BroadleafPostgreSQLDialect extends PostgreSQL95Dialect {
+
+    @Override
+    public SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
+        if (sqlCode == Types.CLOB) {
+            return new PostgreSQLClobTypeDescriptor();
+        }
+
+        return super.getSqlTypeDescriptorOverride(sqlCode);
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/dialect/PostgreSQLClobTypeDescriptor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/dialect/PostgreSQLClobTypeDescriptor.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.dialect;
+
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+import org.hibernate.type.descriptor.sql.BasicBinder;
+import org.hibernate.type.descriptor.sql.BasicExtractor;
+import org.hibernate.type.descriptor.sql.ClobTypeDescriptor;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class PostgreSQLClobTypeDescriptor extends ClobTypeDescriptor {
+    @Override
+    public <X> ValueExtractor<X> getExtractor(JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return new BasicExtractor<X>(javaTypeDescriptor, this) {
+            @Override
+            protected X doExtract(ResultSet rs, String name, WrapperOptions options) throws SQLException {
+                return javaTypeDescriptor.wrap(rs.getString(name), options);
+            }
+
+            @Override
+            protected X doExtract(CallableStatement statement, int index, WrapperOptions options)
+                    throws SQLException {
+                return javaTypeDescriptor.wrap(statement.getString(index), options);
+            }
+
+            @Override
+            protected X doExtract(CallableStatement statement, String name, WrapperOptions options)
+                    throws SQLException {
+                return javaTypeDescriptor.wrap(statement.getString(name), options);
+            }
+        };
+    }
+
+    @Override
+    public <X> BasicBinder<X> getClobBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return new BasicBinder<X>(javaTypeDescriptor, this) {
+            @Override
+            protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options)
+                    throws SQLException {
+                st.setString(index, javaTypeDescriptor.unwrap(value, String.class, options));
+            }
+
+            @Override
+            protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+                    throws SQLException {
+                st.setString(name, javaTypeDescriptor.unwrap(value, String.class, options));
+            }
+        };
+    }
+}


### PR DESCRIPTION
This fixes an issue caused by replacing `StringClobType` with `MaterializedClobType` from the 5.2 upgrade.

Normally a Clob would be stored as a PostgreSQL Large Object pointed to by an OID in the original column. However, the PostgreSQL jdbc driver doesn't implement `createClob`, so instead the string value is placed directly into the column meant for the OID. The Hibernate PostgreSQL dialect does not recognize that the column value is not an OID, so an exception is thrown when attempting to cast the contained string value to a long.

The fix for this comes from a change which [Hibernate made in the past and later reverted.](https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2#changes-to-how-clob-values-are-processed-using-postgresql81dialect-and-its-subclasses) The custom BroadleafPostgreSQLDialect will treat all Clob types as if they contain a string instead of an OID.