### PR TITLE
Update Spring, Spring Boot and Spring Security versions to 4.3.18, 1.5.14 and 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>4.3.17.RELEASE</spring.version>
-        <spring.security.version>4.2.6.RELEASE</spring.security.version>
-        <spring.boot.version>1.5.13.RELEASE</spring.boot.version>
+        <spring.version>4.3.18.RELEASE</spring.version>
+        <spring.security.version>4.2.7.RELEASE</spring.security.version>
+        <spring.boot.version>1.5.14.RELEASE</spring.boot.version>
         <spring.mobile.version>1.1.5.RELEASE</spring.mobile.version>
         <jackson.version>2.8.11</jackson.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>


### PR DESCRIPTION
CVEs published in older versions at https://spring.io/blog/2018/06/14/spring-project-vulnerability-reports-published.