### PR TITLE
Changed redirect path for AJAX requests.

### DIFF
--- a/common/src/main/resources/common_style/templates/utility/blcRedirect.html
+++ b/common/src/main/resources/common_style/templates/utility/blcRedirect.html
@@ -1,1 +1,1 @@
-<div id="blc-redirect-url" class="hidden" th:text="${blc_redirect}" th:if="${!#strings.isEmpty(blc_redirect)}"></div>
+<div id="blc-redirect-url" class="hidden" th:text="@{${blc_redirect}}" th:if="${!#strings.isEmpty(blc_redirect)}"></div>


### PR DESCRIPTION
BroadleafCommerce/QA#3273

th:text="${blc_redirect}" replaced by th:text="@{${blc_redirect}}".