### PR TITLE
If the object name is blank, do not append the appName

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/jmx/AnnotationJmxAttributeSource.java
+++ b/common/src/main/java/org/broadleafcommerce/common/jmx/AnnotationJmxAttributeSource.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.common.jmx;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.jmx.export.metadata.InvalidMetadataException;
 import org.springframework.jmx.export.metadata.ManagedResource;
 
@@ -39,7 +40,9 @@ public class AnnotationJmxAttributeSource extends org.springframework.jmx.export
         ManagedResource resource = super.getManagedResource(beanClass);
         if (resource != null && appName != null) {
             String objectName = resource.getObjectName();
-            objectName += "." + appName;
+            if(StringUtils.isNotBlank(objectName)) {
+                objectName += "." + appName;
+            }
             resource.setObjectName(objectName);
         }
         return resource;


### PR DESCRIPTION
This addresses an issue when we manually apply an appName regardless of what the MBean name actually is on server startup.

Fixes: BroadleafCommerce/Issues#7