### PR TITLE
Updated EntityDuplicator domain to be more generic and extinsible

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminOfferController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminOfferController.java
@@ -17,16 +17,12 @@
  */
 package org.broadleafcommerce.admin.web.controller.entity;
 
-import org.broadleafcommerce.common.persistence.EntityDuplicator;
-import org.broadleafcommerce.common.web.BroadleafRequestContext;
-import org.broadleafcommerce.common.web.JsonResponse;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferImpl;
 import org.broadleafcommerce.core.offer.service.OfferService;
 import org.broadleafcommerce.core.offer.service.type.OfferType;
 import org.broadleafcommerce.openadmin.web.controller.entity.AdminBasicEntityController;
 import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
-import org.broadleafcommerce.openadmin.web.form.entity.EntityFormAction;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.MultiValueMap;
@@ -37,9 +33,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Resource;
@@ -61,9 +54,6 @@ public class AdminOfferController extends AdminBasicEntityController {
 
     @Resource(name="blOfferService")
     protected OfferService offerService;
-
-    @Resource(name="blEntityDuplicator")
-    protected EntityDuplicator duplicator;
 
     @Override
     protected String getSectionKey(Map<String, String> pathVars) {
@@ -97,7 +87,6 @@ public class AdminOfferController extends AdminBasicEntityController {
         customCriteria = new String[]{};
         String view = super.viewEntityForm(request, response, model, pathVars, id);
         modifyModelAttributes(model);
-        addDuplicateOption(model, id);
         return view;
     }
     
@@ -123,43 +112,17 @@ public class AdminOfferController extends AdminBasicEntityController {
         return view;
     }
 
+    /**
+     * @deprecated Moved method to superclass
+     */
+    @Deprecated
+    @Override
     @RequestMapping(value = "/{id}/duplicate", method = RequestMethod.POST)
     public String duplicateEntity(HttpServletRequest request, HttpServletResponse response, Model model,
             @PathVariable  Map<String, String> pathVars, @PathVariable(value="id") String id,
-            @ModelAttribute(value="entityForm") EntityForm entityForm, BindingResult result) throws Exception {
-        if (duplicator.validate(OfferImpl.class, Long.parseLong(id))) {
-            String sectionKey = getSectionKey(pathVars);
-            Offer duplicate;
-            try {
-                duplicate = offerService.duplicate(Long.parseLong(id));
-            } catch (Exception e) {
-                return getErrorDuplicatingResponse(response, "Duplication_Failure");
-            }
-
-            // Note that AJAX Redirects need the context path prepended to them
-            return "ajaxredirect:" + getContextPath(request) + sectionKey + "/" + duplicate.getId();
-        } else {
-            return getErrorDuplicatingResponse(response, "Validation_Failure");
-        }
-    }
-
-    protected String getErrorDuplicatingResponse(HttpServletResponse response, String code) {
-        List<Map<String, Object>> errors = new ArrayList<>();
-        String message;
-        BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
-        if (context != null && context.getMessageSource() != null) {
-            message = context.getMessageSource().getMessage(code, null, code, context.getJavaLocale());
-        } else {
-            LOG.warn("Could not find the MessageSource on the current request, not translating the message key");
-            message = "Duplication_Failure";
-        }
-
-        Map<String, Object> errorMap = new HashMap<>();
-        errorMap.put("errorType", "global");
-        errorMap.put("code", code);
-        errorMap.put("message", message);
-        errors.add(errorMap);
-        return new JsonResponse(response).with("errors", errors).done();
+            @ModelAttribute(value="entityForm") EntityForm entityForm, BindingResult result) 
+            throws Exception {
+        return super.duplicateEntity(request, response, model, pathVars, id, entityForm, result);
     }
 
     /**
@@ -174,16 +137,6 @@ public class AdminOfferController extends AdminBasicEntityController {
         EntityForm form = (EntityForm) model.asMap().get("entityForm");
         if (form != null && form.findField("targetItemCriteria") != null) {
             form.findField("targetItemCriteria").setRequired(true);
-        }
-    }
-
-    protected void addDuplicateOption(Model model, String id) {
-        if (duplicator.validate(OfferImpl.class, Long.parseLong(id))) {
-            EntityForm form = (EntityForm) model.asMap().get("entityForm");
-            EntityFormAction duplicate = new EntityFormAction("duplicate")
-                    .withButtonClass("duplicate-button")
-                    .withDisplayText("Duplicate");
-            form.addAction(duplicate);
         }
     }
 }

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -149,6 +150,7 @@ public class AdminProductController extends AdminBasicEntityController {
         formService.removeNonApplicableFields(collectionMetadata, entityForm, ppr.getCeilingEntityClassname());
 
         entityForm.removeAction(DefaultEntityFormActions.DELETE);
+        entityForm.removeAction(DefaultEntityFormActions.DUPLICATE);
 
         model.addAttribute("entityForm", entityForm);
         model.addAttribute("viewType", "modal/simpleAddEntity");
@@ -196,17 +198,14 @@ public class AdminProductController extends AdminBasicEntityController {
         Entity entity = service.getRecord(ppr, collectionItemId, collectionMetadata, true).getDynamicResultSet().getRecords()[0];
 
         String currentTabName = getCurrentTabName(pathVars, collectionMetadata);
-        Map<String, DynamicResultSet> subRecordsMap = service.getRecordsForSelectedTab(collectionMetadata, entity, sectionCrumbs, currentTabName);
-        if (entityForm == null) {
-            entityForm = formService.createEntityForm(collectionMetadata, entity, subRecordsMap, sectionCrumbs);
-        } else {
-            entityForm.clearFieldsMap();
-            formService.populateEntityForm(collectionMetadata, entity, subRecordsMap, entityForm, sectionCrumbs);
-            //remove all the actions since we're not trying to redisplay them on the form
-            entityForm.removeAllActions();
-        }
+        Map<String, DynamicResultSet> subRecordsMap = service
+                .getRecordsForSelectedTab(collectionMetadata, entity, sectionCrumbs, currentTabName);
+
+        entityForm = reinitializeEntityForm(entityForm, collectionMetadata, entity, subRecordsMap, 
+                sectionCrumbs);
 
         entityForm.removeAction(DefaultEntityFormActions.DELETE);
+        entityForm.removeAction(DefaultEntityFormActions.DUPLICATE);
 
         // Ensure that operations on the Sku subcollections go to the proper URL
         for (ListGrid lg : entityForm.getAllListGrids()) {

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminProductController.java
@@ -30,7 +30,6 @@ import org.broadleafcommerce.core.catalog.domain.SkuImpl;
 import org.broadleafcommerce.core.catalog.service.CatalogService;
 import org.broadleafcommerce.openadmin.dto.BasicCollectionMetadata;
 import org.broadleafcommerce.openadmin.dto.ClassMetadata;
-import org.broadleafcommerce.openadmin.dto.ClassTree;
 import org.broadleafcommerce.openadmin.dto.CriteriaTransferObject;
 import org.broadleafcommerce.openadmin.dto.DynamicResultSet;
 import org.broadleafcommerce.openadmin.dto.Entity;
@@ -54,7 +53,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import java.net.URLDecoder;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -134,32 +133,14 @@ public class AdminProductController extends AdminBasicEntityController {
         if (request.getParameter("entityType") != null) {
             entityType = request.getParameter("entityType");
         }
-        if (StringUtils.isBlank(entityType)) {
-            if (cmd.getPolymorphicEntities().getChildren().length == 0) {
-                entityType = cmd.getPolymorphicEntities().getFullyQualifiedClassname();
-            } else {
-                entityType = getDefaultEntityType();
-            }
-        } else {
-            entityType = URLDecoder.decode(entityType, "UTF-8");
-        }
+        
+        entityType = determineEntityType(entityType, cmd);
 
         if (StringUtils.isBlank(entityType)) {
-            List<ClassTree> entityTypes = getAddEntityTypes(cmd.getPolymorphicEntities());
-            model.addAttribute("entityTypes", entityTypes);
-            model.addAttribute("viewType", "modal/entityTypeSelection");
-            model.addAttribute("entityFriendlyName", cmd.getPolymorphicEntities().getFriendlyName());
-            String requestUri = request.getRequestURI();
-            if (!request.getContextPath().equals("/") && requestUri.startsWith(request.getContextPath())) {
-                requestUri = requestUri.substring(request.getContextPath().length() + 1, requestUri.length());
-            }
-            model.addAttribute("currentUri", requestUri);
-            model.addAttribute("modalHeaderType", ModalHeaderType.ADD_ENTITY.getType());
-            setModelAttributes(model, SECTION_KEY);
-            return "modules/modalContainer";
-        } else {
-            ppr = ppr.withCeilingEntityClassname(entityType);
+            return getModalForBlankEntityType(request, model, SECTION_KEY, cmd);
         }
+        
+        ppr = ppr.withCeilingEntityClassname(entityType);
 
         ClassMetadata collectionMetadata = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
         EntityForm entityForm = formService.createEntityForm(collectionMetadata, sectionCrumbs);
@@ -176,7 +157,7 @@ public class AdminProductController extends AdminBasicEntityController {
         model.addAttribute("modalHeaderType", ModalHeaderType.ADD_COLLECTION_ITEM.getType());
         model.addAttribute("collectionProperty", collectionProperty);
         setModelAttributes(model, SECTION_KEY);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     @Override
@@ -240,7 +221,7 @@ public class AdminProductController extends AdminBasicEntityController {
         model.addAttribute("modalHeaderType", ModalHeaderType.UPDATE_COLLECTION_ITEM.getType());
         model.addAttribute("collectionProperty", collectionProperty);
         setModelAttributes(model, SECTION_KEY);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
@@ -100,7 +100,7 @@ public class AdminAssetUploadController extends AdminAbstractController {
         // We need these attributes to be set appropriately here
         model.addAttribute("entityId", id);
         model.addAttribute("sectionKey", sectionKey);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
     
     @RequestMapping(value = "/{id}/uploadAsset", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
@@ -101,6 +101,8 @@ import javax.persistence.Transient;
 public class StructuredContentImpl implements StructuredContent, AdminMainEntity, ProfileEntity {
 
     private static final long serialVersionUID = 1L;
+    
+    public static final String SC_SC_TYPE_DONT_DUPLICATE_HINT = "dont-duplicate-sc-type";
 
     @Id
     @GeneratedValue(generator = "StructuredContentId")
@@ -331,21 +333,30 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
         cloned.setLocale(locale);
         cloned.setOfflineFlag(offlineFlag);
         cloned.setPriority(priority);
+        
         if (structuredContentType != null) {
-            CreateResponse<StructuredContentType> clonedType = structuredContentType.createOrRetrieveCopyInstance(context);
-            cloned.setStructuredContentType(clonedType.getClone());
+            if (Boolean.valueOf(context.getCopyHints().get(SC_SC_TYPE_DONT_DUPLICATE_HINT))) {
+                cloned.setStructuredContentType(structuredContentType);
+            } else {
+                CreateResponse<StructuredContentType> clonedType = 
+                        structuredContentType.createOrRetrieveCopyInstance(context);
+                cloned.setStructuredContentType(clonedType.getClone());
+            }
         }
+        
         for(StructuredContentItemCriteria itemCriteria : qualifyingItemCriteria){
             CreateResponse<StructuredContentItemCriteria> clonedItem = itemCriteria.createOrRetrieveCopyInstance(context);
             StructuredContentItemCriteria clonedCritera = clonedItem.getClone();
             cloned.getQualifyingItemCriteria().add(clonedCritera);
         }
+        
         for(Entry<String, StructuredContentRule> entry : structuredContentMatchRules.entrySet()){
             CreateResponse<StructuredContentRule> clonedItem = entry.getValue().createOrRetrieveCopyInstance(context);
             StructuredContentRule clonedRule = clonedItem.getClone();
             cloned.getStructuredContentMatchRules().put(entry.getKey(),clonedRule);
 
         }
+        
         for(Entry<String, StructuredContentFieldXref> entry : structuredContentFields.entrySet() ){
             CreateResponse<StructuredContentFieldXref> clonedItem = entry.getValue().createOrRetrieveCopyInstance(context);
             StructuredContentFieldXref clonedContentFieldXref = clonedItem.getClone();

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
@@ -102,7 +102,7 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
 
     private static final long serialVersionUID = 1L;
     
-    public static final String SC_SC_TYPE_DONT_DUPLICATE_HINT = "dont-duplicate-sc-type";
+    public static final String SC_DONT_DUPLICATE_SC_TYPE_HINT = "dont-duplicate-sc-type";
 
     @Id
     @GeneratedValue(generator = "StructuredContentId")
@@ -335,7 +335,7 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
         cloned.setPriority(priority);
         
         if (structuredContentType != null) {
-            if (Boolean.valueOf(context.getCopyHints().get(SC_SC_TYPE_DONT_DUPLICATE_HINT))) {
+            if (Boolean.valueOf(context.getCopyHints().get(SC_DONT_DUPLICATE_SC_TYPE_HINT))) {
                 cloned.setStructuredContentType(structuredContentType);
             } else {
                 CreateResponse<StructuredContentType> clonedType = 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -86,6 +86,9 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
 
     public static final String CURRENT_ADMIN_MODULE_ATTRIBUTE_NAME = "currentAdminModule";
     public static final String CURRENT_ADMIN_SECTION_ATTRIBUTE_NAME = "currentAdminSection";
+    
+    public static final String DEFAULT_CONTAINER_VIEW = "modules/defaultContainer";
+    public static final String MODAL_CONTAINER_VIEW = "modules/modalContainer";
 
     // ***********************
     // RESOURCE DECLARATIONS *

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -105,7 +105,7 @@ public class AdminTranslationController extends AdminAbstractController {
         model.addAttribute("listGrid", lg);
         model.addAttribute("viewType", "modal/translationListGrid");
         model.addAttribute("modalHeaderType", ModalHeaderType.TRANSLATION.getType());
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     /**
@@ -136,7 +136,7 @@ public class AdminTranslationController extends AdminAbstractController {
         model.addAttribute("viewType", "modal/translationAdd");
         model.addAttribute("currentUrl", request.getRequestURL().toString());
         model.addAttribute("modalHeaderType", ModalHeaderType.ADD_TRANSLATION.getType());
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     /**
@@ -198,7 +198,7 @@ public class AdminTranslationController extends AdminAbstractController {
             model.addAttribute("viewType", "modal/translationAdd");
             model.addAttribute("currentUrl", request.getRequestURL().toString());
             model.addAttribute("modalHeaderType", ModalHeaderType.ADD_TRANSLATION.getType());
-            return "modules/modalContainer";
+            return MODAL_CONTAINER_VIEW;
         } else {
             return viewTranslation(request, response, model, form, result);
         }
@@ -252,7 +252,7 @@ public class AdminTranslationController extends AdminAbstractController {
         model.addAttribute("viewType", "modal/translationAdd");
         model.addAttribute("currentUrl", request.getRequestURL().toString());
         model.addAttribute("modalHeaderType", ModalHeaderType.UPDATE_TRANSLATION.getType());
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     /**

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -278,8 +278,6 @@ public class AdminBasicEntityController extends AdminAbstractController {
             }
         }
 
-        isNotReadOnly(cmd);
-
         final boolean canAdd = rowLevelSecurityService
                 .canAdd(adminRemoteSecurityService.getPersistentAdminUser(), sectionClassName, cmd);
         return isNotReadOnly(cmd) && canAdd;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -26,11 +26,15 @@ import org.broadleafcommerce.common.exception.SecurityServiceException;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.common.persistence.EntityDuplicator;
 import org.broadleafcommerce.common.presentation.client.AddMethodType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
+import org.broadleafcommerce.common.service.GenericEntityService;
 import org.broadleafcommerce.common.util.BLCArrayUtils;
 import org.broadleafcommerce.common.util.BLCMessageUtils;
+import org.broadleafcommerce.common.util.StreamingTransactionCapableUtil;
+import org.broadleafcommerce.common.util.TransactionUtils;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.JsonResponse;
 import org.broadleafcommerce.openadmin.dto.AdornedTargetCollectionMetadata;
@@ -70,8 +74,11 @@ import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
 import org.broadleafcommerce.openadmin.web.form.entity.EntityFormAction;
 import org.broadleafcommerce.openadmin.web.form.entity.Field;
 import org.broadleafcommerce.openadmin.web.form.entity.FieldGroup;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.BindingResult;
@@ -87,8 +94,11 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.FlashMap;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.util.UrlPathHelper;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -96,14 +106,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * The default implementation of the {@link #BroadleafAdminAbstractEntityController}. This delegates every call to super
- * and does not provide any custom-tailored functionality. It is responsible for rendering the admin for every entity
- * that is not explicitly customized by its own controller.
+ * The default implementation of the {@link AdminAbstractController}. This delegates every call to 
+ * super and does not provide any custom-tailored functionality. It is responsible for rendering the
+ * admin for every entity that is not explicitly customized by its own controller.
  *
  * @author Andre Azzolini (apazzolini)
  * @author Jeff Fischer
@@ -132,6 +143,12 @@ public class AdminBasicEntityController extends AdminAbstractController {
 
     @Resource(name = "blRowLevelSecurityService")
     protected RowLevelSecurityService rowLevelSecurityService;
+    
+    @Resource(name = "blEntityDuplicator")
+    protected EntityDuplicator duplicator;
+    
+    @Resource(name = "blGenericEntityService")
+    protected GenericEntityService genericEntityService;
 
     // ******************************************
     // REQUEST-MAPPING BOUND CONTROLLER METHODS *
@@ -176,7 +193,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         setupViewEntityListBasicModel(request, cmd, sectionKey, sectionClassName, model, requestParams);
         model.addAttribute("listGrid", listGrid);
 
-        return "modules/defaultContainer";
+        return DEFAULT_CONTAINER_VIEW;
     }
 
     protected void setupViewEntityListBasicModel(HttpServletRequest request, ClassMetadata cmd, String sectionKey,
@@ -256,37 +273,35 @@ public class AdminBasicEntityController extends AdminAbstractController {
         }
     }
 
-    protected boolean isAddActionAllowed(String sectionClassName, ClassMetadata cmd) {
+    protected boolean isAddActionAllowed(final String sectionClassName, final ClassMetadata cmd) {
         // If the user does not have create permissions, we will not add the "Add New" button
-        boolean canCreate = true;
         try {
             adminRemoteSecurityService.securityCheck(sectionClassName, EntityOperationType.ADD);
         } catch (ServiceException e) {
             if (e instanceof SecurityServiceException) {
-                canCreate = false;
+                return false;
             }
         }
 
-        if (canCreate) {
-            checkReadOnly: {
-                //check if all the metadata is read only
-                for (Property property : cmd.getProperties()) {
-                    if (property.getMetadata() instanceof BasicFieldMetadata) {
-                        if (((BasicFieldMetadata) property.getMetadata()).getReadOnly() == null ||
-                                !((BasicFieldMetadata) property.getMetadata()).getReadOnly()) {
-                            break checkReadOnly;
-                        }
-                    }
+        isNotReadOnly(cmd);
+
+        final boolean canAdd = rowLevelSecurityService
+                .canAdd(adminRemoteSecurityService.getPersistentAdminUser(), sectionClassName, cmd);
+        return isNotReadOnly(cmd) && canAdd;
+    }
+    
+    protected boolean isNotReadOnly(final ClassMetadata cmd) {
+        //check if all the metadata is read only
+        for (Property property : cmd.getProperties()) {
+            if (property.getMetadata() instanceof BasicFieldMetadata) {
+                if (((BasicFieldMetadata) property.getMetadata()).getReadOnly() == null ||
+                        !((BasicFieldMetadata) property.getMetadata()).getReadOnly()) {
+                    return true;
                 }
-                canCreate = false;
             }
         }
-
-        if (canCreate) {
-            canCreate = rowLevelSecurityService.canAdd(adminRemoteSecurityService.getPersistentAdminUser(), sectionClassName, cmd);
-        }
-
-        return canCreate;
+        
+        return false;
     }
 
     /**
@@ -313,17 +328,8 @@ public class AdminBasicEntityController extends AdminAbstractController {
         PersistencePackageRequest ppr = getSectionPersistencePackageRequest(sectionClassName, sectionCrumbs, pathVars);
         ppr.setAddOperationInspect(true);
         ClassMetadata cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
-
-        // If the entity type isn't specified, we need to determine if there are various polymorphic types for this entity.
-        if (StringUtils.isBlank(entityType)) {
-            if (cmd.getPolymorphicEntities().getChildren().length == 0) {
-                entityType = cmd.getPolymorphicEntities().getFullyQualifiedClassname();
-            } else {
-                entityType = getDefaultEntityType();
-            }
-        } else {
-            entityType = URLDecoder.decode(entityType, "UTF-8");
-        }
+        
+        entityType = determineEntityType(entityType, cmd);
 
         EntityForm entityForm = formService.createEntityForm(cmd, sectionCrumbs);
 
@@ -346,7 +352,23 @@ public class AdminBasicEntityController extends AdminAbstractController {
         model.addAttribute("currentUrl", request.getRequestURL().toString());
         model.addAttribute("modalHeaderType", ModalHeaderType.ADD_ENTITY.getType());
         setModelAttributes(model, sectionKey);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
+    }
+
+    // If the entity type isn't specified, we need to determine if there are various polymorphic 
+    // types for this entity.
+    protected String determineEntityType(String entityType, final ClassMetadata cmd) 
+            throws UnsupportedEncodingException {
+        if (StringUtils.isBlank(entityType)) {
+            if (cmd.getPolymorphicEntities().getChildren().length == 0) {
+                entityType = cmd.getPolymorphicEntities().getFullyQualifiedClassname();
+            } else {
+                entityType = getDefaultEntityType();
+            }
+        } else {
+            entityType = URLDecoder.decode(entityType, "UTF-8");
+        }
+        return entityType;
     }
 
     /**
@@ -388,11 +410,65 @@ public class AdminBasicEntityController extends AdminAbstractController {
             model.addAttribute("modalHeaderType", ModalHeaderType.ADD_ENTITY.getType());
             model.addAttribute("entityFriendlyName", cmd.getPolymorphicEntities().getFriendlyName());
             setModelAttributes(model, sectionKey);
-            return "modules/modalContainer";
+            return MODAL_CONTAINER_VIEW;
         }
 
         // Note that AJAX Redirects need the context path prepended to them
         return "ajaxredirect:" + getContextPath(request) + sectionKey + "/" + entity.getPMap().get("id").getValue();
+    }
+
+    @RequestMapping(value = "/{id}/duplicate", method = RequestMethod.POST)
+    public String duplicateEntity(final HttpServletRequest request,
+            final HttpServletResponse response, 
+            final Model model,
+            @PathVariable final Map<String, String> pathVars,
+            @PathVariable(value = "id") final String id,
+            @ModelAttribute(value = "entityForm") final EntityForm entityForm,
+            final BindingResult result) throws Exception {
+        final String sectionKey = getSectionKey(pathVars);
+        final String sectionClassName = getClassNameForSection(sectionKey);
+        final Class<?> entityClass = dynamicEntityDao.getImplClass(sectionClassName);
+        final long identifier = Long.parseLong(id);
+        
+        if (duplicator.validate(entityClass, identifier)) {
+            final Object duplicate;
+            
+            try {
+                duplicate = duplicator.copy(entityClass, identifier);
+            } catch (Exception e) {
+                LOG.error("Could not duplicate entity", e);
+                return getErrorDuplicatingResponse(response, "Duplication_Failure");
+            }
+
+            final Serializable dupId = genericEntityService.getIdentifier(duplicate);
+            
+            // Note that AJAX Redirects need the context path prepended to them
+            return "ajaxredirect:" + getContextPath(request) + sectionKey + "/" + dupId;
+        } else {
+            return getErrorDuplicatingResponse(response, "Validation_Failure");
+        }
+    }
+
+    protected String getErrorDuplicatingResponse(HttpServletResponse response, String code) {
+        List<Map<String, Object>> errors = new ArrayList<>();
+        String message;
+        BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
+        if (context != null && context.getMessageSource() != null) {
+            message = context.getMessageSource()
+                    .getMessage(code, null, code, context.getJavaLocale());
+        } else {
+            LOG.warn(
+                    "Could not find the MessageSource on the current request, " 
+                            + "not translating the message key");
+            message = "Duplication_Failure";
+        }
+
+        Map<String, Object> errorMap = new HashMap<>();
+        errorMap.put("errorType", "global");
+        errorMap.put("code", code);
+        errorMap.put("message", message);
+        errors.add(errorMap);
+        return new JsonResponse(response).with("errors", errors).done();
     }
 
     /**
@@ -422,11 +498,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
 
         EntityForm entityForm = formService.createEntityForm(cmd, entity, subRecordsMap, crumbs);
 
-        if (isAddRequest(entity)) {
-            modifyAddEntityForm(entityForm, pathVars);
-        } else {
-            modifyEntityForm(entityForm, pathVars);
-        }
+        modifyEntityForm(entity, entityForm, pathVars);
 
         if (request.getParameter("headerFlash") != null) {
             model.addAttribute("headerFlash", request.getParameter("headerFlash"));
@@ -451,16 +523,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         // We want to replace author ids with their names
         addAuditableDisplayFields(entityForm);
 
-        if (isAjaxRequest(request)) {
-            entityForm.setReadOnly();
-            model.addAttribute("viewType", "modal/entityView");
-            model.addAttribute("modalHeaderType", ModalHeaderType.VIEW_ENTITY.getType());
-            return "modules/modalContainer";
-        } else {
-            model.addAttribute("useAjaxUpdate", true);
-            model.addAttribute("viewType", "entityEdit");
-            return "modules/defaultContainer";
-        }
+        return resolveAppropriateEntityView(request, model, entityForm);
     }
 
     protected Map<String, DynamicResultSet> getViewSubRecords(HttpServletRequest request, Map<String, String> pathVars,
@@ -513,11 +576,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         Map<String, DynamicResultSet> subRecordsMap = getViewSubRecords(request, pathVars, cmd, entity, crumbs);
         entityForm = formService.createEntityForm(cmd, entity, subRecordsMap, crumbs);
 
-        if (isAddRequest(entity)) {
-            modifyAddEntityForm(entityForm, pathVars);
-        } else {
-            modifyEntityForm(entityForm, pathVars);
-        }
+        modifyEntityForm(entity, entityForm, pathVars);
 
         model.addAttribute("entity", entity);
         model.addAttribute("entityForm", entityForm);
@@ -527,7 +586,8 @@ public class AdminBasicEntityController extends AdminAbstractController {
 
         model.addAttribute("useAjaxUpdate", true);
         model.addAttribute("viewType", "entityEdit");
-        return "modules/defaultContainer";
+        
+        return DEFAULT_CONTAINER_VIEW;
     }
 
     /**
@@ -627,6 +687,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         Entity entity = service.updateEntity(entityForm, sectionCriteria, sectionCrumbs).getEntity();
 
         entityFormValidator.validate(entityForm, entity, result);
+        
         if (result.hasErrors()) {
             model.addAttribute("headerFlash", "save.unsuccessful");
             model.addAttribute("headerFlashAlert", true);
@@ -635,32 +696,43 @@ public class AdminBasicEntityController extends AdminAbstractController {
             entityForm.clearFieldsMap();
             formService.populateEntityForm(cmd, entity, subRecordsMap, entityForm, sectionCrumbs);
 
-            if (isAddRequest(entity)) {
-                modifyAddEntityForm(entityForm, pathVars);
-            } else {
-                modifyEntityForm(entityForm, pathVars);
-            }
+            modifyEntityForm(entity, entityForm, pathVars);
 
             model.addAttribute("entity", entity);
             model.addAttribute("currentUrl", request.getRequestURL().toString());
 
             setModelAttributes(model, sectionKey);
 
-            if (isAjaxRequest(request)) {
-                entityForm.setReadOnly();
-                model.addAttribute("viewType", "modal/entityView");
-                model.addAttribute("modalHeaderType", ModalHeaderType.VIEW_ENTITY.getType());
-                return "modules/modalContainer";
-            } else {
-                model.addAttribute("useAjaxUpdate", true);
-                model.addAttribute("viewType", "entityEdit");
-                return "modules/defaultContainer";
-            }
+            return resolveAppropriateEntityView(request, model, entityForm);
         }
 
         ra.addFlashAttribute("headerFlash", "save.successful");
 
         return "redirect:/" + sectionKey + "/" + id;
+    }
+    
+    protected void modifyEntityForm(final Entity entity, final EntityForm entityForm, 
+            final Map<String, String> pathVars) throws Exception {
+        if (isAddRequest(entity)) {
+            modifyAddEntityForm(entityForm, pathVars);
+        } else {
+            modifyEntityForm(entityForm, pathVars);
+        }
+    }
+
+    protected String resolveAppropriateEntityView(final HttpServletRequest request,
+            final Model model,
+            final @ModelAttribute(value = "entityForm") EntityForm entityForm) {
+        if (isAjaxRequest(request)) {
+            entityForm.setReadOnly();
+            model.addAttribute("viewType", "modal/entityView");
+            model.addAttribute("modalHeaderType", ModalHeaderType.VIEW_ENTITY.getType());
+            return MODAL_CONTAINER_VIEW;
+        } else {
+            model.addAttribute("useAjaxUpdate", true);
+            model.addAttribute("viewType", "entityEdit");
+            return DEFAULT_CONTAINER_VIEW;
+        }
     }
 
     /**
@@ -925,35 +997,18 @@ public class AdminBasicEntityController extends AdminAbstractController {
                 // If the entity type isn't specified, we need to determine if there are various polymorphic types
                 // for this entity.
                 String entityType = null;
+                
                 if (requestParams.containsKey("entityType")) {
                     entityType = requestParams.get("entityType").get(0);
                 }
-                if (StringUtils.isBlank(entityType)) {
-                    if (cmd.getPolymorphicEntities().getChildren().length == 0) {
-                        entityType = cmd.getPolymorphicEntities().getFullyQualifiedClassname();
-                    } else {
-                        entityType = getDefaultEntityType();
-                    }
-                } else {
-                    entityType = URLDecoder.decode(entityType, "UTF-8");
-                }
+                
+                entityType = determineEntityType(entityType, cmd);
 
                 if (StringUtils.isBlank(entityType)) {
-                    List<ClassTree> entityTypes = getAddEntityTypes(cmd.getPolymorphicEntities());
-                    model.addAttribute("entityTypes", entityTypes);
-                    model.addAttribute("viewType", "modal/entityTypeSelection");
-                    model.addAttribute("entityFriendlyName", cmd.getPolymorphicEntities().getFriendlyName());
-                    String requestUri = request.getRequestURI();
-                    if (!request.getContextPath().equals("/") && requestUri.startsWith(request.getContextPath())) {
-                        requestUri = requestUri.substring(request.getContextPath().length() + 1, requestUri.length());
-                    }
-                    model.addAttribute("currentUri", requestUri);
-                    model.addAttribute("modalHeaderType", ModalHeaderType.ADD_ENTITY.getType());
-                    setModelAttributes(model, sectionKey);
-                    return "modules/modalContainer";
-                } else {
-                    ppr = ppr.withCeilingEntityClassname(entityType);
-                }
+                    return getModalForBlankEntityType(request, model, sectionKey, cmd);
+                } 
+                
+                ppr = ppr.withCeilingEntityClassname(entityType);
             }
         } else if (md instanceof MapMetadata) {
             ExtensionResultStatusType result = extensionManager.getProxy().modifyModelForAddCollectionType(request,response,model,sectionKey,id,requestParams,(MapMetadata) md);
@@ -961,15 +1016,34 @@ public class AdminBasicEntityController extends AdminAbstractController {
                 model.addAttribute("entityId", id);
                 model.addAttribute("sectionKey", sectionKey);
                 model.addAttribute("collectionField", collectionField);
-                return "modules/modalContainer";
+                return MODAL_CONTAINER_VIEW;
             }
         }
-
-        //service.getContextSpecificRelationshipId(mainMetadata, entity, prefix);
 
         model.addAttribute("currentParams", new ObjectMapper().writeValueAsString(requestParams));
 
         return buildAddCollectionItemModel(request, response, model, id, collectionField, sectionKey, collectionProperty, md, ppr, null, null);
+    }
+    
+    protected String getModalForBlankEntityType(final HttpServletRequest request, 
+            final Model model, final String sectionKey, final ClassMetadata cmd) {
+        final List<ClassTree> entityTypes = getAddEntityTypes(cmd.getPolymorphicEntities());
+        model.addAttribute("entityTypes", entityTypes);
+        model.addAttribute("viewType", "modal/entityTypeSelection");
+        model.addAttribute("entityFriendlyName", cmd.getPolymorphicEntities().getFriendlyName());
+        
+        String requestUri = request.getRequestURI();
+        final String contextPath = request.getContextPath();
+        
+        if (!contextPath.equals("/") && requestUri.startsWith(contextPath)) {
+            requestUri = requestUri.substring(contextPath.length() + 1, requestUri.length());
+        }
+
+        model.addAttribute("currentUri", requestUri);
+        model.addAttribute("modalHeaderType", ModalHeaderType.ADD_ENTITY.getType());
+        setModelAttributes(model, sectionKey);
+        
+        return MODAL_CONTAINER_VIEW;
     }
 
     @RequestMapping(value = "/{id}/{collectionField:.*}/add/{collectionItemId}/verify", method = RequestMethod.POST)
@@ -1317,7 +1391,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         model.addAttribute("modalHeaderType", ModalHeaderType.ADD_COLLECTION_ITEM.getType());
         model.addAttribute("collectionProperty", collectionProperty);
         setModelAttributes(model, sectionKey);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     /**
@@ -1601,7 +1675,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
         model.addAttribute("modalHeaderType", modalHeaderType);
         model.addAttribute("collectionProperty", collectionProperty);
         setModelAttributes(model, sectionKey);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     /**

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -154,7 +154,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
         model.addAttribute("collectionProperty", collectionProperty);
         model.addAttribute("sectionCrumbs", request.getParameter("sectionCrumbs"));
         setModelAttributes(model, owningClass);
-        return "modules/modalContainer";
+        return MODAL_CONTAINER_VIEW;
     }
 
     @RequestMapping(value = "/{owningClass:.*}/{collectionField:.*}/typeahead", method = RequestMethod.GET)

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/DefaultEntityFormActions.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/DefaultEntityFormActions.java
@@ -33,5 +33,9 @@ public class DefaultEntityFormActions {
     public static final EntityFormAction PREVIEW = new EntityFormAction(EntityFormAction.PREVIEW)
         .withButtonClass("preview-button")
         .withDisplayText("Preview");
+    
+    public static final EntityFormAction DUPLICATE = new EntityFormAction(EntityFormAction.DUPLICATE)
+            .withButtonClass("duplicate-button")
+            .withDisplayText("Duplicate");
 
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityFormAction.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityFormAction.java
@@ -27,6 +27,7 @@ public class EntityFormAction implements Cloneable {
     public static final String SAVE = "SAVE";
     public static final String DELETE = "DELETE";
     public static final String PREVIEW = "PREVIEW";
+    public static final String DUPLICATE = "DUPLICATE";
 
     protected String buttonType = "button";
     protected String buttonClass = "";
@@ -184,7 +185,7 @@ public class EntityFormAction implements Cloneable {
      * This is a manual override for the data-actionurl attribute for an listgrid action. The data-actionurl attribute on a
      * button is normally automatically computed by appending the postfix URL to the path of the list grid
      * 
-     * @param actionUrlOverride
+     * @param urlOverride
      */
     public void setUrlOverride(String urlOverride) {
         this.urlOverride = urlOverride;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -31,6 +31,7 @@ import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.media.domain.MediaDto;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
+import org.broadleafcommerce.common.persistence.EntityDuplicator;
 import org.broadleafcommerce.common.presentation.client.AddMethodType;
 import org.broadleafcommerce.common.presentation.client.AdornedTargetAddMethodType;
 import org.broadleafcommerce.common.presentation.client.LookupType;
@@ -57,6 +58,7 @@ import org.broadleafcommerce.openadmin.dto.MapStructure;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.dto.SectionCrumb;
 import org.broadleafcommerce.openadmin.dto.TabMetadata;
+import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.domain.PersistencePackageRequest;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminSection;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
@@ -98,9 +100,11 @@ import org.codehaus.jettison.json.JSONObject;
 import org.springframework.context.MessageSource;
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.stereotype.Service;
+
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DateFormat;
@@ -117,6 +121,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import javax.annotation.Resource;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
@@ -159,6 +164,12 @@ public class FormBuilderServiceImpl implements FormBuilderService {
 
     @Resource(name = "blAdminNavigationService")
     protected AdminNavigationService adminNavigationService;
+
+    @Resource(name = "blEntityDuplicator")
+    protected EntityDuplicator duplicator;
+
+    @Resource(name = "blDynamicEntityDao")
+    protected DynamicEntityDao dynamicEntityDao;
 
     protected static final VisibilityEnum[] FORM_HIDDEN_VISIBILITIES = new VisibilityEnum[] { 
             VisibilityEnum.HIDDEN_ALL, VisibilityEnum.FORM_HIDDEN
@@ -1576,6 +1587,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
         }
         
         addDeleteActionIfAllowed(ef, cmd, entity);
+        addDuplicateActionIfAllowed(ef, cmd);
         setReadOnlyState(ef, cmd, entity);
 
         // check for fields that should be hidden based on annotations
@@ -1602,28 +1614,52 @@ public class FormBuilderServiceImpl implements FormBuilderService {
      * @see {@link RowLevelSecurityService#canRemove(AdminUser, Entity)}
      */
     protected void addDeleteActionIfAllowed(EntityForm entityForm, ClassMetadata cmd, Entity entity) {
-        boolean canDelete = true;
-        try {
-            String securityEntityClassname = getSecurityClassname(entityForm, cmd);
-            adminRemoteSecurityService.securityCheck(securityEntityClassname, EntityOperationType.REMOVE);
-        } catch (ServiceException e) {
-            if (e instanceof SecurityServiceException) {
-                canDelete = false;
-            }
-        }
-        
-        // If I cannot update a record then I certainly cannot delete it either
-        if (canDelete) {
-            canDelete = rowLevelSecurityService.canUpdate(adminRemoteSecurityService.getPersistentAdminUser(), entity);
-        }
-        
-        if (canDelete) {
-            canDelete = rowLevelSecurityService.canRemove(adminRemoteSecurityService.getPersistentAdminUser(), entity);
-        }
-        
-        if (canDelete) {
+        if (isDeletionAllowed(entityForm, cmd, entity)) {
             entityForm.addAction(DefaultEntityFormActions.DELETE);
         }
+    }
+    
+    protected boolean isDeletionAllowed(final EntityForm entityForm, final ClassMetadata cmd, 
+            final Entity entity) {
+        try {
+            String securityEntityClassname = getSecurityClassname(entityForm, cmd);
+            adminRemoteSecurityService
+                    .securityCheck(securityEntityClassname, EntityOperationType.REMOVE);
+        } catch (ServiceException e) {
+            if (e instanceof SecurityServiceException) {
+                return false;
+            }
+        }
+
+        final AdminUser persistentAdminUser = adminRemoteSecurityService.getPersistentAdminUser();
+        
+        return rowLevelSecurityService.canUpdate(persistentAdminUser, entity)
+                && rowLevelSecurityService.canRemove(persistentAdminUser, entity);
+    }
+    
+    protected void addDuplicateActionIfAllowed(final EntityForm entityForm,
+            final ClassMetadata cmd) {
+        if (isDuplicationAllowed(entityForm, cmd)) {
+            entityForm.addAction(DefaultEntityFormActions.DUPLICATE);
+        }
+    }
+
+    protected boolean isDuplicationAllowed(final EntityForm entityForm, final ClassMetadata cmd) {
+        final String securityClassname = getSecurityClassname(entityForm, cmd);
+
+        try {
+            adminRemoteSecurityService.securityCheck(securityClassname, EntityOperationType.ADD);
+        } catch (ServiceException e) {
+            if (e instanceof SecurityServiceException) {
+                return false;
+            }
+        }
+
+        final Class<?> entityClass = dynamicEntityDao.getImplClass(securityClassname);
+        
+        return duplicator.validate(entityClass, Long.valueOf(entityForm.getId())) && 
+                rowLevelSecurityService.canAdd(adminRemoteSecurityService.getPersistentAdminUser(), 
+                        securityClassname, cmd);
     }
     
     /**

--- a/common/src/main/java/org/broadleafcommerce/common/dao/GenericEntityDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/dao/GenericEntityDaoImpl.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.persistence;
 
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
@@ -1,19 +1,38 @@
 package org.broadleafcommerce.common.persistence;
 
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.springframework.core.env.Environment;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Implements {@link #getCopyHints()} and {@link #addCopyHint(String, String)}, 
- * using a {@link HashMap} as the underlying data structure for storing the hints.
+ * using a {@link HashMap} as the underlying data structure for storing the hints. Also provides a
+ * helper method {@link #getCopySuffix()} for the usual use-case of changing the name of the 
+ * duplicated entity.
  * 
  * @author Nathan Moore (nathanmoore).
  */
 public abstract class AbstractEntityDuplicationHelper<T> implements EntityDuplicationHelper<T> {
     
     protected Map<String, String> copyHints = new HashMap<>();
+    
+    protected final Environment env;
+    
+    public AbstractEntityDuplicationHelper(final Environment environment) {
+        this.env = environment;
+    }
+
+    /**
+     * Defaults to " - Copy" but can be overridden using 
+     * {@code admin.entity.duplication.suffix.default}. 
+     * 
+     * @return suffix to append to the name/identifier of the entity copy
+     */
+    protected String getCopySuffix() {
+        return env.getProperty("admin.entity.duplication.suffix.default", String.class, " - Copy");
+    }
     
     @Override 
     public abstract boolean canHandle(final MultiTenantCloneable candidate);

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
@@ -1,0 +1,33 @@
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implements {@link #getCopyHints()} and {@link #addCopyHint(String, String)}, 
+ * using a {@link HashMap} as the underlying data structure for storing the hints.
+ * 
+ * @author Nathan Moore (nathanmoore).
+ */
+public abstract class AbstractEntityDuplicationHelper<T> implements EntityDuplicationHelper<T> {
+    
+    protected Map<String, String> copyHints = new HashMap<>();
+    
+    @Override 
+    public abstract boolean canHandle(final MultiTenantCloneable candidate);
+
+    @Override 
+    public Map<String, String> getCopyHints() {
+        return copyHints;
+    }
+
+    @Override 
+    public void addCopyHint(final String name, final String hint) {
+        copyHints.put(name, hint);
+    }
+
+    @Override 
+    public abstract void modifyInitialDuplicateState(final T copy);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicateModifier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicateModifier.java
@@ -18,9 +18,7 @@
 package org.broadleafcommerce.common.persistence;
 
 /**
- * Perform final modifications on a duplicated entity before persistence.
- *
- * @author Jeff Fischer
+ * @deprecated Implement {@link EntityDuplicationHelper} instead
  */
 public interface EntityDuplicateModifier<T> {
 

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2018 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.common.persistence;
 
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
@@ -1,0 +1,28 @@
+package org.broadleafcommerce.common.persistence;
+
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+
+import java.util.Map;
+
+/**
+ * Provides additional metadata and performs final modifications for an entity before persistence.
+ * 
+ * In order to perform duplication using {@link EntityDuplicator}, an 
+ * {@code EntityDuplicationHelper} must be made for a specific entity.
+ * 
+ * @author Nathan Moore (nathanmoore).
+ */
+public interface EntityDuplicationHelper<T> {
+
+    boolean canHandle(MultiTenantCloneable candidate);
+
+    /**
+     * @return Hints used to fine tune copying - generally support for hints is included in 
+     * {@link org.broadleafcommerce.common.copy.MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
+     */
+    Map<String, String> getCopyHints();
+    
+    void addCopyHint(final String name, final String hint);
+
+    void modifyInitialDuplicateState(T copy);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- *
+ * 
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
@@ -31,13 +31,17 @@ import java.util.Map;
  * </p>
  * </p>
  *      The feature must first be enabled before use. To enable, add the following property to your 
- *      Spring property file: {@code admin.entity.duplication.isactive=true}
+ *      Spring property file: {@code admin.entity.duplication.isactive=true}. Furthermore, 
+ *      for any entity you wish to be able to duplicate, you must implement an
+ *      {@link EntityDuplicationHelper}. Consider extending {@link AbstractEntityDuplicationHelper} 
+ *      because it implements {@link EntityDuplicationHelper#getCopyHints()} and 
+ *      {@link EntityDuplicationHelper#addCopyHint(String, String)} for you. 
  * </p>
  * <p>
- *     Furthermore, for any entity you wish to be able to duplicate, you must implement an
- *     {@link EntityDuplicationHelper}. Consider extending {@link AbstractEntityDuplicationHelper} 
- *     because it implements {@link EntityDuplicationHelper#getCopyHints()} and 
- *     {@link EntityDuplicationHelper#addCopyHint(String, String)} for you.
+ *     CopyHints can be added to change the behavior of 
+ *     {@link MultiTenantCloneable#createOrRetrieveCopyInstance(MultiTenantCopyContext)} for a
+ *     specific entity. See {@code org.broadleafcommerce.core.offer.service.OfferDuplicateModifier}
+ *     and {@code org.broadleafcommerce.core.offer.domain.OfferImpl} for an example.
  * </p>
  *
  * @author Jeff Fischer

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicator.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -23,57 +23,92 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import java.util.Map;
 
 /**
- * Create a production duplicate of an entity. In the case of the enterprise module, the entity to be duplicated may not
- * be a sandbox copy. In the case of the multitenant module, the entity to be duplicated must not be referenced in a derived
- * catalog (apart from a standard site override) and must not be owned by another site.
+ * <p>
+ *      Creates a production duplicate of an entity. In the case of the enterprise module, the 
+ *      entity to be duplicated may not be a sandbox copy. In the case of the multitenant module, 
+ *      the entity to be duplicated must not be referenced in a derived catalog (apart from a 
+ *      standard site override) and must not be owned by another site.
  * </p>
- * The feature must first be enabled before use. To enable, add the following property to your Spring property file:
  * </p>
- * {@code admin.entity.duplication.isactive=true}
+ *      The feature must first be enabled before use. To enable, add the following property to your 
+ *      Spring property file: {@code admin.entity.duplication.isactive=true}
+ * </p>
+ * <p>
+ *     Furthermore, for any entity you wish to be able to duplicate, you must implement an
+ *     {@link EntityDuplicationHelper}. Consider extending {@link AbstractEntityDuplicationHelper} 
+ *     because it implements {@link EntityDuplicationHelper#getCopyHints()} and 
+ *     {@link EntityDuplicationHelper#addCopyHint(String, String)} for you.
+ * </p>
  *
  * @author Jeff Fischer
  */
 public interface EntityDuplicator {
 
     /**
-     * Validate whether or not this feature is enabled and whether or not the passed entity params are valid for duplication.
+     * Validate whether or not this feature is enabled and whether the passed entity params are 
+     * valid for duplication.
      *
      * @param entityClass
      * @param id
+     *
      * @return
      */
     boolean validate(Class<?> entityClass, Long id);
 
     /**
-     * Validate whether or not this feature is enabled and whether or not the passed entity params are valid for duplication.
+     * Validate whether or not this feature is enabled and whether or not the passed entity params 
+     * are valid for duplication.
      *
      * @param entity
+     *
      * @return
      */
     boolean validate(Object entity);
 
     /**
-     * Create a production duplicate of the entity specified in the params. The is the most oft used copy method.
-     *
-     * @param entityClass the class for the entity
-     * @param id the primary key
-     * @param copyHints hints used to fine tune copying - generally support for hints is included in {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
-     * @param modifiers list of modifications to perform to the resulting duplicate prior to persistence
-     * @param <T> the entity type
-     * @return the duplicated entity
+     * @deprecated use {@link #copy(Class, Long)}. Modifiers have been moved to a list bean 
+     * to allow easier inclusion (see {@code EntityDuplicationHelpers}) and copy hints can be added 
+     * to implementations of {@link EntityDuplicationHelper}s
      */
-    <T> T copy(Class<T> entityClass, Long id, Map<String, String> copyHints, EntityDuplicateModifier... modifiers);
+    @Deprecated
+    <T> T copy(Class<T> entityClass,
+            Long id,
+            Map<String, String> copyHints,
+            EntityDuplicateModifier... modifiers);
 
     /**
-     * Create a production duplicate of the entity specified in the params. The is the least oft used copy method.
+     * @deprecated use {@link #copy(MultiTenantCopyContext, MultiTenantCloneable)}.
+     * Modifiers have been moved to a list bean 
+     * to allow easier inclusion (see {@code EntityDuplicationHelpers}) and copy hints can be added 
+     * to implementations of {@link EntityDuplicationHelper}s
+     */
+    @Deprecated
+    <T> T copy(MultiTenantCopyContext context,
+            MultiTenantCloneable<T> entity,
+            Map<String, String> copyHints,
+            EntityDuplicateModifier... modifiers);
+
+    /**
+     * Create a production duplicate of the entity specified in the params. 
+     * The is the most oft used copy method.
      *
-     * @param context prepopulated copy context that is setup for catalog and/or site
-     * @param entity the instance to duplicate
-     * @param copyHints hints used to fine tune copying - generally support for hints is included in {@link MultiTenantCloneable#createOrRetrieveCopyInstance(org.broadleafcommerce.common.copy.MultiTenantCopyContext)} implementations.
-     * @param modifiers list of modifications to perform to the resulting duplicate prior to persistence
-     * @param <T> the entity type
+     * @param entityClass the class for the entity
+     * @param id          the primary key
+     * @param <T>         the entity type
+     *
      * @return the duplicated entity
      */
-    <T> T copy(MultiTenantCopyContext context, MultiTenantCloneable<T> entity, Map<String, String> copyHints, EntityDuplicateModifier... modifiers);
+    <T> T copy(Class<T> entityClass, Long id);
 
+    /**
+     * Create a production duplicate of the entity specified in the params. 
+     * The is the least oft used copy method.
+     *
+     * @param context   prepopulated copy context that is setup for catalog and/or site
+     * @param entity    the instance to duplicate
+     * @param <T>       the entity type
+     *
+     * @return the duplicated entity
+     */
+    <T> T copy(MultiTenantCopyContext context, MultiTenantCloneable<T> entity);
 }

--- a/common/src/test/resources/blc-config/bl-test-applicationContext.xml
+++ b/common/src/test/resources/blc-config/bl-test-applicationContext.xml
@@ -19,11 +19,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx" xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <bean id="blMergedPersistenceXmlLocations-it" class="org.springframework.beans.factory.config.ListFactoryBean">
         <property name="sourceList">
@@ -59,6 +55,14 @@
     
     <bean id="root" class="java.lang.String">
         <constructor-arg index="0" value="root"/>
+    </bean>
+
+    <bean id="blEntityDuplicationHelpers"
+          class="org.springframework.beans.factory.config.ListFactoryBean" scope="prototype">
+      <property name="sourceList">
+        <list>
+        </list>
+      </property>
     </bean>
 
 </beans>

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -93,9 +93,10 @@ import javax.persistence.Transient;
 })
 public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation {
 
-    public static final String EXCLUDE_OFFERCODE_COPY_HINT = "exclude-offerCodes";
     public static final long serialVersionUID = 1L;
 
+    public static final String EXCLUDE_OFFERCODE_COPY_HINT = "exclude-offer-offerCodes";
+    
     @Id
     @GeneratedValue(generator= "OfferId")
     @GenericGenerator(

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
@@ -34,7 +34,7 @@ public class OfferDuplicateModifier extends AbstractEntityDuplicationHelper<Offe
 
     @Autowired
     public OfferDuplicateModifier() {
-        addCopyHint(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, "true");
+        addCopyHint(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, Boolean.TRUE.toString());
     }
     
     @Override
@@ -45,7 +45,7 @@ public class OfferDuplicateModifier extends AbstractEntityDuplicationHelper<Offe
     @Override
     public void modifyInitialDuplicateState(final Offer copy) {
         String currentName = copy.getName();
-        copy.setName("Copy of " + currentName);
+        copy.setName(currentName + " - Copy");
         copy.setStartDate(null);
         copy.setEndDate(null);
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
@@ -17,8 +17,11 @@
  */
 package org.broadleafcommerce.core.offer.service;
 
-import org.broadleafcommerce.common.persistence.EntityDuplicateModifier;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.persistence.AbstractEntityDuplicationHelper;
 import org.broadleafcommerce.core.offer.domain.Offer;
+import org.broadleafcommerce.core.offer.domain.OfferImpl;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,12 +30,22 @@ import org.springframework.stereotype.Component;
  * @author Jeff Fischer
  */
 @Component("blOfferDuplicateModifier")
-public class OfferDuplicateModifier implements EntityDuplicateModifier<Offer> {
+public class OfferDuplicateModifier extends AbstractEntityDuplicationHelper<Offer> {
 
+    @Autowired
+    public OfferDuplicateModifier() {
+        addCopyHint(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, "true");
+    }
+    
     @Override
-    public void modifyInitialDuplicateState(Offer copy) {
+    public boolean canHandle(final MultiTenantCloneable candidate) {
+        return Offer.class.isAssignableFrom(candidate.getClass());
+    }
+    
+    @Override
+    public void modifyInitialDuplicateState(final Offer copy) {
         String currentName = copy.getName();
-        copy.setName("Copy Of ("+currentName+")");
+        copy.setName("Copy of " + currentName);
         copy.setStartDate(null);
         copy.setEndDate(null);
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferDuplicateModifier.java
@@ -22,6 +22,7 @@ import org.broadleafcommerce.common.persistence.AbstractEntityDuplicationHelper;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,7 +34,9 @@ import org.springframework.stereotype.Component;
 public class OfferDuplicateModifier extends AbstractEntityDuplicationHelper<Offer> {
 
     @Autowired
-    public OfferDuplicateModifier() {
+    public OfferDuplicateModifier(final Environment environment) {
+        super(environment);
+        
         addCopyHint(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, Boolean.TRUE.toString());
     }
     
@@ -45,7 +48,7 @@ public class OfferDuplicateModifier extends AbstractEntityDuplicationHelper<Offe
     @Override
     public void modifyInitialDuplicateState(final Offer copy) {
         String currentName = copy.getName();
-        copy.setName(currentName + " - Copy");
+        copy.setName(currentName + getCopySuffix());
         copy.setStartDate(null);
         copy.setEndDate(null);
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -119,7 +119,10 @@ public class OfferServiceImpl implements OfferService {
     @Resource(name="blEntityDuplicator")
     protected EntityDuplicator duplicator;
 
-    @Resource(name="blOfferDuplicateModifier")
+    /**
+     * @deprecated Add {@link EntityDuplicateModifier}s to {@code blEntityDuplicationHelpers}
+     */
+    @Deprecated
     protected EntityDuplicateModifier<Offer> offerDuplicateModifier;
 
     @Override
@@ -635,9 +638,7 @@ public class OfferServiceImpl implements OfferService {
     @Transactional("blTransactionManager")
     @Override
     public Offer duplicate(Long originalOfferId) {
-        Map<String, String> copyHints = new HashMap<String, String>();
-        copyHints.put(OfferImpl.EXCLUDE_OFFERCODE_COPY_HINT, "true");
-        return duplicator.copy(OfferImpl.class, originalOfferId, copyHints, offerDuplicateModifier);
+        return duplicator.copy(OfferImpl.class, originalOfferId);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
@@ -233,4 +233,12 @@
         </property>
     </bean>
 
+    <bean id="blEntityDuplicationHelpers"
+          class="org.springframework.beans.factory.config.ListFactoryBean" scope="prototype">
+        <property name="sourceList">
+            <list>
+                <ref bean="blOfferDuplicateModifier"/>
+            </list>
+        </property>
+    </bean>
 </beans>


### PR DESCRIPTION
# New and Noteworthy
Expanded and fleshed-out entity duplication feature.

## Overview of Changes
- Moved "add duplicate button" logic from `AdminOfferController` to the `FormBuilderService` so that it can be added to any entity form in the admin
- Used "add" row level security to control whether the button is allowed to show since this is essentially the same kind of operation
- Moved "duplicate" endpoint out of offer controller into `AdminBasicEntityController` so that it can be used for any entity
- Migrated purpose of `EntityDuplicateModifier` to `EntityDuplicationHelper` and added additional capabilities
    - `EntityDuplicationHelper` must be implemented to enable duplication of a particular entity (or set of entities; see `OfferDuplicateModifier`)
    - `CopyHints` moved from loose collection to be a field of `EntityDuplicationHelper`
    - Added list bean `blEntityDuplicationHelpers` to keep track of all `EntityDuplicationHelpers` rather than have them be passed into the `EntityDuplicator` from the caller
- Extracted duplicate logic in `AdminBasicEntityController` and `AdminProductController` into methods in the superclass

## How to Enable Duplication

1. Set `admin.entity.duplication.isactive=true`
2. Implement an `org.broadleafcommerce.common.persistence.EntityDuplicationHelper` preferably via the provided `AbstractEntityDuplicationHelper` for the entity you wish to allow duplication in the admin. See out-of-the-box example `org.broadleafcommerce.core.offer.service.OfferDuplicateModifier`
3. Add bean reference to `blEntityDuplicationHelpers`
4. For extended entities, must also override `#createOrRetrieveCopyInstance` even if it is just to call the `super` method.

## How to Duplicate

1. Select an entity record from the main list grid
2. Click the dropdown arrow next to the save button
3. Click "Duplicate"

>Notes: Duplication is only possible on production records, and copies will be created as production records.

<img width="134" alt="screen shot 2018-07-23 at 9 17 12 am" src="https://user-images.githubusercontent.com/5314838/43082241-2e173612-8e59-11e8-84dd-c2f7912ceb36.png">

## Other Info

### EntityDuplicator

- Primary service responsible for duplicating entities. 
- Default implementation is designed to only work with classes that implement `MultiTenantCloneable`

### EntityDuplicationHelper

- Intended to provide additional metadata and perform final modifications for a duplicated entity before persistence
- Required to enable duplication of a specific entity or group of entities
- `AbstractEntityDuplicationHelper` provides default implementation for managing copy hints

### Copy Hints

- Intended as a way to provide additional, entity-specific information during the copy process
- It is up to implementors to harvest and utilize this information in implementations of `MultiTenantCloneable#createOrRetrieveCopyInstance()`
- Copy hints can be used to determine what fields of an entity should be copied vs cloned during the duplication process. For example, some foreign key relationships should not be cloned such as if copying a Product: The parent Category should not be cloned rather the reference should be copied in order to avoid creating a new category. Generally, only collections and dependent relationships should be cloned in this context. Therefore, if implementors desire to enable copying for Product, they will be required to work down the entity hierarchy and add copy hints to prevent cloning such relationships (e.g., add copy hints to Product, Sku, ProductOption, etc.)