### PR TITLE
AdornedTargetCollections on a Sku do not work in the admin when viewing the main product page

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
@@ -550,6 +550,15 @@ public class AdminEntityServiceImpl implements AdminEntityService {
             if (maintainedFields == null || maintainedFields.length == 0) {
                 ppr.setValidateUnsubmittedProperties(false);
             }
+
+            // Fix for an adorned target collection where the link is maintained from a
+            // ToOne property on a main entity
+            String linkedProperty = ppr.getAdornedList().getLinkedObjectPath() + "." + ppr.getAdornedList().getLinkedIdProperty();
+            for (Property p : properties) {
+                if (p.getName().equals(linkedProperty)) {
+                    p.setValue(getContextSpecificRelationshipId(mainMetadata, parentEntity, field.getName()));
+                }
+            }
         } else if (md instanceof MapMetadata) {
             ppr.getEntity().setType(new String[] { entityForm.getEntityType() });
             


### PR DESCRIPTION
1. Create an `@AdminPresentationAdornedTargetCollection` on a Sku
2. Update the `sequence_generator` table to ensure that the entries for `ProductImpl` and `SkuImpl` are different so that new products and Skus will have mismatched IDs
3. Add an entry to the new collection in the admin
4. You will get an `EntityNotFoundException` in your logs

```console
java.lang.IllegalArgumentException: Entity not found
	at org.springframework.util.Assert.isTrue(Assert.java:92)
	at com.broadleafcommerce.enterprise.workflow.admin.service.module.EnterpriseAdornedTargetListPersistenceModule.createPopulatedAdornedTargetInstance(EnterpriseAdornedTargetListPersistenceModule.java:436)
```

In normal community, your entry will just not get added at all and fail silently.

Fixes BroadleafCommerce/QA#3409