### PR TITLE
Check to see if the structured content's id is null or an empty string

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/StructuredContentTypeCustomPersistenceHandler.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/StructuredContentTypeCustomPersistenceHandler.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.cms.admin.server.handler;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.cms.field.domain.FieldDefinition;
@@ -187,7 +188,7 @@ public class StructuredContentTypeCustomPersistenceHandler extends CustomPersist
                     property.setIsDirty(true);
                 }
 
-                if (SupportedFieldType.ADDITIONAL_FOREIGN_KEY.equals(def.getFieldType()) && value != null) {
+                if (SupportedFieldType.ADDITIONAL_FOREIGN_KEY.equals(def.getFieldType()) && StringUtils.isNotEmpty(value)) {
                     // we need to look up the display value
                     String display = service.getForeignEntityName(def.getAdditionalForeignKeyClass(), value);
                     property.setDisplayValue(display);


### PR DESCRIPTION
When loading the display value, if there is no foreign key (i.e. a blank lookup) don't throw an error, instead skip the lookup.