### PR TITLE
BroadleafCommerce/QA#3494 - Now double quotes in the default ESAPI HT…

### DIFF
--- a/common/src/main/resources/esapi/ESAPI.properties
+++ b/common/src/main/resources/esapi/ESAPI.properties
@@ -457,7 +457,7 @@ Validator.HTTPParameterValue=^[a-zA-Z0-9.\\-\\/+=@_ ]*$
 Validator.HTTPCookieName=^[a-zA-Z0-9\\-_]{1,32}$
 Validator.HTTPCookieValue=^[a-zA-Z0-9\\-\\/+=_ ]*$
 Validator.HTTPHeaderName=^[a-zA-Z0-9\\-_]{1,32}$
-Validator.HTTPHeaderValue=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
+Validator.HTTPHeaderValue=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ \"]*$
 Validator.HTTPContextPath=^\\/?[a-zA-Z0-9.\\-\\/_]*$
 Validator.HTTPServletPath=^[a-zA-Z0-9.\\-\\/_]*$
 Validator.HTTPPath=^[a-zA-Z0-9.\\-_]*$


### PR DESCRIPTION
…TP Header Value are allowed

https://github.com/BroadleafCommerce/QA/issues/3494