### PR TITLE
Fixing a NPE that occurs in Admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
@@ -155,6 +155,11 @@ public class AdminNavigationServiceImpl implements AdminNavigationService {
             clazz = clazz.substring(0, clazz.length() - 4);
             sections = adminNavigationDao.readAdminSectionForClassName(clazz);
         }
+        
+        if (sections == null) {
+            return null;
+        }
+        
         for (AdminSection section : sections) {
             //When identifying the "base" section, multiple can be returned.  "Type" sections (e.g. product:addon) will have a ":".
             //  Since we are looking for the base section, the "type" sections should be ignored


### PR DESCRIPTION
Fixing a NPE that occurs in Admin when navigating to the My Changes and Workflow Audit sections, after making changes to a Content Item. One example of when the NPE occurs is when you edit a content item and try to approve it through the sandboxing workflow. The class is `org.broadleafcommerce.cms.structure.domain.StructuredContent` which returns no sections, and the NPE is thrown on in the for loop because `sections` is null