### PR TITLE
Fix template error when opening admin reset password link

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/login/resetPassword.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/login/resetPassword.html
@@ -1,67 +1,62 @@
 <div>
     <div th:fragment="messages">
-        <div class="alert" th:switch="${errorCode}" th:unless="${#strings.isEmpty(errorCode)}">  
-            <div th:case="'notFound'" th:text="#{password.notFound}" ></div>
-            <div th:case="'invalidUser'" th:text="#{password.invalidUser}" ></div>
-            <div th:case="'inactiveUser'" th:text="#{password.inactiveUser}" ></div>
-            <div th:case="'invalidToken'" th:text="#{password.invalidToken}" ></div>
-            <div th:case="'tokenExpired'" th:text="#{password.tokenExpired}" ></div>
-            <div th:case="'tokenUsed'" th:text="#{password.tokenUsed}" ></div>
-            <div th:case="'invalidPassword'" th:text="#{password.invalidPassword}" ></div>
-            <div th:case="'passwordMismatch'" th:text="#{password.passwordMismatch}" ></div>
-            <div th:case="*" th:inline="text">[[#{password.unknown}]] <span th:text="${errorCode}"></span>
-</div>
+        <div class="alert" th:switch="${errorCode}" th:unless="${#strings.isEmpty(errorCode)}">
+            <div th:case="'notFound'" th:text="#{password.notFound}"></div>
+            <div th:case="'invalidUser'" th:text="#{password.invalidUser}"></div>
+            <div th:case="'inactiveUser'" th:text="#{password.inactiveUser}"></div>
+            <div th:case="'invalidToken'" th:text="#{password.invalidToken}"></div>
+            <div th:case="'tokenExpired'" th:text="#{password.tokenExpired}"></div>
+            <div th:case="'tokenUsed'" th:text="#{password.tokenUsed}"></div>
+            <div th:case="'invalidPassword'" th:text="#{password.invalidPassword}"></div>
+            <div th:case="'passwordMismatch'" th:text="#{password.passwordMismatch}"></div>
+            <div th:case="*" th:inline="text">[[#{password.unknown}]] <span th:text="${errorCode}"></span></div>
         </div>
-        
-        <div class="alert alert-success" th:unless="${#strings.isEmpty(param.messageCode) and ! #strings.isEmpty(errorCode)}">            
-            <div th:if="${param.messageCode[0] == 'passwordTokenSent'}" th:text="#{password.passwordTokenSent}" ></div>
-        </div>        
+
+        <!-- Show success alert unless (there's no message to show OR there was an error) -->
+        <div class="alert alert-success"
+             th:unless="${#strings.isEmpty(param.messageCode) or !#strings.isEmpty(errorCode)}">
+            <div th:if="${param.messageCode[0] == 'passwordTokenSent'}" th:text="#{password.passwordTokenSent}"></div>
+        </div>
     </div>
 
     <blc:form th:fragment="form" action="#" th:action="@{/resetPassword}" method="post" class="form-horizontal" th:object="${resetPasswordForm}">
 
         <div class="field-group">
-            <label th:text="#{password.username}" ></label>
+            <label th:text="#{password.username}" for="username"></label>
             <input type="text" id="username" name="username" autofocus="autofocus" class="twelve" th:field="*{username}"/>
         </div>
 
         <div class="field-group">
-            <label th:text="#{password.token}" ></label>
-            <input type="text" id="token" name="token" class="twelve" th:field="*{token}" />
+            <label th:text="#{password.token}" for="token"></label>
+            <input type="text" id="token" name="token" class="twelve" th:field="*{token}"/>
         </div>
 
         <div class="field-group">
-            <label th:text="#{password.newPassword}" ></label>
-            <input type="password" id="password" name="password" class="twelve" th:field="*{password}" />
+            <label th:text="#{password.newPassword}" for="password"></label>
+            <input type="password" id="password" name="password" class="twelve" th:field="*{password}"/>
         </div>
 
         <div class="field-group">
-            <label th:text="#{password.confirmNewPassword}" ></label>
-            <input type="password" id="confirmPassword" name="confirmPassword" class="twelve" th:field="*{confirmPassword}" />
+            <label th:text="#{password.confirmNewPassword}" for="confirmPassword"></label>
+            <input type="password" id="confirmPassword" name="confirmPassword" class="twelve" th:field="*{confirmPassword}"/>
         </div>
 
         <div class="account-actions">
             <ul class="inline-list">
-                <li><a href="#" th:href="@{/login}" th:text="#{password.login}" ></a>
-</li>
-                <li><a href="#" th:href="@{/forgotUsername}" th:text="#{password.forgotUsername}" ></a>
-</li>
-                <li><a href="#" th:href="@{/forgotPassword}" th:text="#{password.forgotPassword}" ></a>
-</li>
+                <li><a href="#" th:href="@{/login}" th:text="#{password.login}"></a></li>
+                <li><a href="#" th:href="@{/forgotUsername}" th:text="#{password.forgotUsername}"></a></li>
+                <li><a href="#" th:href="@{/forgotPassword}" th:text="#{password.forgotPassword}"></a></li>
             </ul>
             <input type="submit" class="button primary large" value="Reset Password"/>
         </div>
     </blc:form>
-      
-    
+
+
     <div th:fragment="options">
         <ul class="inline-list">
-            <li><a href="#" th:href="@{/login}" th:text="#{password.login}" ></a>
-</li>
-            <li><a href="#" th:href="@{/forgotUsername}" th:text="#{password.forgotUsername}" ></a>
-</li>
-            <li><a href="#" th:href="@{/forgotPassword}" th:text="#{password.forgotPassword}" ></a>
-</li>
+            <li><a href="#" th:href="@{/login}" th:text="#{password.login}"></a></li>
+            <li><a href="#" th:href="@{/forgotUsername}" th:text="#{password.forgotUsername}"></a></li>
+            <li><a href="#" th:href="@{/forgotPassword}" th:text="#{password.forgotPassword}"></a></li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
The reset password link has no "messageCode" parameter which was previously causing an error when opening the link. This corrects the logic for when the messageCode should be used to display the "email sent" message.