### PR TITLE
Update to Spring 5.0.7, Boot 2.0.3, Spring Security 5.0.6 and Jackson 2.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.0.6.RELEASE</spring.version>
-        <spring.security.version>5.0.5.RELEASE</spring.security.version>
-        <spring.boot.version>2.0.2.RELEASE</spring.boot.version>
+        <spring.version>5.0.7.RELEASE</spring.version>
+        <spring.security.version>5.0.6.RELEASE</spring.security.version>
+        <spring.boot.version>2.0.3.RELEASE</spring.boot.version>
         <spring.mobile.version>2.0.0.M3</spring.mobile.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>
         <geb.version>1.0</geb.version>
         <spock.core.version>1.1-groovy-2.4</spock.core.version>


### PR DESCRIPTION
Fixes CVEs reported at https://spring.io/blog/2018/06/14/spring-project-vulnerability-reports-published and ensures that our 6.0 release targets the latest Spring releases.