### PR TITLE
Handle empty date fields in the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -341,6 +341,10 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                         if (value == null) {
                             value = "false";
                         }
+                    } else if (metadata.getFieldType().equals(SupportedFieldType.DATE)) {
+                        if (StringUtils.isEmpty(value)) {
+                            value = null;
+                        }
                     }
 
                     if (attemptToPopulateValue(property, fieldManager, instance, setId, metadata, entity, value)) {


### PR DESCRIPTION
There is an issue when trying to add an entity with a non-required date field.  If the field is not filled in, the value that gets passed to the persistence module is an empty string `""` which fails the date format validation.

This fix changes any empty string date fields to be null before running the validations effectively skipping the format validation.