### PR TITLE
Remove collection alias' from SolrQuery in favor of executing commands on a collection

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Indexable.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Indexable.java
@@ -48,7 +48,7 @@ public interface Indexable {
      * Which type of {@link Field} should be queried for when looking up database-driven search fields to store in the
      * search index
      * 
-     * @see SolrIndexService#buildIncrementalIndex(java.util.List, org.apache.solr.client.solrj.SolrClient)
+     * @see SolrIndexService#buildIncrementalIndex(String, java.util.List, org.apache.solr.client.solrj.SolrClient)
      * @see FieldDao#readFieldsByEntityType(FieldEntity)
      */
     public FieldEntity getFieldEntityType();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/BroadleafCloudSolrClient.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/BroadleafCloudSolrClient.java
@@ -20,8 +20,6 @@ package org.broadleafcommerce.core.search.service.solr;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.LBHttpSolrClient;
-import org.broadleafcommerce.common.site.domain.Site;
-import org.broadleafcommerce.common.web.BroadleafRequestContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +28,11 @@ import java.util.Optional;
 
 /**
  * @author Nick Crum (ncrum)
+ *
+ * @deprecated Functionality for determining the default collection has been moved to {@link SolrConfiguration} 
+ * therefore there's no need to use the BroadleafCloudSolrClient. Simply use {@link CloudSolrClient}
  */
+@Deprecated
 public class BroadleafCloudSolrClient extends CloudSolrClient {
 
     protected SolrConfiguration solrConfig;
@@ -90,16 +92,6 @@ public class BroadleafCloudSolrClient extends CloudSolrClient {
             builder.sendUpdatesToAllReplicasInShard();
         }
         return builder;
-    }
-
-    @Override
-    public String getDefaultCollection() {
-        if (solrConfig != null && solrConfig.isSiteCollections()) {
-            Site site = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
-            return (reindexClient) ? solrConfig.getSiteReindexAliasName(site) : solrConfig.getSiteAliasName(site);
-        }
-
-        return super.getDefaultCollection();
     }
 
     public boolean isReindexClient() {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
@@ -714,21 +714,25 @@ public class SolrConfiguration implements InitializingBean {
     }
 
     public String getQueryCollectionName() {
-        if (isSiteCollections()) {
+        if (isSiteCollections() && isSolrCloudMode()) {
             Site site = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
             return getSiteAliasName(site);
+        } else if (isSolrCloudMode()) {
+            return primaryName;
         }
-
-        return primaryName;
+        // If it's not SolrCloud mode then we just want to operate on the primary core for that server and we do that by not specifying a collection
+        return null;
     }
 
     public String getReindexCollectionName() {
-        if (isSiteCollections()) {
+        if (isSiteCollections() && isSolrCloudMode()) {
             Site site = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
             return getSiteReindexAliasName(site);
+        } else if (isSolrCloudMode()) {
+            return reindexName;
         }
-
-        return reindexName;
+        // If it's not SolrCloud mode then we just want to operate on the primary core for that server and we do that by not specifying a collection
+        return null;
     }
 
     protected String determineCoreName(HttpSolrClient httpSolrClient) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrConfiguration.java
@@ -172,10 +172,6 @@ public class SolrConfiguration implements InitializingBean {
                 }
             }
             
-            if (BroadleafCloudSolrClient.class.isAssignableFrom(server.getClass())) {
-                ((BroadleafCloudSolrClient) server).setReindexClient(false);
-                ((BroadleafCloudSolrClient) server).setSolrConfig(this);
-            }
         }
 
         primaryServer = server;
@@ -214,10 +210,6 @@ public class SolrConfiguration implements InitializingBean {
                                 + cs.getDefaultCollection());
                     }
                 }
-            }
-            if (BroadleafCloudSolrClient.class.isAssignableFrom(server.getClass())) {
-                ((BroadleafCloudSolrClient) server).setReindexClient(true);
-                ((BroadleafCloudSolrClient) server).setSolrConfig(this);
             }
         }
         reindexServer = server;
@@ -719,6 +711,24 @@ public class SolrConfiguration implements InitializingBean {
 
     public void setSolrCloudNumShards(int solrCloudNumShards) {
         this.solrCloudNumShards = solrCloudNumShards;
+    }
+
+    public String getQueryCollectionName() {
+        if (isSiteCollections()) {
+            Site site = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
+            return getSiteAliasName(site);
+        }
+
+        return primaryName;
+    }
+
+    public String getReindexCollectionName() {
+        if (isSiteCollections()) {
+            Site site = BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite();
+            return getSiteReindexAliasName(site);
+        }
+
+        return reindexName;
     }
 
     protected String determineCoreName(HttpSolrClient httpSolrClient) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperService.java
@@ -293,12 +293,27 @@ public interface SolrHelperService {
     public Object getPropertyValue(Object object, String propertyName) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException;
 
     /**
-     * Tells Solr to optimize the index.  This is an expensive operation and should be use rarely or never.
+     * Tells Solr to optimize the index.  This is an expensive operation and should be used rarely or never.
      * 
-     * @param server
+     * @param collection The collection to operate on
+     * @param server The server to use to do the operation
+     * 
      * @throws ServiceException
      * @throws IOException
      */
+    public void optimizeIndex(String collection, SolrClient server) throws ServiceException, IOException;
+
+    /**
+     * Tells Solr to optimize the index. This is an expensive operation and should be used rarely or never.
+     * 
+     * @param server The server to use to do the operation
+     * 
+     * @throws ServiceException
+     * @throws IOException
+     * 
+     * @deprecated Use {@link #optimizeIndex(String, SolrClient)} instead so that the collection that's being used can be customized otherwise the default collection will always be used. Generally use {@link SolrConfiguration#getQueryCollectionName()} or {@link SolrConfiguration#getReindexCollectionName()}
+     */
+    @Deprecated
     public void optimizeIndex(SolrClient server) throws ServiceException, IOException;
 
     /**

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -196,13 +196,6 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
                 .setStart((start) * searchCriteria.getPageSize())
                 .setRequestHandler(searchCriteria.getRequestHandler());
 
-        //This is for SolrCloud.  We assume that we are always searching against a collection aliased as "PRIMARY"
-        if (solrConfiguration.isSiteCollections()) {
-            solrQuery.setParam("collection", solrConfiguration.getSiteAliasName(BroadleafRequestContext.getBroadleafRequestContext().getNonPersistentSite()));
-        } else {
-            solrQuery.setParam("collection", solrConfiguration.getPrimaryName()); //This should be ignored if not using SolrCloud
-        }
-
         solrQuery.setFields(shs.getIndexableIdFieldName());
         if (filterQueries != null) {
             solrQuery.setFilterQueries(filterQueries);
@@ -249,7 +242,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         List<SolrDocument> responseDocuments;
         int numResults = 0;
         try {
-            response = solrConfiguration.getServer().query(solrQuery, getSolrQueryMethod());
+            response = solrConfiguration.getServer().query(solrConfiguration.getQueryCollectionName(), solrQuery, getSolrQueryMethod());
             responseDocuments = getResponseDocuments(response);
             numResults = (int) response.getResults().getNumFound();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/GlobalSolrFullReIndexOperation.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/GlobalSolrFullReIndexOperation.java
@@ -85,6 +85,11 @@ public abstract class GlobalSolrFullReIndexOperation implements SolrIndexOperati
     }
 
     @Override
+    public String getSolrCollectionForIndexing() {
+        return solrConfiguration.getReindexCollectionName();
+    }
+
+    @Override
     public void beforeCountIndexables() {
         // By default we want to do nothing here
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexOperation.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexOperation.java
@@ -23,6 +23,7 @@ package org.broadleafcommerce.core.search.service.solr.index;
 import org.apache.solr.client.solrj.SolrClient;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.core.catalog.domain.Indexable;
+
 import java.util.List;
 
 
@@ -43,6 +44,11 @@ public interface SolrIndexOperation {
      * Which {@link SolrClient} the index should be built on
      */
     public SolrClient getSolrServerForIndexing();
+
+    /**
+     * Which collection the index should be built on
+     */
+    public String getSolrCollectionForIndexing();
 
     /**
      * Executes before the count, this is where any filters or setup for counting can be taken care of
@@ -85,7 +91,7 @@ public interface SolrIndexOperation {
 
     /**
      * Build a page from {@link #readIndexables(int, Long)} on the {@link #getSolrServerForIndexing()}. This is used as a
-     * wrapper extension around {@link SolrIndexService#buildIncrementalIndex(List, SolrClient)}.
+     * wrapper extension around {@link SolrIndexService#buildIncrementalIndex(String, List, SolrClient)}.
      */
     public void buildPage(List<? extends Indexable> indexables) throws ServiceException;
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -317,7 +317,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
             String deleteQuery = StringUtil.sanitize(shs.getNamespaceFieldName()) + ":(\"" 
                     + StringUtil.sanitize(solrConfiguration.getNamespace()) + "\")";
             LOG.debug("Deleting by query: " + deleteQuery);
-            server.deleteByQuery(deleteQuery);
+            server.deleteByQuery(collection, deleteQuery);
 
             //Explicitly do a hard commit here since we just deleted the entire index
             server.commit(collection);
@@ -334,7 +334,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
         try {
             String deleteQuery = "*:*";
             LOG.debug("Deleting by query: " + deleteQuery);
-            server.deleteByQuery(deleteQuery);
+            server.deleteByQuery(collection, deleteQuery);
             server.commit(collection);
         } catch (Exception e) {
             throw new ServiceException("Could not delete documents", e);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -173,7 +173,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
     @Override
     public void preBuildIndex() throws ServiceException {
-        deleteAllNamespaceDocuments(solrConfiguration.getReindexServer());
+        deleteAllNamespaceDocuments(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
     }
 
     @Override
@@ -184,7 +184,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     @Override
     public void postBuildIndex() throws IOException, ServiceException {
         // this is required to be at the very very very end after rebuilding the whole index
-        optimizeIndex(solrConfiguration.getReindexServer());
+        optimizeIndex(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
         // Swap the active and the reindex cores
         if (!solrConfiguration.isSingleCoreMode()) {
             shs.swapActiveCores(solrConfiguration);
@@ -207,7 +207,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
             @Override
             public void buildPage(List<? extends Indexable> indexables) throws ServiceException {
-                buildIncrementalIndex(indexables, getSolrServerForIndexing());
+                buildIncrementalIndex(getSolrCollectionForIndexing(), indexables, getSolrServerForIndexing());
             }
         };
     }
@@ -308,11 +308,11 @@ public class SolrIndexServiceImpl implements SolrIndexService {
      * @throws ServiceException if there was a problem removing the documents
      */
     protected void deleteAllReindexCoreDocuments() throws ServiceException {
-        deleteAllNamespaceDocuments(solrConfiguration.getReindexServer());
+        deleteAllNamespaceDocuments(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
     }
 
     @Override
-    public void deleteAllNamespaceDocuments(SolrClient server) throws ServiceException {
+    public void deleteAllNamespaceDocuments(String collection, SolrClient server) throws ServiceException {
         try {
             String deleteQuery = StringUtil.sanitize(shs.getNamespaceFieldName()) + ":(\"" 
                     + StringUtil.sanitize(solrConfiguration.getNamespace()) + "\")";
@@ -320,7 +320,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
             server.deleteByQuery(deleteQuery);
 
             //Explicitly do a hard commit here since we just deleted the entire index
-            server.commit();
+            server.commit(collection);
         } catch (Exception e) {
             if (ServiceException.class.isAssignableFrom(e.getClass())) {
                 throw (ServiceException) e;
@@ -330,12 +330,12 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     }
     
     @Override
-    public void deleteAllDocuments(SolrClient server) throws ServiceException {
+    public void deleteAllDocuments(String collection, SolrClient server) throws ServiceException {
         try {
             String deleteQuery = "*:*";
             LOG.debug("Deleting by query: " + deleteQuery);
             server.deleteByQuery(deleteQuery);
-            server.commit();
+            server.commit(collection);
         } catch (Exception e) {
             throw new ServiceException("Could not delete documents", e);
         }
@@ -379,7 +379,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     }
 
     @Override
-    public Collection<SolrInputDocument> buildIncrementalIndex(List<? extends Indexable> indexables, SolrClient solrServer) throws ServiceException {
+    public Collection<SolrInputDocument> buildIncrementalIndex(String collection, List<? extends Indexable> indexables, SolrClient solrServer) throws ServiceException {
         TransactionStatus status = TransactionUtils.createTransaction("executeIncrementalIndex",
                 TransactionDefinition.PROPAGATION_REQUIRED, transactionManager, true);
         if (SolrIndexCachedOperation.getCache() == null) {
@@ -428,8 +428,8 @@ public class SolrIndexServiceImpl implements SolrIndexService {
             logDocuments(documents);
 
             if (!CollectionUtils.isEmpty(documents) && solrServer != null) {
-                solrServer.add(documents);
-                commit(solrServer);
+                solrServer.add(collection, documents);
+                commit(collection, solrServer);
             }
             TransactionUtils.finalizeTransaction(status, transactionManager, false);
 
@@ -721,21 +721,21 @@ public class SolrIndexServiceImpl implements SolrIndexService {
      }
      
     @Override
-    public void optimizeIndex(SolrClient server) throws ServiceException, IOException {
-        shs.optimizeIndex(server);
+    public void optimizeIndex(String collection, SolrClient server) throws ServiceException, IOException {
+        shs.optimizeIndex(collection, server);
     }
 
     @Override
-    public void commit(SolrClient server) throws ServiceException, IOException {
+    public void commit(String collection, SolrClient server) throws ServiceException, IOException {
         if (this.commit) {
-            commit(server, this.softCommit, this.waitSearcher, this.waitFlush);
+            commit(collection, server, this.softCommit, this.waitSearcher, this.waitFlush);
         } else if (LOG.isDebugEnabled()) {
             LOG.debug("The flag / property \"solr.index.commit\" is false. Not committing! Ensure autoCommit is configured.");
         }
     }
 
     @Override
-    public void commit(SolrClient server, boolean softCommit, boolean waitSearcher, boolean waitFlush) throws ServiceException, IOException {
+    public void commit(String collection, SolrClient server, boolean softCommit, boolean waitSearcher, boolean waitFlush) throws ServiceException, IOException {
         try {
             if (!this.commit) {
                 LOG.warn("The flag / property \"solr.index.commit\" is set to false but a commit is being forced via the API.");
@@ -746,7 +746,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
                         + ", waitSearcher: " + waitSearcher + ", waitFlush: " + waitFlush);
             }
 
-            server.commit(waitFlush, waitSearcher, softCommit);
+            server.commit(collection, waitFlush, waitSearcher, softCommit);
         } catch (SolrServerException e) {
             throw new ServiceException("Could not commit changes to Solr index", e);
         }
@@ -787,8 +787,8 @@ public class SolrIndexServiceImpl implements SolrIndexService {
         deleteQuery = productFilter + " AND (" + deleteQuery + ")";
 
         String childDeleteQuery = "{!child of=" + productFilter + "} " + deleteQuery;
-        solrConfiguration.getServer().deleteByQuery(childDeleteQuery);
-        solrConfiguration.getServer().deleteByQuery(deleteQuery);
+        solrConfiguration.getServer().deleteByQuery(solrConfiguration.getQueryCollectionName(), childDeleteQuery);
+        solrConfiguration.getServer().deleteByQuery(solrConfiguration.getQueryCollectionName(), deleteQuery);
 
         logDeleteQuery(childDeleteQuery);
         logDeleteQuery(deleteQuery);
@@ -796,7 +796,7 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
     @Override
     public void addDocuments(Collection<SolrInputDocument> documents) throws IOException, SolrServerException {
-        solrConfiguration.getServer().add(documents);
+        solrConfiguration.getServer().add(solrConfiguration.getQueryCollectionName(), documents);
         logDocuments(documents);
     }
 
@@ -805,6 +805,36 @@ public class SolrIndexServiceImpl implements SolrIndexService {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Delete query: " + deleteQuery);
         }
+    }
+
+    @Override
+    public Collection<SolrInputDocument> buildIncrementalIndex(List<? extends Indexable> indexables, SolrClient solrServer) throws ServiceException {
+        return buildIncrementalIndex(null, indexables, solrServer);
+    }
+
+    @Override
+    public void optimizeIndex(SolrClient server) throws ServiceException, IOException {
+        optimizeIndex(null, server);
+    }
+
+    @Override
+    public void commit(SolrClient server) throws ServiceException, IOException {
+        commit(null, server);
+    }
+
+    @Override
+    public void commit(SolrClient server, boolean softCommit, boolean waitSearcher, boolean waitFlush) throws ServiceException, IOException {
+        commit(null, server, softCommit, waitSearcher, waitFlush);
+    }
+
+    @Override
+    public void deleteAllNamespaceDocuments(SolrClient server) throws ServiceException {
+        deleteAllNamespaceDocuments(null, server);
+    }
+
+    @Override
+    public void deleteAllDocuments(SolrClient server) throws ServiceException {
+        deleteAllDocuments(null, server);
     }
 
 }


### PR DESCRIPTION
After upgrading Solr to version 7 in BLC 6 we found that search requests were failing if you were using POST. It was found that this was being caused because we were sending the collection alias that we wanted to operate on via a SolrQuery parameter which is no longer allowed. The proper way to specify the collection you want to operate on is in the actual call through SolrJ (i.e. `server.query(collection, query)` instead of `server.query(query)`). If the collection is not specified Solr will simply use the default collection name set on the SolrServer that you're operating on. These code changes not only update all of our SolrJ API calls to specify a collection but also method signatures were modified to allow sending a collection name and `SolrConfiguration` was updated to have methods to call to retrieve the collection we want to work on when we're doing a query/full index/incremental index. Because this logic was created in `SolrConfiguration` it left `BroadleafCloudSolrClient` unneeded since the only reason it existed was to override the `getDefaultCollection` in `CloudSolrClient`. We couldn't simply leave all of our code the same because even though it would make sense that Solr would call `getDefaultCollection` in order to find the default collection if it was not specified it in fact does not and instead refers to the property directly. Since this left our override pointless it made sense to simply move that logic into `SolrConfiguration` so that implementors were no longer forced to use our custom `SolrClient` if they were in a Solr Cloud environment. Additionally all public interface methods that needed the "collection" parameter added were left and deprecated with implementations that delegate to the method with the "collection" parameter in order to satisfy backwards compatibility. The downside to simply leaving it up to Solr to determine the default collection is in the event you want every site in a MT solution to have its own collection we no longer can override which collection we should be operating on so it will simply always use the default collection.

This PR solves https://github.com/BroadleafCommerce/QA/issues/3493