### PR TITLE
Performance improvements for building metadata

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
@@ -153,6 +153,9 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
 
     protected ApplicationContext applicationContext;
 
+
+    protected FieldManager fieldManager = new FieldManager(entityConfiguration, null);
+
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
@@ -1554,6 +1557,7 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
     @Override
     public void setStandardEntityManager(EntityManager entityManager) {
         this.standardEntityManager = entityManager;
+        fieldManager = new FieldManager(entityConfiguration, entityManager);
     }
 
     @Override
@@ -1568,7 +1572,7 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
 
     @Override
     public FieldManager getFieldManager() {
-        return new FieldManager(entityConfiguration, getStandardEntityManager());
+        return fieldManager;
     }
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
@@ -154,7 +154,7 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
     protected ApplicationContext applicationContext;
 
 
-    protected FieldManager fieldManager = new FieldManager(entityConfiguration, null);
+    protected FieldManager fieldManager;
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -1572,6 +1572,11 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
 
     @Override
     public FieldManager getFieldManager() {
+        if (fieldManager == null) {
+            //keep in mind that getStandardEntityManager() can return null, this is in general OK,
+            // we re-init fieldManager in setStandardEntityManager method
+            fieldManager = new FieldManager(entityConfiguration, getStandardEntityManager());
+        }
         return fieldManager;
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -62,7 +62,7 @@ public class FieldManager {
     protected EntityConfiguration entityConfiguration;
     protected EntityManager entityManager;
     protected List<SortableValue> middleFields = new ArrayList<SortableValue>(5);
-    protected Set<Class> classes = new HashSet<>();
+    protected Set<Class> managedEntityClasses = new HashSet<>();
     protected Map<Class, Map<String, Field>> classFields = new HashMap<>();
 
     public FieldManager(EntityConfiguration entityConfiguration, EntityManager entityManager) {
@@ -71,7 +71,7 @@ public class FieldManager {
         if (entityManager != null) {
             Set<EntityType<?>> managedEntities = entityManager.getMetamodel().getEntities();
             for (EntityType managedEntity : managedEntities) {
-                classes.add(managedEntity.getJavaType());
+                managedEntityClasses.add(managedEntity.getJavaType());
             }
         }
     }
@@ -277,7 +277,7 @@ public class FieldManager {
 
     protected boolean isPersistentClass(Class entityClass) {
         if (entityManager != null) {
-            return classes.contains(entityClass);
+            return managedEntityClasses.contains(entityClass);
         }
         return false;
     }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,12 +49,12 @@ import javax.persistence.EntityManager;
 import javax.persistence.metamodel.EntityType;
 
 /**
- * 
+ *
  * @author jfischer
  *
  */
 public class FieldManager {
-    
+
     private static final Log LOG = LogFactory.getLog(FieldManager.class);
 
     public static final String MAPFIELDSEPARATOR = "---";
@@ -61,10 +62,18 @@ public class FieldManager {
     protected EntityConfiguration entityConfiguration;
     protected EntityManager entityManager;
     protected List<SortableValue> middleFields = new ArrayList<SortableValue>(5);
+    protected Set<Class> classes = new HashSet<>();
+    protected Map<Class, Map<String, Field>> classFields = new HashMap<>();
 
     public FieldManager(EntityConfiguration entityConfiguration, EntityManager entityManager) {
         this.entityConfiguration = entityConfiguration;
         this.entityManager = entityManager;
+        if (entityManager != null) {
+            Set<EntityType<?>> managedEntities = entityManager.getMetamodel().getEntities();
+            for (EntityType managedEntity : managedEntities) {
+                classes.add(managedEntity.getJavaType());
+            }
+        }
     }
 
     public static Field getSingleField(Class<?> clazz, String fieldName) throws IllegalStateException {
@@ -72,13 +81,25 @@ public class FieldManager {
     }
 
     public Field getField(Class<?> clazz, String fieldName) throws IllegalStateException {
-        DynamicEntityDao dynamicEntityDao = getPersistenceManager(clazz).getDynamicEntityDao();
-        SessionFactory sessionFactory = dynamicEntityDao.getDynamicDaoHelper().
-                getSessionFactory((HibernateEntityManager) dynamicEntityDao.getStandardEntityManager());
-        BLCFieldUtils fieldUtils = new BLCFieldUtils(sessionFactory, true, dynamicEntityDao.useCache(),
-                dynamicEntityDao.getEjb3ConfigurationDao(), entityConfiguration,
-                dynamicEntityDao.getDynamicDaoHelper());
-        return fieldUtils.getField(clazz, fieldName);
+        Map<String, Field> stringFieldMap = classFields.get(clazz);
+        if(stringFieldMap==null){
+            stringFieldMap = new HashMap<>();
+            classFields.put(clazz, stringFieldMap);
+        }
+        Field field = stringFieldMap.get(fieldName);
+        if(field!=null){
+            return field;
+        }else {
+            DynamicEntityDao dynamicEntityDao = getPersistenceManager(clazz).getDynamicEntityDao();
+            SessionFactory sessionFactory = dynamicEntityDao.getDynamicDaoHelper().
+                    getSessionFactory((HibernateEntityManager) dynamicEntityDao.getStandardEntityManager());
+            BLCFieldUtils fieldUtils = new BLCFieldUtils(sessionFactory, true, dynamicEntityDao.useCache(),
+                    dynamicEntityDao.getEjb3ConfigurationDao(), entityConfiguration,
+                    dynamicEntityDao.getDynamicDaoHelper());
+            Field fld = fieldUtils.getField(clazz, fieldName);
+            stringFieldMap.put(fieldName, fld);
+            return fld;
+        }
     }
 
     public Object getFieldValue(Object bean, String fieldName) throws IllegalAccessException, FieldNotAvailableException {
@@ -128,7 +149,7 @@ public class FieldManager {
         Field field;
         bean = HibernateUtils.deproxy(bean);
         Object value = bean;
-        
+
         int count = tokens.countTokens();
         int j=0;
         StringBuilder sb = new StringBuilder();
@@ -196,7 +217,7 @@ public class FieldManager {
             sb.append(".");
             j++;
         }
-        
+
         return value;
 
     }
@@ -224,17 +245,17 @@ public class FieldManager {
         }
         return response;
     }
-    
+
     public Map<String, Serializable> persistMiddleEntities() throws InstantiationException, IllegalAccessException {
         Map<String, Serializable> persistedEntities = new HashMap<String, Serializable>();
-        
+
         Collections.sort(middleFields);
         for (SortableValue val : middleFields) {
             Serializable s = entityManager.merge(val.entity);
             persistedEntities.put(val.getContainingPropertyName(), s);
             setFieldValue(val.getBean(), val.getContainingPropertyName(), s);
         }
-        
+
         return persistedEntities;
     }
 
@@ -256,14 +277,8 @@ public class FieldManager {
 
     protected boolean isPersistentClass(Class entityClass) {
         if (entityManager != null) {
-            Set<EntityType<?>> managedEntities = entityManager.getMetamodel().getEntities();
-            for (EntityType managedEntity : managedEntities) {
-                if (managedEntity.getJavaType().equals(entityClass)) {
-                    return true;
-                }
-            }
+            return classes.contains(entityClass);
         }
-
         return false;
     }
 
@@ -365,13 +380,13 @@ public class FieldManager {
     }
 
     private class SortableValue implements Comparable<SortableValue> {
-        
+
         private Integer pos;
         private Serializable entity;
         private Class<?> entityClass;
         private String containingPropertyName;
         private Object bean;
-        
+
         public SortableValue(Object bean, Serializable entity, Integer pos, String containingPropertyName) {
             this.bean = bean;
             this.entity = entity;
@@ -384,7 +399,7 @@ public class FieldManager {
         public int compareTo(SortableValue o) {
             return pos.compareTo(o.pos) * -1;
         }
-        
+
         public String getContainingPropertyName() {
             return containingPropertyName;
         }
@@ -432,5 +447,5 @@ public class FieldManager {
         }
 
     }
-    
+
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -63,7 +63,7 @@ public class FieldManager {
     protected EntityManager entityManager;
     protected List<SortableValue> middleFields = new ArrayList<SortableValue>(5);
     protected Set<Class> managedEntityClasses = new HashSet<>();
-    protected Map<Class, Map<String, Field>> classFields = new HashMap<>();
+    protected BLCFieldUtils fieldUtils;
 
     public FieldManager(EntityConfiguration entityConfiguration, EntityManager entityManager) {
         this.entityConfiguration = entityConfiguration;
@@ -81,25 +81,16 @@ public class FieldManager {
     }
 
     public Field getField(Class<?> clazz, String fieldName) throws IllegalStateException {
-        Map<String, Field> stringFieldMap = classFields.get(clazz);
-        if(stringFieldMap==null){
-            stringFieldMap = new HashMap<>();
-            classFields.put(clazz, stringFieldMap);
-        }
-        Field field = stringFieldMap.get(fieldName);
-        if(field!=null){
-            return field;
-        }else {
-            DynamicEntityDao dynamicEntityDao = getPersistenceManager(clazz).getDynamicEntityDao();
-            SessionFactory sessionFactory = dynamicEntityDao.getDynamicDaoHelper().
-                    getSessionFactory((HibernateEntityManager) dynamicEntityDao.getStandardEntityManager());
-            BLCFieldUtils fieldUtils = new BLCFieldUtils(sessionFactory, true, dynamicEntityDao.useCache(),
+        DynamicEntityDao dynamicEntityDao = getPersistenceManager(clazz).getDynamicEntityDao();
+        SessionFactory sessionFactory = dynamicEntityDao.getDynamicDaoHelper().
+                getSessionFactory((HibernateEntityManager) dynamicEntityDao.getStandardEntityManager());
+        if(fieldUtils==null) {
+            fieldUtils = new BLCFieldUtils(sessionFactory, true, dynamicEntityDao.useCache(),
                     dynamicEntityDao.getEjb3ConfigurationDao(), entityConfiguration,
                     dynamicEntityDao.getDynamicDaoHelper());
-            Field fld = fieldUtils.getField(clazz, fieldName);
-            stringFieldMap.put(fieldName, fld);
-            return fld;
         }
+        Field fld = fieldUtils.getField(clazz, fieldName);
+        return fld;
     }
 
     public Object getFieldValue(Object bean, String fieldName) throws IllegalAccessException, FieldNotAvailableException {


### PR DESCRIPTION
performance improvements for building metadata after profiling
Originally was asked by emeratech that return request screen is slow.
This is because new entity was introduced and it has field orderItem, fulfillmentOrderItem etc, and some of the fields that should be visible in grid are deep inside orderItem.xxx.yyy.zzz.fieldName
So to build metadata for those properties metadata buiilder does a pretty deep recursion and it takes some time to build metadata for the introduced class.
Profiling with invocation count and time spent identified couple of hot spots that I was trying to address in that PR. in general reflection is not fast thing, so some caching can be handy.