### PR TITLE
Fixes the issue where filter applied to entity list-grid carries over to switch site modal

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -847,8 +847,10 @@
 
                 // check for existing rules in the url
                 var queryString = BLCAdmin.filterBuilders.getQueryVariable(field.id);
+                // make sure its not modal
+                var modal = BLCAdmin.currentModal();
 
-                if (queryString != null) {
+                if ((queryString != null) && (modal == undefined)) {
                     var numInputs = 1;
                     // is this a 'BETWEEN' filter?
                     if (queryString.indexOf('|') > 0) {


### PR DESCRIPTION
Filter builder is trying add existing filter from URL. Check if it is modal and if its not then only apply the filter.

https://github.com/BroadleafCommerce/QA/issues/3451