### PR TITLE
Add support for overriding generated index names for Broadleaf Filter columns

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyTransformMember.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyTransformMember.java
@@ -44,4 +44,19 @@ public @interface DirectCopyTransformMember {
      */
     boolean skipOverlaps() default true;
 
+    /**
+     * The name that should be used when dynamically generating index names instead of the table name. This is needed
+     * when two entities have table names that create the same dynamic index names. Generally the strategy used to create
+     * the table name part of the index is to use the first two characters of each word in the table name split on the underscores.
+     * 
+     * i.e.
+     * BLC_APPLE_CARROT -> BLAPCA
+     * BLC_APPLY_CAR    -> BLAPCA
+     * 
+     * Since both tables have a collision, BLC_APPLY_CAR can set this property to "BLAPPCA" to avoid collisions
+     * 
+     * @return
+     */
+    String overrideIndexNameKey() default "";
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/filter/Filter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/filter/Filter.java
@@ -33,6 +33,7 @@ public class Filter {
     String condition;
     String entityImplementationClassName;
     List<String> indexColumnNames;
+    String overrideIndexNameKey;
 
     public String getCondition() {
         return condition;
@@ -66,6 +67,14 @@ public class Filter {
         this.indexColumnNames = indexColumnNames;
     }
 
+    public String getOverrideIndexNameKey() {
+        return overrideIndexNameKey;
+    }
+
+    public void setOverrideIndexNameKey(String overrideIndexNameKey) {
+        this.overrideIndexNameKey = overrideIndexNameKey;
+    }
+
     public Filter copy() {
         Filter copy = new Filter();
         copy.setName(name);
@@ -74,6 +83,7 @@ public class Filter {
         if (!CollectionUtils.isEmpty(indexColumnNames)) {
             copy.setIndexColumnNames(new ArrayList<String>(indexColumnNames));
         }
+        copy.setOverrideIndexNameKey(overrideIndexNameKey);
         return copy;
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/weave/ConditionalDirectCopyTransformMemberDto.java
+++ b/common/src/main/java/org/broadleafcommerce/common/weave/ConditionalDirectCopyTransformMemberDto.java
@@ -44,6 +44,21 @@ public class ConditionalDirectCopyTransformMemberDto implements Serializable {
     protected String conditionalProperty;
     protected Boolean conditionalValue;
 
+    /**
+     * The name that should be used when dynamically generating index names instead of the table name. This is needed
+     * when two entities have table names that create the same dynamic index names. Generally the strategy used to create
+     * the table name part of the index is to use the first two characters of each word in the table name split on the underscores.
+     * 
+     * i.e.
+     * BLC_APPLE_CARROT -> BLAPCA
+     * BLC_APPLY_CAR    -> BLAPCA
+     * 
+     * Since both tables have a collision, BLC_APPLY_CAR can set this property to "BLAPPCA" to avoid collisions
+     * 
+     * @return
+     */
+    protected String overrideIndexNameKey;
+
     public String[] getTemplateTokens() {
         return templateTokens;
     }
@@ -82,5 +97,13 @@ public class ConditionalDirectCopyTransformMemberDto implements Serializable {
 
     public void setConditionalValue(Boolean conditionalValue) {
         this.conditionalValue = conditionalValue;
+    }
+
+    public String getOverrideIndexNameKey() {
+        return overrideIndexNameKey;
+    }
+
+    public void setOverrideIndexNameKey(String overrideIndexNameKey) {
+        this.overrideIndexNameKey = overrideIndexNameKey;
     }
 }


### PR DESCRIPTION
This was added in order to circumvent issues where two entities with similar table names would have identical index names created which causes errors on Hibernate schema creation.

This issue manifested itself with creating indexes on Sandbox columns for the AutomotiveRetailModule entities `BLC_AUTO_MANUFACTURER` and `BLC_AUTO_MAKE` since the index name prefix dynamically created was `BLAUMA` for both tables.