### PR TITLE
Make Solr search method configurable via a property

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -646,12 +646,12 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
      * Allows the user to choose the query method to use.  POST allows for longer, more complex queries with 
      * a higher number of facets.
      * 
-     * Default value is POST.  Implementors can override this to use GET if they wish.
+     * Default value is POST.  Implementors can change the value by setting the solr.search.method property
      * 
      * @return
      */
     protected METHOD getSolrQueryMethod() {
-        return METHOD.POST;
+        return environment.getProperty("solr.search.method", METHOD.class, METHOD.POST);
     }
 
     @Override


### PR DESCRIPTION
Currently the method defaults to `METHOD.POST` and only can be changed if the implementor overrides the method. Since this is simply an enum it is trivial to make this configurable by a property thus making it easier to change.

_Note: The default of METHOD.POST is the preferred method since it supports larger search queries therefore this property generally shouldn't be changed_