### PR TITLE
Disallow customers from logging in if they're archived

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/UserDetailsServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/UserDetailsServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.profile.core.service;
 
+import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.core.domain.CustomerRole;
 import org.springframework.dao.DataAccessException;
@@ -55,9 +56,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         if (customer == null) {
             throw new UsernameNotFoundException("The customer was not found");
         }
-
+        boolean isActive = ((Status) customer).isActive() && !customer.isDeactivated();
         List<GrantedAuthority> grantedAuthorities = createGrantedAuthorities(roleService.findCustomerRolesByCustomerId(customer.getId()));
-        return new CustomerUserDetails(customer.getId(), username, customer.getPassword(), !customer.isDeactivated(), true, !customer.isPasswordChangeRequired(), true, grantedAuthorities);
+        return new CustomerUserDetails(customer.getId(), username, customer.getPassword(), isActive, true, !customer.isPasswordChangeRequired(), true, grantedAuthorities);
     }
 
     protected List<GrantedAuthority> createGrantedAuthorities(List<CustomerRole> customerRoles) {

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/UserDetailsServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/UserDetailsServiceImpl.java
@@ -56,7 +56,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         if (customer == null) {
             throw new UsernameNotFoundException("The customer was not found");
         }
-        boolean isActive = ((Status) customer).isActive() && !customer.isDeactivated();
+        boolean isActive = !customer.isDeactivated();
+        if (Status.class.isAssignableFrom(customer.getClass())) {
+            isActive = isActive && ((Status) customer).isActive();
+        }
         List<GrantedAuthority> grantedAuthorities = createGrantedAuthorities(roleService.findCustomerRolesByCustomerId(customer.getId()));
         return new CustomerUserDetails(customer.getId(), username, customer.getPassword(), isActive, true, !customer.isPasswordChangeRequired(), true, grantedAuthorities);
     }


### PR DESCRIPTION
Since `Customer`s aren't sandboxabled the Hibernate filter to filter out archived `Customer`s isn't weaved on therefore in the `UserDetailsServiceImpl` we allow a `Customer` to log in even if they've been archived.