### PR TITLE
Added null check for order when DatabaseOrderLockManager is configured to throw exception instead of queueing the lock attempt

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/DatabaseOrderLockManager.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/DatabaseOrderLockManager.java
@@ -87,7 +87,7 @@ public class DatabaseOrderLockManager implements OrderLockManager {
 
     @Override
     public Object acquireLockIfAvailable(Order order) {
-        if (order instanceof NullOrderImpl) {
+        if (order == null || order instanceof NullOrderImpl) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Attempted to grab a lock for a NullOrderImpl. Not blocking");
             }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/DatabaseOrderLockManager.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/DatabaseOrderLockManager.java
@@ -89,7 +89,7 @@ public class DatabaseOrderLockManager implements OrderLockManager {
     public Object acquireLockIfAvailable(Order order) {
         if (order == null || order instanceof NullOrderImpl) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Attempted to grab a lock for a NullOrderImpl. Not blocking");
+                LOG.debug("Attempted to grab a lock - order was null or it was a NullOrderImpl. Not blocking");
             }
             return order;
         }


### PR DESCRIPTION
This will get called with order.lock.errorInsteadOfQueue=true.  Fixes https://github.com/BroadleafCommerce/QA/issues/3411