### PR TITLE
Added null check when ValidateAddActivity evaluates the order currency

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
@@ -247,7 +247,7 @@ public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<Cart
     }
 
     protected boolean hasSameCurrency(OrderItemRequestDTO orderItemRequestDTO, CartOperationRequest request, Sku sku) {
-        if (orderItemRequestDTO instanceof NonDiscreteOrderItemRequestDTO || sku == null || sku.getCurrency() == null) {
+        if (orderItemRequestDTO instanceof NonDiscreteOrderItemRequestDTO || sku == null || sku.getCurrency() == null || request.getOrder().getCurrency() == null) {
             return true;
         } else {
             BroadleafCurrency orderCurrency = request.getOrder().getCurrency();


### PR DESCRIPTION
Added null check for order.getCurrency when checking if the order and sku have the same currency.  This is a regression that was introduced when the code was refactored.  Fixes https://github.com/BroadleafCommerce/QA/issues/3418