### PR TITLE
Allow AdornedTargetCollection fields to have i18n translatable values

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -1509,6 +1509,11 @@ public class AdminBasicEntityController extends AdminAbstractController {
                     collectionField,
                     collectionItemId, responseMap);
 
+            //For AdornedTargetCollections, we need to be specific on what translation ceilingEntity and Id is used.
+            //It should be the entity and referenced Id of the adorned entity (not the target entity and Id).
+            entityForm.setTranslationCeilingEntity(entityForm.getEntityType());
+            entityForm.setTranslationId(alternateId);
+
             ClassMetadata cmd = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
             for (String field : fmd.getMaintainedAdornedTargetFields()) {
                 if (responseMap.containsKey(field) && responseMap.containsKey("autoSubmit")) {

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslatedEntity.java
@@ -61,6 +61,8 @@ public class TranslatedEntity implements Serializable, BroadleafEnumerationType 
     public static final TranslatedEntity CATALOG = new TranslatedEntity("org.broadleafcommerce.common.site.domain.Catalog", "Catalog");
     public static final TranslatedEntity STRUCTURED_CONTENT = new TranslatedEntity("org.broadleafcommerce.cms.structure.domain.StructuredContent", "StructuredContent");
     public static final TranslatedEntity FIELD = new TranslatedEntity("org.broadleafcommerce.core.search.domain.Field", "Field");
+    public static final TranslatedEntity CROSS_SALE_PRODUCT = new TranslatedEntity("org.broadleafcommerce.core.catalog.domain.CrossSaleProduct", "CrossSaleProduct");
+    public static final TranslatedEntity UP_SALE_PRODUCT = new TranslatedEntity("org.broadleafcommerce.core.catalog.domain.UpSaleProduct", "UpSaleProduct");
 
     public static TranslatedEntity getInstance(final String type) {
         return TYPES.get(type);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProduct.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProduct.java
@@ -1,0 +1,12 @@
+
+package org.broadleafcommerce.core.catalog.domain;
+
+/**
+ * This is a specific interface for CrossSaleProductImpl and is needed for entity mapping and translations
+ * 
+ * @author dcolgrove
+ *
+ */
+public interface CrossSaleProduct extends RelatedProduct {
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
@@ -23,6 +23,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
@@ -43,7 +44,7 @@ import java.math.BigDecimal;
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class CrossSaleProductImpl implements RelatedProduct, MultiTenantCloneable<CrossSaleProductImpl> {
+public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantCloneable<CrossSaleProductImpl> {
 
     protected static final long serialVersionUID = 1L;
 
@@ -61,7 +62,7 @@ public class CrossSaleProductImpl implements RelatedProduct, MultiTenantCloneabl
     protected Long id;
     
     @Column(name = "PROMOTION_MESSAGE")
-    @AdminPresentation(friendlyName = "CrossSaleProductImpl_Cross_Sale_Promotion_Message", largeEntry=true)
+    @AdminPresentation(friendlyName = "CrossSaleProductImpl_Cross_Sale_Promotion_Message", translatable=true, largeEntry=true)
     protected String promotionMessage;
 
     @Column(name = "SEQUENCE", precision = 10, scale = 6)
@@ -95,7 +96,7 @@ public class CrossSaleProductImpl implements RelatedProduct, MultiTenantCloneabl
 
     @Override
     public String getPromotionMessage() {
-        return promotionMessage;
+        return DynamicTranslationProvider.getValue(this, "promotionMessage", promotionMessage);
     }
     
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProduct.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProduct.java
@@ -1,0 +1,11 @@
+package org.broadleafcommerce.core.catalog.domain;
+
+/**
+ * This is a specific interface for CrossSaleProductImpl and is needed for entity mapping and translations
+ * 
+ * @author dcolgrove
+ *
+ */
+public interface UpSaleProduct extends RelatedProduct {
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
@@ -43,7 +43,7 @@ import java.math.BigDecimal;
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class UpSaleProductImpl implements RelatedProduct, MultiTenantCloneable<UpSaleProductImpl> {
+public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<UpSaleProductImpl> {
 
     private static final long serialVersionUID = 1L;
 
@@ -61,7 +61,7 @@ public class UpSaleProductImpl implements RelatedProduct, MultiTenantCloneable<U
     private Long id;
     
     @Column(name = "PROMOTION_MESSAGE")
-    @AdminPresentation(friendlyName = "UpSaleProductImpl_Upsale_Promotion_Message", largeEntry=true)
+    @AdminPresentation(friendlyName = "UpSaleProductImpl_Upsale_Promotion_Message", translatable=true, largeEntry=true)
     private String promotionMessage;
 
     @Column(name = "SEQUENCE", precision = 10, scale = 6)

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-entity.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-entity.xml
@@ -53,6 +53,8 @@
     <bean id="org.broadleafcommerce.core.catalog.domain.ProductBundle" class="org.broadleafcommerce.core.catalog.domain.ProductBundleImpl" scope="prototype" />
     <bean id="org.broadleafcommerce.core.catalog.domain.ProductOption" class="org.broadleafcommerce.core.catalog.domain.ProductOptionImpl" scope="prototype" />
     <bean id="org.broadleafcommerce.core.catalog.domain.ProductOptionValue" class="org.broadleafcommerce.core.catalog.domain.ProductOptionValueImpl" scope="prototype" />
+    <bean id="org.broadleafcommerce.core.catalog.domain.CrossSaleProduct" class="org.broadleafcommerce.core.catalog.domain.CrossSaleProductImpl" scope="prototype" />
+    <bean id="org.broadleafcommerce.core.catalog.domain.UpSaleProduct" class="org.broadleafcommerce.core.catalog.domain.UpSaleProductImpl" scope="prototype" />    
     <bean id="org.broadleafcommerce.core.catalog.domain.SkuBundleItem" class="org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl" scope="prototype" />
     <bean id="org.broadleafcommerce.core.catalog.domain.Sku" class="org.broadleafcommerce.core.catalog.domain.SkuImpl" scope="prototype"/>
     <bean id="org.broadleafcommerce.core.catalog.domain.SkuAttribute" class="org.broadleafcommerce.core.catalog.domain.SkuAttributeImpl" scope="prototype"/>


### PR DESCRIPTION
Also added translatable functionality to CrossSell/UpSell promotionMessage.  Fixes https://github.com/BroadleafCommerce/QA/issues/3421