### PR TITLE
Fixed JS error when the admin error page shows

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -26,8 +26,11 @@
     BLCAdmin.entityForm = {
 
         initializeStickyHeader : function () {
-            originalStickyBarOffset = $('.sticky-container').offset().top;
-            originalStickyBarHeight = $('.sticky-container').height();
+            var $stickyContainer = $('.sticky-container');
+            if ($stickyContainer.length) {
+                originalStickyBarOffset = $stickyContainer.offset().top;
+                originalStickyBarHeight = $stickyContainer.height();
+            }
 
             if ($('form.entity-form').length && !$('.oms').length) {
                 var $sc = $('.sticky-container');


### PR DESCRIPTION
When you try to access a page that doesn't exist or an entity is not found by its ID, there is a JS error on the page which prevents you from clicking any links