### PR TITLE
Fix issue where alt text was not being persisted

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
@@ -125,7 +125,8 @@ public class AdminAssetUploadController extends AdminAbstractController {
 
         responseMap.put("adminDisplayAssetUrl", request.getContextPath() + assetUrl);
         responseMap.put("assetUrl", assetUrl);
-        
+        responseMap.put("altText", staticAsset.getAltText());
+
         if (staticAsset instanceof ImageStaticAssetImpl) {
             responseMap.put("image", Boolean.TRUE);
             responseMap.put("assetThumbnail", assetUrl + "?smallAdminThumbnail");

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
@@ -55,8 +55,9 @@
             $redactor.on('assetInfoSelected', function(event, fields) {
                 currentRedactor.selection.restore();
                 var assetUrl =   fields['assetUrl'];
+                var altText = fields['altText'];
                 if (assetUrl.charAt(0) == "/") assetUrl = assetUrl.substr(1);
-                var $img = $('<img>', { 'src' : assetUrl });
+                var $img = $('<img>', { 'src' : assetUrl, 'alt': altText });
                 currentRedactor.insert.html($img.outerHTML());
                 BLCAdmin.hideCurrentModal();
             });

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
@@ -146,6 +146,7 @@ $(document).ready(function() {
                 } else {
                     var mediaJson = mediaItem.val() == "" || mediaItem.val() == "null" ? {} : jQuery.parseJSON(mediaItem.val());
                     mediaJson.url = fields['assetUrl'];
+                    mediaJson.altText = fields['altText'];
                     mediaItem.val(JSON.stringify(mediaJson)).trigger('input');
                 }
             }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -183,6 +183,12 @@
                 fields['selectedRow'] = $tr;
             }
 
+            var $selectedAssetImg = $('.asset-item.active .image-wrapper img');
+
+            if ($selectedAssetImg.length) {
+                fields['altText'] = $selectedAssetImg.attr('alt');
+            }
+
             return fields;
         },
 


### PR DESCRIPTION
BroadleafCommerce/QA#3476 - Allow alt text to be persisted

- Back-port code from `5.2` that adds the `altText` to the controller and html.
- Add code in JS to allow the alt text to be set correctly so it can be sent with the request to the server.
