### PR TITLE
Add AdminPresentation annotations to reviews domain

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
@@ -270,3 +270,30 @@ Category_List_View=List
 
 ProductImpl_Financial=Financial
 CategoryImpl_ParentCategory=Parent Category
+
+# Reviews
+RatingDetail=Rating Detail
+RatingDetail_rating=Rating
+RatingDetail_submittedDate=Submitted Date
+RatingDetail_customer=Customer
+RatingDetail_summary=Summary
+RatingSummary=Rating Summary
+RatingSummary_itemId=Item ID
+RatingSummary_ratingType=Rating Type
+RatingSummary_averageRating=Average Rating
+RatingSummary_ratings=Ratings
+RatingSummary_reviews=Reviews
+ReviewDetail=Review Detail
+ReviewDetail_customer=Customer
+ReviewDetail_submittedDate=Submitted Date
+ReviewDetail_reviewText=Review Text
+ReviewDetail_status=Status
+ReviewDetail_summary=Summary
+ReviewDetail_feedback=Feedback
+ReviewDetail_ratingDetail=Rating Detail
+ReviewDetail_helpfulCount=Helpful Count
+ReviewDetail_notHelpfulCount=Not Helpful Count
+ReviewFeedback=Review Feedback
+ReviewFeedback_customer=Customer
+ReviewFeedback_isHelpful=Helpful
+ReviewFeedback_reviewDetail=Review Detail

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- *
+ * 
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
@@ -10,19 +10,22 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
 
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.core.domain.CustomerImpl;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import javax.persistence.Column;
@@ -38,7 +41,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_RATING_DETAIL")
-public class RatingDetailImpl implements RatingDetail {
+public class RatingDetailImpl implements RatingDetail, Serializable {
 
     @Id
     @GeneratedValue(generator = "RatingDetailId")
@@ -54,25 +57,31 @@ public class RatingDetailImpl implements RatingDetail {
     private Long id;
 
     @Column(name = "RATING", nullable = false)
+    @AdminPresentation(friendlyName = "RatingDetail_rating", prominent = true)
     protected Double rating;
 
     @Column(name = "RATING_SUBMITTED_DATE", nullable = false)
+    @AdminPresentation(friendlyName = "RatingDetail_submittedDate", prominent = true)
     protected Date ratingSubmittedDate;
 
     @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @Index(name="RATING_CUSTOMER_INDEX", columnNames={"CUSTOMER_ID"})
+    @AdminPresentation(friendlyName = "RatingDetail_customer", prominent = true)
+    @AdminPresentationToOneLookup
     protected Customer customer;
 
     @ManyToOne(optional = false, targetEntity = RatingSummaryImpl.class)
     @JoinColumn(name = "RATING_SUMMARY_ID")
+    @AdminPresentation(friendlyName = "RatingDetail_summary")
+    @AdminPresentationToOneLookup
     protected RatingSummary ratingSummary;
 
     @Override
     public Long getId() {
         return id;
     }
-    
+
     @Override
     public void setId(Long id) {
         this.id = id;
@@ -82,7 +91,7 @@ public class RatingDetailImpl implements RatingDetail {
     public Double getRating() {
         return rating;
     }
-    
+
     @Override
     public void setRating(Double newRating) {
         this.rating = newRating;
@@ -92,7 +101,7 @@ public class RatingDetailImpl implements RatingDetail {
     public Date getRatingSubmittedDate() {
         return ratingSubmittedDate;
     }
-    
+
     @Override
     public void setRatingSubmittedDate(Date ratingSubmittedDate) {
         this.ratingSubmittedDate = ratingSubmittedDate;
@@ -102,7 +111,7 @@ public class RatingDetailImpl implements RatingDetail {
     public Customer getCustomer() {
         return customer;
     }
-    
+
     @Override
     public void setCustomer(Customer customer) {
         this.customer = customer;
@@ -112,11 +121,11 @@ public class RatingDetailImpl implements RatingDetail {
     public RatingSummary getRatingSummary() {
         return ratingSummary;
     }
-    
+
     @Override
     public void setRatingSummary(RatingSummary ratingSummary) {
         this.ratingSummary = ratingSummary;
     }
-    
-    
+
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -10,21 +10,23 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
 
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.core.rating.service.type.RatingType;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
-
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,7 +40,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_RATING_SUMMARY")
-public class RatingSummaryImpl implements RatingSummary {
+public class RatingSummaryImpl implements RatingSummary, Serializable {
 
     @Id
     @GeneratedValue(generator = "RatingSummaryId")
@@ -55,26 +57,34 @@ public class RatingSummaryImpl implements RatingSummary {
 
     @Column(name = "ITEM_ID", nullable = false)
     @Index(name="RATINGSUMM_ITEM_INDEX", columnNames={"ITEM_ID"})
+    @AdminPresentation(friendlyName = "RatingSummary_itemId", prominent = true)
     protected String itemId;
 
     @Column(name = "RATING_TYPE", nullable = false)
     @Index(name="RATINGSUMM_TYPE_INDEX", columnNames={"RATING_TYPE"})
+    @AdminPresentation(friendlyName = "RatingSummary_ratingType",
+        prominent = true,
+        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+        broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.RatingType")
     protected String ratingTypeStr;
 
     @Column(name = "AVERAGE_RATING", nullable = false)
+    @AdminPresentation(friendlyName = "RatingSummary_averageRating", prominent = true)
     protected Double averageRating = new Double(0);
 
     @OneToMany(mappedBy = "ratingSummary", targetEntity = RatingDetailImpl.class, cascade = {CascadeType.ALL})
+    @AdminPresentationCollection(friendlyName = "RatingSummary_ratings")
     protected List<RatingDetail> ratings = new ArrayList<RatingDetail>();
 
     @OneToMany(mappedBy = "ratingSummary", targetEntity = ReviewDetailImpl.class, cascade = {CascadeType.ALL})
+    @AdminPresentationCollection(friendlyName = "RatingSummary_reviews")
     protected List<ReviewDetail> reviews = new ArrayList<ReviewDetail>();
 
     @Override
     public Long getId() {
         return id;
     }
-    
+
     /**
      * @param id the id to set
      */
@@ -87,7 +97,7 @@ public class RatingSummaryImpl implements RatingSummary {
     public Double getAverageRating() {
         return averageRating;
     }
-    
+
     @Override
     public void resetAverageRating() {
         if (ratings == null || ratings.isEmpty()) {
@@ -106,7 +116,7 @@ public class RatingSummaryImpl implements RatingSummary {
     public String getItemId() {
         return itemId;
     }
-    
+
     @Override
     public void setItemId(String itemId) {
         this.itemId = itemId;
@@ -126,7 +136,7 @@ public class RatingSummaryImpl implements RatingSummary {
     public RatingType getRatingType() {
         return new RatingType(ratingTypeStr);
     }
-    
+
     @Override
     public void setRatingType(RatingType type) {
         ratingTypeStr = (type == null) ? null : type.getType();
@@ -136,7 +146,7 @@ public class RatingSummaryImpl implements RatingSummary {
     public List<RatingDetail> getRatings() {
         return ratings == null ? new ArrayList<RatingDetail>() : ratings;
     }
-    
+
     @Override
     public void setRatings(List<RatingDetail> ratings) {
         this.ratings = ratings;
@@ -146,7 +156,7 @@ public class RatingSummaryImpl implements RatingSummary {
     public List<ReviewDetail> getReviews() {
         return reviews == null ? new ArrayList<ReviewDetail>() : reviews;
     }
-    
+
     @Override
     public void setReviews(List<ReviewDetail> reviews) {
         this.reviews = reviews;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -18,7 +18,9 @@
 package org.broadleafcommerce.core.rating.domain;
 
 import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.core.rating.service.type.RatingType;
 import org.hibernate.annotations.GenericGenerator;
@@ -40,7 +42,10 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_RATING_SUMMARY")
+@AdminPresentationClass(friendlyName = "RatingSummary", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 public class RatingSummaryImpl implements RatingSummary, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "RatingSummaryId")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
@@ -29,12 +29,10 @@ import org.broadleafcommerce.profile.core.domain.CustomerImpl;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -54,6 +52,8 @@ import javax.persistence.Table;
 @AdminPresentationClass(friendlyName = "ReviewDetail", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 public class ReviewDetailImpl implements ReviewDetail, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     @Id
     @GeneratedValue(generator = "ReviewDetailId")
     @GenericGenerator(
@@ -65,7 +65,6 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
         }
     )
     @Column(name = "REVIEW_DETAIL_ID")
-    @AdminPresentation(excluded = true)
     private Long id;
 
     @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
@@ -80,7 +79,7 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
     protected Date reivewSubmittedDate;
 
     @Column(name = "REVIEW_TEXT", nullable = false)
-    @AdminPresentation(friendlyName = "ReviewDetail_reviewText")
+    @AdminPresentation(friendlyName = "ReviewDetail_reviewText", largeEntry = true)
     protected String reviewText;
 
     @Column(name = "REVIEW_STATUS", nullable = false)
@@ -92,27 +91,27 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
     protected String reviewStatus;
 
     @Column(name = "HELPFUL_COUNT", nullable = false)
-    @AdminPresentation(excluded = true)
+    @AdminPresentation(friendlyName = "ReviewDetail_helpfulCount")
     protected Integer helpfulCount;
 
     @Column(name = "NOT_HELPFUL_COUNT", nullable = false)
-    @AdminPresentation(excluded = true)
+    @AdminPresentation(friendlyName = "ReviewDetail_notHelpfulCount")
     protected Integer notHelpfulCount;
 
     @ManyToOne(optional = false, targetEntity = RatingSummaryImpl.class)
     @JoinColumn(name = "RATING_SUMMARY_ID")
     @Index(name="REVIEWDETAIL_SUMMARY_INDEX", columnNames={"RATING_SUMMARY_ID"})
-    @AdminPresentationToOneLookup
-    @AdminPresentation(friendlyName = "ReviewDetail_summary")
     protected RatingSummary ratingSummary;
 
     @OneToMany(mappedBy = "reviewDetail", targetEntity = ReviewFeedbackImpl.class, cascade = {CascadeType.ALL})
-    @AdminPresentationCollection(friendlyName = "ReviewDeatil_feedback")
+    @AdminPresentationCollection(friendlyName = "ReviewDetail_feedback")
     protected List<ReviewFeedback> reviewFeedback;
 
     @OneToOne(targetEntity = RatingDetailImpl.class)
     @JoinColumn(name = "RATING_DETAIL_ID")
     @Index(name="REVIEWDETAIL_RATING_INDEX", columnNames={"RATING_DETAIL_ID"})
+    @AdminPresentation(friendlyName = "ReviewDetail_ratingDetail")
+    @AdminPresentationToOneLookup
     protected RatingDetail ratingDetail;
 
     public ReviewDetailImpl() {}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
@@ -10,13 +10,19 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
 
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.core.rating.service.type.ReviewStatusType;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.core.domain.CustomerImpl;
@@ -24,6 +30,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -44,7 +51,8 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_REVIEW_DETAIL")
-public class ReviewDetailImpl implements ReviewDetail {
+@AdminPresentationClass(friendlyName = "ReviewDetail", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+public class ReviewDetailImpl implements ReviewDetail, Serializable {
 
     @Id
     @GeneratedValue(generator = "ReviewDetailId")
@@ -57,35 +65,49 @@ public class ReviewDetailImpl implements ReviewDetail {
         }
     )
     @Column(name = "REVIEW_DETAIL_ID")
+    @AdminPresentation(excluded = true)
     private Long id;
 
     @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @Index(name="REVIEWDETAIL_CUSTOMER_INDEX", columnNames={"CUSTOMER_ID"})
+    @AdminPresentationToOneLookup
+    @AdminPresentation(friendlyName = "ReviewDetail_customer")
     protected Customer customer;
 
     @Column(name = "REVIEW_SUBMITTED_DATE", nullable = false)
+    @AdminPresentation(friendlyName = "ReviewDetail_submittedDate")
     protected Date reivewSubmittedDate;
 
     @Column(name = "REVIEW_TEXT", nullable = false)
+    @AdminPresentation(friendlyName = "ReviewDetail_reviewText")
     protected String reviewText;
 
     @Column(name = "REVIEW_STATUS", nullable = false)
     @Index(name="REVIEWDETAIL_STATUS_INDEX", columnNames={"REVIEW_STATUS"})
+    @AdminPresentation(friendlyName = "ReviewDetail_status",
+        prominent = true,
+        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+        broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.ReviewStatusType")
     protected String reviewStatus;
 
     @Column(name = "HELPFUL_COUNT", nullable = false)
+    @AdminPresentation(excluded = true)
     protected Integer helpfulCount;
 
     @Column(name = "NOT_HELPFUL_COUNT", nullable = false)
+    @AdminPresentation(excluded = true)
     protected Integer notHelpfulCount;
 
     @ManyToOne(optional = false, targetEntity = RatingSummaryImpl.class)
     @JoinColumn(name = "RATING_SUMMARY_ID")
     @Index(name="REVIEWDETAIL_SUMMARY_INDEX", columnNames={"RATING_SUMMARY_ID"})
+    @AdminPresentationToOneLookup
+    @AdminPresentation(friendlyName = "ReviewDetail_summary")
     protected RatingSummary ratingSummary;
 
     @OneToMany(mappedBy = "reviewDetail", targetEntity = ReviewFeedbackImpl.class, cascade = {CascadeType.ALL})
+    @AdminPresentationCollection(friendlyName = "ReviewDeatil_feedback")
     protected List<ReviewFeedback> reviewFeedback;
 
     @OneToOne(targetEntity = RatingDetailImpl.class)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
@@ -17,14 +17,14 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.core.domain.CustomerImpl;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
-
 import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -39,6 +39,8 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_REVIEW_FEEDBACK")
 public class ReviewFeedbackImpl implements ReviewFeedback, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "ReviewFeedbackId")
@@ -56,14 +58,19 @@ public class ReviewFeedbackImpl implements ReviewFeedback, Serializable {
     @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @Index(name="REVIEWFEED_CUSTOMER_INDEX", columnNames={"CUSTOMER_ID"})
+    @AdminPresentation(friendlyName="ReviewFeedback_customer")
+    @AdminPresentationToOneLookup
     protected Customer customer;
 
     @Column(name = "IS_HELPFUL", nullable = false)
+    @AdminPresentation(friendlyName = "ReviewFeedback_isHelpful")
     protected Boolean isHelpful = false;
 
     @ManyToOne(optional = false, targetEntity = ReviewDetailImpl.class)
     @JoinColumn(name = "REVIEW_DETAIL_ID")
     @Index(name="REVIEWFEED_DETAIL_INDEX", columnNames={"REVIEW_DETAIL_ID"})
+    @AdminPresentationToOneLookup
+    @AdminPresentation(friendlyName = "ReviewFeedback_reviewDetail")
     protected ReviewDetail reviewDetail;
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -22,6 +22,8 @@ import org.broadleafcommerce.profile.core.domain.CustomerImpl;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
+
+import java.io.Serializable;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -36,7 +38,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_REVIEW_FEEDBACK")
-public class ReviewFeedbackImpl implements ReviewFeedback {
+public class ReviewFeedbackImpl implements ReviewFeedback, Serializable {
 
     @Id
     @GeneratedValue(generator = "ReviewFeedbackId")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/RatingSortType.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/RatingSortType.java
@@ -10,42 +10,56 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.service.type;
 
+import org.broadleafcommerce.common.BroadleafEnumerationType;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 
-public class RatingSortType implements Serializable {
+public class RatingSortType implements BroadleafEnumerationType, Serializable {
     private static final long serialVersionUID = 1L;
 
     private static final Map<String, RatingSortType> TYPES = new HashMap<String, RatingSortType>();
 
-    public static final RatingSortType MOST_HELPFUL = new RatingSortType("MOST_HELPFUL");
-    public static final RatingSortType MOST_RECENT = new RatingSortType("MOST_RECENT");
-    public static final RatingSortType DEFAULT = new RatingSortType("DEFAULT");
+    public static final RatingSortType MOST_HELPFUL = new RatingSortType("MOST_HELPFUL", "Most Helpful");
+    public static final RatingSortType MOST_RECENT = new RatingSortType("MOST_RECENT", "Most Recent");
+    public static final RatingSortType DEFAULT = new RatingSortType("DEFAULT", "Default");
 
     public static RatingSortType getInstance(final String type) {
         return TYPES.get(type);
     }
 
     private String type;
+    private String friendlyType;
 
     public RatingSortType() {
+        //do nothing
     }
 
-    public RatingSortType(final String type) {
-        setType(type);
+    public RatingSortType(String type) {
+        this(type, type);
     }
 
+    public RatingSortType(String type, String friendlyType) {
+        this.friendlyType = friendlyType;
+        this.setType(type);
+    }
+
+    @Override
     public String getType() {
         return type;
+    }
+
+    @Override
+    public String getFriendlyType() {
+        return friendlyType;
     }
 
     private void setType(final String type) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/RatingType.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/RatingType.java
@@ -10,38 +10,53 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.service.type;
 
+import org.broadleafcommerce.common.BroadleafEnumerationType;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class RatingType {
+public class RatingType implements BroadleafEnumerationType, Serializable {
     private static final long serialVersionUID = 1L;
 
     private static final Map<String, RatingType> TYPES = new HashMap<String, RatingType>();
 
-    public static final RatingType PRODUCT = new RatingType("PRODUCT");
+    public static final RatingType PRODUCT = new RatingType("PRODUCT", "Product");
 
     public static RatingType getInstance(final String type) {
         return TYPES.get(type);
     }
 
     private String type;
+    private String friendlyType;
 
     public RatingType() {
+        //do nothing
     }
 
-    public RatingType(final String type) {
-        setType(type);
+    public RatingType(String type) {
+        this(type, type);
     }
 
+    public RatingType(String type, String friendlyType) {
+        this.friendlyType = friendlyType;
+        this.setType(type);
+    }
+
+    @Override
     public String getType() {
         return type;
+    }
+
+    @Override
+    public String getFriendlyType() {
+        return friendlyType;
     }
 
     private void setType(final String type) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/ReviewStatusType.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/type/ReviewStatusType.java
@@ -10,17 +10,19 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.service.type;
 
+import org.broadleafcommerce.common.BroadleafEnumerationType;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ReviewStatusType {
+public class ReviewStatusType implements BroadleafEnumerationType, Serializable {
     private static final long serialVersionUID = 1L;
 
     private static final Map<String, ReviewStatusType> TYPES = new HashMap<String, ReviewStatusType>();
@@ -34,19 +36,32 @@ public class ReviewStatusType {
     }
 
     private String type;
+    private String friendlyType;
 
     public ReviewStatusType() {
+        //do nothing
     }
 
-    public ReviewStatusType(final String type) {
-        setType(type);
+    public ReviewStatusType(String type) {
+        this(type, type);
     }
 
+    public ReviewStatusType(String type, String friendlyType) {
+        this.friendlyType = friendlyType;
+        this.setType(type);
+    }
+
+    @Override
     public String getType() {
         return type;
     }
 
-    private void setType(String type) {
+    @Override
+    public String getFriendlyType() {
+        return friendlyType;
+    }
+
+    private void setType(final String type) {
         this.type = type;
         if (!TYPES.containsKey(type)) {
             TYPES.put(type, this);


### PR DESCRIPTION
While this does not add it to the admin, this gives the ability to build a view to target the ratings domain in the admin.

Fixes BroadleafCommerce/QA#3374.