### PR TITLE
6.0 Community Uploading a large asset causes generic error message

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/exception/FileUploadExceptionAdvice.java
+++ b/common/src/main/java/org/broadleafcommerce/common/exception/FileUploadExceptionAdvice.java
@@ -1,0 +1,43 @@
+package org.broadleafcommerce.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * L%
+ */
+
+@ControllerAdvice
+public class FileUploadExceptionAdvice extends SimpleMappingExceptionResolver {
+
+    protected String DEFAULT_ERROR_VIEW = "utility/error";
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ModelAndView handleMaxSizeException(MaxUploadSizeExceededException exc, HttpServletRequest request, HttpServletResponse response){
+        ModelAndView modelAndView = getModelAndView(DEFAULT_ERROR_VIEW, exc, request);
+        modelAndView.getModel().put("exceptionUUID", "File too large!");
+        modelAndView.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        return modelAndView;
+    }
+}


### PR DESCRIPTION
BroadleafCommerce/QA#3401
Fix pop up after exception max size img.