### PR TITLE
Remove the currency prefix from the value based on the current currency

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.admin.server.service.handler;
 
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Date;
@@ -205,6 +206,10 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
             customCriteria = persistencePackage.getCustomCriteria()[0];
         }
 
+        Locale locale =  BroadleafRequestContext.getBroadleafRequestContext().getLocale();
+        BroadleafCurrency currency =  BroadleafRequestContext.getBroadleafRequestContext().getBroadleafCurrency();
+        NumberFormat nf = BroadleafCurrencyUtils.getNumberFormatFromCache(locale.getJavaLocale(), currency.getJavaCurrency());
+
         for (Entity entity : resultSet.getRecords()) {
             Property discountType = entity.findProperty("discountType");
             Property discountValue = entity.findProperty("value");
@@ -216,9 +221,6 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
                 value = !value.contains(".") ? value : value.replaceAll("0*$", "").replaceAll("\\.$", "");
                 discountValue.setValue(value + "%");
             } else if (discountType.getValue().equals("AMOUNT_OFF")) {
-                Locale locale =  BroadleafRequestContext.getBroadleafRequestContext().getLocale();
-                BroadleafCurrency currency =  BroadleafRequestContext.getBroadleafRequestContext().getBroadleafCurrency();
-                NumberFormat nf = BroadleafCurrencyUtils.getNumberFormatFromCache(locale.getJavaLocale(), currency.getJavaCurrency());
                 discountValue.setValue(nf.format(new BigDecimal(value)));
             }
 
@@ -233,8 +235,9 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
             entity.addProperty(buildStackableProperty(offerItemTargetRuleType));
 
             if (!"listGridView".equals(customCriteria)) {
+                String moneyPrefix = ((DecimalFormat) nf).getPositivePrefix();
                 String setValue = discountValue.getValue();
-                setValue = setValue.replaceAll("\\%", "").replaceAll("\\$", "");
+                setValue = setValue.replaceAll("\\%", "").replaceAll(moneyPrefix, "");
                 discountValue.setValue(setValue);
             }
 


### PR DESCRIPTION
If the default currency is not USD, the currency symbol is not replaced causing validation errors when trying to save a non-numeric value in the field.