### PR TITLE
Return true when there is a defaultValue so that the NO VALUE SELECTED option will not show

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -603,7 +603,7 @@ public class BasicFieldMetadata extends FieldMetadata {
 
     public Boolean getAllowNoValueEnumOption() {
         return StringUtils.isEmpty(getDefaultValue())
-            || (!getRequired() && !(getRequiredOverride() != null && getRequiredOverride()));
+            && (!getRequired() && !(getRequiredOverride() != null && getRequiredOverride()));
     }
 
     public void setCanLinkToExternalEntity(Boolean canLinkToExternalEntity) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/data_driven_enumeration.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/data_driven_enumeration.html
@@ -14,7 +14,7 @@
 
 <th:block th:if="${!#maps.isEmpty(field.options) and #maps.size(field.options) lt #props.getAsInt('admin.enum.minCountForDropDown')}">
     <div class="radio-container">
-        <div th:if="!${field.required}" class="radio-option">
+        <div th:if="${field.allowNoValueEnumOption}" class="radio-option">
             <input th:field="*{fields['__${field.name}__'].value}" type="radio" class="radio" value=""/>
             <label class="radio-label" th:utext="#{No_Value_Selected}" th:classappend="${field.readOnly}? 'disabled'"></label>
         </div>


### PR DESCRIPTION
BroadleafCommerce/QA#3489 

- Return `true` when there is a `defaultValue`
- Refactor the data-driven-enum template so it uses the updated `allowNoValueEnumOption` method.