### PR TITLE
Overrode default Hibernate naming strategies

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JPAPropertiesPersistenceUnitPostProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JPAPropertiesPersistenceUnitPostProcessor.java
@@ -93,9 +93,9 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blPUHibernateHbm2ddlImport_files;
     @Value("${blPU.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blPUHibernateHbm2ddlImport_files_sql_extractor;
-    @Value("${blPU.hibernate.naming.implicit-strategy}")
+    @Value("${blPU.hibernate.implicit_naming_strategy}")
     protected String blPUHibernateNamingImplicitStrategy;
-    @Value("${blPU.hibernate.naming.physical-strategy}")
+    @Value("${blPU.hibernate.physical_naming_strategy}")
     protected String blPUHibernateNamingPhysicalStrategy;
 
     @Value("${blCMSStorage.hibernate.hbm2ddl.auto}")
@@ -112,9 +112,9 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blCMSStorageHibernateHbm2ddlImport_files;
     @Value("${blCMSStorage.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blCMSStorageHibernateHbm2ddlImport_files_sql_extractor;
-    @Value("${blCMSStorage.hibernate.naming.implicit-strategy}")
+    @Value("${blCMSStorage.hibernate.implicit_naming_strategy}")
     protected String blCMSStorageHibernateNamingImplicitStrategy;
-    @Value("${blCMSStorage.hibernate.naming.physical-strategy}")
+    @Value("${blCMSStorage.hibernate.physical_naming_strategy}")
     protected String blCMSStorageHibernateNamingPhysicalStrategy;
 
     @Value("${blSecurePU.hibernate.hbm2ddl.auto}")
@@ -131,9 +131,9 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blSecurePUHibernateHbm2ddlImport_files;
     @Value("${blSecurePU.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blSecurePUHibernateHbm2ddlImport_files_sql_extractor;
-    @Value("${blSecurePU.hibernate.naming.implicit-strategy}")
+    @Value("${blSecurePU.hibernate.implicit_naming_strategy}")
     protected String blSecurePUHibernateNamingImplicitStrategy;
-    @Value("${blSecurePU.hibernate.naming.physical-strategy}")
+    @Value("${blSecurePU.hibernate.physical_naming_strategy}")
     protected String blSecurePUHibernateNamingPhysicalStrategy;
 
     @PostConstruct
@@ -163,8 +163,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
             }
         }
         if (!blPUHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.hbm2ddl.import_files_sql_extractor", blPUHibernateHbm2ddlImport_files_sql_extractor);
-        if (!blPUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.naming.implicit-strategy", blPUHibernateNamingImplicitStrategy);
-        if (!blPUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.naming.implicit-strategy", blPUHibernateNamingPhysicalStrategy);
+        if (!blPUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.implicit_naming_strategy", blPUHibernateNamingImplicitStrategy);
+        if (!blPUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.physical_naming_strategy", blPUHibernateNamingPhysicalStrategy);
 
         if (!blCMSStorageHibernateHbm2ddlAuto.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.auto", blCMSStorageHibernateHbm2ddlAuto);
         if (!blCMSStorageHibernateDialect.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.dialect", blCMSStorageHibernateDialect);
@@ -173,8 +173,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
         if (!blCMSStorageHibernateCacheUse_query_cache.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.cache.use_query_cache", blCMSStorageHibernateCacheUse_query_cache);
         if (!blCMSStorageHibernateHbm2ddlImport_files.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.import_files", blCMSStorageHibernateHbm2ddlImport_files);
         if (!blCMSStorageHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.import_files_sql_extractor", blCMSStorageHibernateHbm2ddlImport_files_sql_extractor);
-        if (!blCMSStorageHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.naming.implicit-strategy", blCMSStorageHibernateNamingImplicitStrategy);
-        if (!blCMSStorageHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.naming.implicit-strategy", blCMSStorageHibernateNamingPhysicalStrategy);
+        if (!blCMSStorageHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.implicit_naming_strategy", blCMSStorageHibernateNamingImplicitStrategy);
+        if (!blCMSStorageHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.physical_naming_strategy", blCMSStorageHibernateNamingPhysicalStrategy);
 
         if (!blSecurePUHibernateHbm2ddlAuto.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.auto", blSecurePUHibernateHbm2ddlAuto);
         if (!blSecurePUHibernateDialect.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.dialect", blSecurePUHibernateDialect);
@@ -183,8 +183,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
         if (!blSecurePUHibernateCacheUse_query_cache.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.cache.use_query_cache", blSecurePUHibernateCacheUse_query_cache);
         if (!blSecurePUHibernateHbm2ddlImport_files.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.import_files", blSecurePUHibernateHbm2ddlImport_files);
         if (!blSecurePUHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.import_files_sql_extractor", blSecurePUHibernateHbm2ddlImport_files_sql_extractor);
-        if (!blSecurePUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.naming.implicit-strategy", blSecurePUHibernateNamingImplicitStrategy);
-        if (!blSecurePUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.naming.implicit-strategy", blSecurePUHibernateNamingPhysicalStrategy);
+        if (!blSecurePUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.implicit_naming_strategy", blSecurePUHibernateNamingImplicitStrategy);
+        if (!blSecurePUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.physical_naming_strategy", blSecurePUHibernateNamingPhysicalStrategy);
 
         persistenceUnitProperties.putAll(overrideProperties);
     }

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JPAPropertiesPersistenceUnitPostProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JPAPropertiesPersistenceUnitPostProcessor.java
@@ -93,6 +93,10 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blPUHibernateHbm2ddlImport_files;
     @Value("${blPU.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blPUHibernateHbm2ddlImport_files_sql_extractor;
+    @Value("${blPU.hibernate.naming.implicit-strategy}")
+    protected String blPUHibernateNamingImplicitStrategy;
+    @Value("${blPU.hibernate.naming.physical-strategy}")
+    protected String blPUHibernateNamingPhysicalStrategy;
 
     @Value("${blCMSStorage.hibernate.hbm2ddl.auto}")
     protected String blCMSStorageHibernateHbm2ddlAuto;
@@ -108,6 +112,10 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blCMSStorageHibernateHbm2ddlImport_files;
     @Value("${blCMSStorage.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blCMSStorageHibernateHbm2ddlImport_files_sql_extractor;
+    @Value("${blCMSStorage.hibernate.naming.implicit-strategy}")
+    protected String blCMSStorageHibernateNamingImplicitStrategy;
+    @Value("${blCMSStorage.hibernate.naming.physical-strategy}")
+    protected String blCMSStorageHibernateNamingPhysicalStrategy;
 
     @Value("${blSecurePU.hibernate.hbm2ddl.auto}")
     protected String blSecurePUHibernateHbm2ddlAuto;
@@ -123,6 +131,10 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
     protected String blSecurePUHibernateHbm2ddlImport_files;
     @Value("${blSecurePU.hibernate.hbm2ddl.import_files_sql_extractor}")
     protected String blSecurePUHibernateHbm2ddlImport_files_sql_extractor;
+    @Value("${blSecurePU.hibernate.naming.implicit-strategy}")
+    protected String blSecurePUHibernateNamingImplicitStrategy;
+    @Value("${blSecurePU.hibernate.naming.physical-strategy}")
+    protected String blSecurePUHibernateNamingPhysicalStrategy;
 
     @PostConstruct
     public void populatePresetProperties() {
@@ -151,6 +163,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
             }
         }
         if (!blPUHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.hbm2ddl.import_files_sql_extractor", blPUHibernateHbm2ddlImport_files_sql_extractor);
+        if (!blPUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.naming.implicit-strategy", blPUHibernateNamingImplicitStrategy);
+        if (!blPUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blPU.hibernate.naming.implicit-strategy", blPUHibernateNamingPhysicalStrategy);
 
         if (!blCMSStorageHibernateHbm2ddlAuto.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.auto", blCMSStorageHibernateHbm2ddlAuto);
         if (!blCMSStorageHibernateDialect.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.dialect", blCMSStorageHibernateDialect);
@@ -159,6 +173,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
         if (!blCMSStorageHibernateCacheUse_query_cache.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.cache.use_query_cache", blCMSStorageHibernateCacheUse_query_cache);
         if (!blCMSStorageHibernateHbm2ddlImport_files.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.import_files", blCMSStorageHibernateHbm2ddlImport_files);
         if (!blCMSStorageHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.hbm2ddl.import_files_sql_extractor", blCMSStorageHibernateHbm2ddlImport_files_sql_extractor);
+        if (!blCMSStorageHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.naming.implicit-strategy", blCMSStorageHibernateNamingImplicitStrategy);
+        if (!blCMSStorageHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blCMSStorage.hibernate.naming.implicit-strategy", blCMSStorageHibernateNamingPhysicalStrategy);
 
         if (!blSecurePUHibernateHbm2ddlAuto.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.auto", blSecurePUHibernateHbm2ddlAuto);
         if (!blSecurePUHibernateDialect.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.dialect", blSecurePUHibernateDialect);
@@ -167,6 +183,8 @@ public class JPAPropertiesPersistenceUnitPostProcessor implements org.springfram
         if (!blSecurePUHibernateCacheUse_query_cache.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.cache.use_query_cache", blSecurePUHibernateCacheUse_query_cache);
         if (!blSecurePUHibernateHbm2ddlImport_files.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.import_files", blSecurePUHibernateHbm2ddlImport_files);
         if (!blSecurePUHibernateHbm2ddlImport_files_sql_extractor.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.hbm2ddl.import_files_sql_extractor", blSecurePUHibernateHbm2ddlImport_files_sql_extractor);
+        if (!blSecurePUHibernateNamingImplicitStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.naming.implicit-strategy", blSecurePUHibernateNamingImplicitStrategy);
+        if (!blSecurePUHibernateNamingPhysicalStrategy.startsWith("${")) persistenceUnitProperties.put("blSecurePU.hibernate.naming.implicit-strategy", blSecurePUHibernateNamingPhysicalStrategy);
 
         persistenceUnitProperties.putAll(overrideProperties);
     }


### PR DESCRIPTION
Added properties to override the default Hibernate naming strategies to fix inconsistencies introduced with upgrade from Hibernate 4 to 5. By default, Broadleaf will use the legacy implicit naming strategy to ensure clients are not impacted until they can make the necessary changes.

An example from the before the upgrade:

```java
// from PageImpl
@JoinTable(name = "BLC_PAGE_RULE_MAP",
           inverseJoinColumns = @JoinColumn(name = "PAGE_RULE_ID", referencedColumnName = "PAGE_RULE_ID"))
```

would produce the column name (for the join column) `BLC_PAGE_PAGE_ID`.
After the upgrade, the name would be `PageImpl_PAGE_ID`.

See https://github.com/hibernate/hibernate-orm/blob/5.0/migration-guide.adoc#naming-strategies for Hibernate's migration guide
See https://docs.jboss.org/hibernate/orm/5.1/userguide/html_single/chapters/domain/naming.html for more details about Hibernate naming strategies