### PR TITLE
Truncate timestamps when adding demo data to a Postgres database

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/sql/importsql/DemoPostgresSingleLineSqlCommandExtractor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/sql/importsql/DemoPostgresSingleLineSqlCommandExtractor.java
@@ -73,6 +73,11 @@ public class DemoPostgresSingleLineSqlCommandExtractor extends SingleLineSqlComm
                 newCommand = charMatcher.replaceAll("CHR(" + charCode + ")");
             }
 
+            // Replace CURRENT_TIMESTAMP with date_trunc('second', CURRENT_TIMESTAMP) otherwise the time will be in fractions of a second
+            // This is an issue because when adding a collection item to a sandboxable item the time will be rounded and
+            // an attempt to save straight to production will occur resulting in an error
+            newCommand = newCommand.replaceAll("CURRENT_TIMESTAMP", "date_trunc('second', CURRENT_TIMESTAMP)");
+
             newCommands[i] = newCommand;
             i++;
         }


### PR DESCRIPTION
Updated DemoPostgresSingleLineSqlExtractor to replace all instances of `CURRENT_TIMESTAMP` with `date_trunc('second', CURRENT_TIMESTAMP)`

This change was done because `CURRENT_TIMESTAMP` for Postgres inserts the time accurate up to fractions of seconds instead of full seconds. This was an issue because when a sub collection is added to an entity that is sandboxable the date field is updated to the truncated time somewhere in the admin pipeline and then the entity was being persisted under the assumption that no fields would be changed. Since the date field changed an error was thrown saying that a production change on a sandboxable entity attempted to be done through the admin. This solution fixes the issue since it simply truncates to extra fractions of a second off.