### PR TITLE
Fixed issue where a subcollection entity name can be a null reference in the enterprise workflow process

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminEntityServiceImpl.java
@@ -655,6 +655,11 @@ public class AdminEntityServiceImpl implements AdminEntityService {
         Property parentNameProp = parentEntity.getPMap().get(AdminMainEntity.MAIN_ENTITY_NAME_PROPERTY);
         if (parentNameProp != null) {
             ppr.setRequestingEntityName(parentNameProp.getValue());
+        } else {
+            Property name = parentEntity.getPMap().get("name");
+            if(name !=null) {
+                ppr.setRequestingEntityName(name.getValue());
+            }
         }
 
         Property p = new Property();


### PR DESCRIPTION
This fixes specifically the "update" subcollection use case.  The "add" use case had already been fixed.  Fixes https://github.com/BroadleafCommerce/QA/issues/3444