### PR TITLE
Password field's label should not display the actual password value

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/password.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/password.html
@@ -1,4 +1,4 @@
-<label th:for="*{fields['__${field.name}__'].value}" th:classappend="${field.required ? 'required' : ''}" >
+<label th:for="${'fields[''' + field.name + '''].value'}" th:classappend="${field.required ? 'required' : ''}" >
     <span th:utext="#{${field.friendlyName}}"></span>
 <span th:replace="components/fieldTooltip" ></span>
 </label>


### PR DESCRIPTION
Currently in the admin any password entry field will show the current password as the field's label's `for` attribute.