### PR TITLE
Override equals and hashCode

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -34,6 +34,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -187,6 +188,12 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
             return false;
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id, getAttributeValue());
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
@@ -30,6 +30,8 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Polymorphism;
 import org.hibernate.annotations.PolymorphismType;
 
+import java.util.Objects;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -127,5 +129,21 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
             cloned.setProductOptionValue(productOptionValue.createOrRetrieveCopyInstance(context).getClone());
         }
         return createResponse;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SkuProductOptionValueXrefImpl that = (SkuProductOptionValueXrefImpl) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(getSku(), that.getSku()) &&
+                Objects.equals(getProductOptionValue(), that.getProductOptionValue());
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id, getSku(), getProductOptionValue());
     }
 }


### PR DESCRIPTION
BroadleafCommerce/QA#3487
Override equals and hashCode as SkuProductOptionValueXrefImpl used in the HashSet collection "SkuImpl#productOptionValueXrefs".