### PR TITLE
Add item attributes to orderItemRequestDTO on update

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
@@ -50,6 +50,20 @@ public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<C
         CartOperationRequest request = context.getSeedData();
         OrderItemRequestDTO orderItemRequestDTO = request.getItemRequest();
         
+        Map <String, String> attributes = new HashMap<>();
++        OrderItem requestedOrderItem = new OrderItemImpl();
++        for (OrderItem oi : request.getOrder().getOrderItems()) {
++            if (oi.getId() == orderItemRequestDTO.getOrderItemId()){
++                requestedOrderItem = oi;
++            }
++        }
++
++        for (String key : requestedOrderItem.getOrderItemAttributes().keySet()) {
++            attributes.put(key, requestedOrderItem.getOrderItemAttributes().get(key).getValue());
++        }
++
++        orderItemRequestDTO.setItemAttributes(attributes);
+        
         // Throw an exception if the user did not specify an orderItemId
         if (orderItemRequestDTO.getOrderItemId() == null) {
             throw new IllegalArgumentException("OrderItemId must be specified when removing from order");

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
@@ -51,18 +51,18 @@ public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<C
         OrderItemRequestDTO orderItemRequestDTO = request.getItemRequest();
         
         Map <String, String> attributes = new HashMap<>();
-+        OrderItem requestedOrderItem = new OrderItemImpl();
-+        for (OrderItem oi : request.getOrder().getOrderItems()) {
-+            if (oi.getId() == orderItemRequestDTO.getOrderItemId()){
-+                requestedOrderItem = oi;
-+            }
-+        }
-+
-+        for (String key : requestedOrderItem.getOrderItemAttributes().keySet()) {
-+            attributes.put(key, requestedOrderItem.getOrderItemAttributes().get(key).getValue());
-+        }
-+
-+        orderItemRequestDTO.setItemAttributes(attributes);
+        OrderItem requestedOrderItem = new OrderItemImpl();
+        for (OrderItem oi : request.getOrder().getOrderItems()) {
+            if (oi.getId() == orderItemRequestDTO.getOrderItemId()){
+                requestedOrderItem = oi;
+            }
+        }
+
+        for (String key : requestedOrderItem.getOrderItemAttributes().keySet()) {
+            attributes.put(key, requestedOrderItem.getOrderItemAttributes().get(key).getValue());
+        }
+
+        orderItemRequestDTO.setItemAttributes(attributes);
         
         // Throw an exception if the user did not specify an orderItemId
         if (orderItemRequestDTO.getOrderItemId() == null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/update/ValidateUpdateRequestActivity.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.core.order.service.workflow.update;
 
 import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;
 import org.broadleafcommerce.core.order.domain.OrderItem;
+import org.broadleafcommerce.core.order.domain.OrderItemImpl;
 import org.broadleafcommerce.core.order.service.OrderItemService;
 import org.broadleafcommerce.core.order.service.call.OrderItemRequestDTO;
 import org.broadleafcommerce.core.order.service.exception.MinQuantityNotFulfilledException;
@@ -29,6 +30,8 @@ import org.broadleafcommerce.core.workflow.ProcessContext;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component("blValidateUpdateRequestActivity")
 public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<CartOperationRequest>> {
@@ -50,7 +53,7 @@ public class ValidateUpdateRequestActivity extends BaseActivity<ProcessContext<C
         CartOperationRequest request = context.getSeedData();
         OrderItemRequestDTO orderItemRequestDTO = request.getItemRequest();
         
-        Map <String, String> attributes = new HashMap<>();
+        Map<String, String> attributes = new HashMap<>();
         OrderItem requestedOrderItem = new OrderItemImpl();
         for (OrderItem oi : request.getOrder().getOrderItems()) {
             if (oi.getId() == orderItemRequestDTO.getOrderItemId()){


### PR DESCRIPTION
In satisfiesMinQuantityCondition it validates for required attributes, but on the update request we do not add those to the requestDTO, which causes the RequiredAttributeNotProvidedException to be thrown when attempting to update the item in the cart.