### PR TITLE
Fixed the issue with duplicate OrderItemAttributes

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
@@ -39,7 +39,8 @@ import java.lang.reflect.Method;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_ORDER_ITEM_ATTRIBUTE")
+@Table(name="BLC_ORDER_ITEM_ATTRIBUTE",
+        uniqueConstraints = @UniqueConstraint(name = "ATTR_NAME_ORDER_ITEM_ID", columnNames = {"NAME", "ORDER_ITEM_ID"}))
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOrderElements")
 @AdminPresentationClass(friendlyName = "OrderItemAttributeImpl_baseProductAttribute")
 public class OrderItemAttributeImpl implements OrderItemAttribute {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
@@ -119,10 +119,17 @@ public class OrderItemServiceImpl implements OrderItemService {
             }
             for (String key : attributes.keySet()) {
                 String value = attributes.get(key);
-                OrderItemAttribute attribute = new OrderItemAttributeImpl();
+
+                OrderItemAttribute attribute = orderItemAttributes.get(key);
+
+                if(attribute == null) {
+                    attribute = new OrderItemAttributeImpl();
+                }
+
                 attribute.setName(key);
                 attribute.setValue(value);
                 attribute.setOrderItem(item);
+
                 orderItemAttributes.put(key, attribute);
             }
         }


### PR DESCRIPTION
BroadleafCommerce/QA#3464
Added the unique constraint to prevent a issue with duplicate of the OrderItemAttributes. Added check if the OrderItemAttribute already exists, update it.