### PR TITLE
Revert "Changed redirect path for AJAX requests."

### DIFF
--- a/common/src/main/resources/common_style/templates/utility/blcRedirect.html
+++ b/common/src/main/resources/common_style/templates/utility/blcRedirect.html
@@ -1,1 +1,1 @@
-<div id="blc-redirect-url" class="hidden" th:text="@{${blc_redirect}}" th:if="${!#strings.isEmpty(blc_redirect)}"></div>
+<div id="blc-redirect-url" class="hidden" th:text="${blc_redirect}" th:if="${!#strings.isEmpty(blc_redirect)}"></div>


### PR DESCRIPTION
Reverts BroadleafCommerce/BroadleafCommerce#1947

This PR is causing the servlet path to be appended twice when the application is being run within a context (e.g. /admin).