### PR TITLE
Forcing Admin images extension to be lowercase

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/UrlRewriteProcessor.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/UrlRewriteProcessor.java
@@ -128,7 +128,7 @@ public class UrlRewriteProcessor extends AbstractBroadleafAttributeModifierProce
             extension = assetPath.substring(extensionStartIndex);
         }
 
-        return extension;
+        return extension.toLowerCase();
     }
 
     protected String getDefaultFileTypeImagePath(String extension) {


### PR DESCRIPTION
BroadleafCommerce/QA#3429
Admin images extension fixes.