### PR TITLE
BroadleafEntityValidator enables entity/form validation

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -409,6 +409,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 entityList.add(instance);
                 Entity invalid = getRecords(mergedProperties, entityList, null, null, null)[0];
                 invalid.setPropertyValidationErrors(entity.getPropertyValidationErrors());
+                invalid.setGlobalValidationErrors(entity.getGlobalValidationErrors());
                 invalid.overridePropertyValues(entity);
 
                 String message = ValidationUtil.buildErrorMessage(invalid.getPropertyValidationErrors(), invalid.getGlobalValidationErrors());

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
@@ -1,0 +1,40 @@
+package org.broadleafcommerce.openadmin.server.service.persistence.validation;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import org.broadleafcommerce.openadmin.dto.Entity;
+import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
+
+/**
+ * A Spring bean extending this class will automatically be called when validation is done on the entity specified by
+ * the generic type.
+ * 
+ * The persistent entity class that Hibernate is aware of should be used as the generic type. For example,
+ * SomeEntityImpl instead of SomeEntity interface.
+ * 
+ * In the implementation of valdate {@link Entity#addValidationError(String, String)} and
+ * {@link Entity#addValidationError(String, String)} can be used to create an error that is displayed to the user before
+ * an add or update cocurs. {@link Entity#isValidationFailure()} can be used to see if there core validation found any
+ * issues like required fields being blank to decide if any additional validation should be executed.
+ * 
+ * @param <T>
+ *            Persistence Entity implementation to validate
+ */
+public abstract class BroadleafEntityValidator<T> {
+
+	/**
+	 * Validation that should be done on the specified entity after core validation is completed.
+	 */
+	abstract void validate(Entity submittedEntity, @Nonnull T instance, Map<String, FieldMetadata> propertiesMetadata,
+			RecordHelper recordHelper, boolean validateUnsubmittedProperties);
+
+	@SuppressWarnings("unchecked")
+	void validate(Entity submittedEntity, @Nonnull Serializable instance, Map<String, FieldMetadata> propertiesMetadata,
+			RecordHelper recordHelper, boolean validateUnsubmittedProperties) {
+		validate(submittedEntity, (T) instance, propertiesMetadata, recordHelper, validateUnsubmittedProperties);
+	}
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -31,6 +31,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceExc
 import org.broadleafcommerce.openadmin.server.service.persistence.module.BasicPersistenceModule;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.FieldNotAvailableException;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.stereotype.Service;
@@ -61,9 +62,10 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
     
     @Resource(name = "blGlobalEntityPropertyValidators")
     protected List<GlobalPropertyValidator> globalEntityValidators;
-    
-    protected ApplicationContext applicationContext;
 
+    @Autowired
+    protected ApplicationContext applicationContext;
+    
     @Resource(name = "blRowLevelSecurityService")
     protected RowLevelSecurityService securityService;
     

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -18,6 +18,8 @@
 package org.broadleafcommerce.openadmin.server.service.persistence.validation;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.presentation.ValidationConfiguration;
 import org.broadleafcommerce.common.presentation.client.OperationType;
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
@@ -29,18 +31,19 @@ import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceExc
 import org.broadleafcommerce.openadmin.server.service.persistence.module.BasicPersistenceModule;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.FieldNotAvailableException;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.GenericTypeResolver;
 import org.springframework.stereotype.Service;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
 import javax.annotation.Resource;
 
 
@@ -53,7 +56,8 @@ import javax.annotation.Resource;
  * @see {@link ValidationConfiguration}
  */
 @Service("blEntityValidatorService")
-public class EntityValidatorServiceImpl implements EntityValidatorService, ApplicationContextAware {
+public class EntityValidatorServiceImpl implements EntityValidatorService {
+	protected static final Log LOG = LogFactory.getLog(EntityValidatorServiceImpl.class);
     
     @Resource(name = "blGlobalEntityPropertyValidators")
     protected List<GlobalPropertyValidator> globalEntityValidators;
@@ -62,6 +66,37 @@ public class EntityValidatorServiceImpl implements EntityValidatorService, Appli
 
     @Resource(name = "blRowLevelSecurityService")
     protected RowLevelSecurityService securityService;
+    
+    private Map<String, List<BroadleafEntityValidator<?>>> formFoxValidatorMap;
+
+	@PostConstruct
+	public void populateFormFoxValidatorMap() {
+		String[] beanNames = applicationContext.getBeanNamesForType(BroadleafEntityValidator.class);
+		formFoxValidatorMap = new HashMap<>(beanNames.length);
+
+		for (String beanName : beanNames) {
+			BroadleafEntityValidator<?> formFoxValidator = applicationContext.getBean(beanName,
+					BroadleafEntityValidator.class);
+			Class<?> entityType = GenericTypeResolver.resolveTypeArgument(formFoxValidator.getClass(),
+					BroadleafEntityValidator.class);
+			if (entityType != null) {
+				String entityClassName = entityType.getName();
+				LOG.info(String.format("Registering validator %s for entity type %s",
+						formFoxValidator.getClass().getName(), entityClassName));
+
+				List<BroadleafEntityValidator<?>> registeredValidatorsForType = formFoxValidatorMap
+						.get(entityClassName);
+				if (registeredValidatorsForType == null) {
+					registeredValidatorsForType = new ArrayList<>();
+					formFoxValidatorMap.put(entityClassName, registeredValidatorsForType);
+				}
+				registeredValidatorsForType.add(formFoxValidator);
+			} else {
+				LOG.warn("Could not determine entity type for " + formFoxValidator.getClass().getName());
+			}
+		}
+	}
+    
     
     @Override
     public void validate(Entity submittedEntity, @Nullable Serializable instance, Map<String, FieldMetadata> propertiesMetadata,
@@ -192,6 +227,17 @@ public class EntityValidatorServiceImpl implements EntityValidatorService, Appli
                 }
             }
         }
+        if (instance != null) {
+			List<BroadleafEntityValidator<?>> formFoxValidators = formFoxValidatorMap
+					.get(instance.getClass().getName());
+			if (formFoxValidators != null) {
+				for (BroadleafEntityValidator<?> formFoxValidator : formFoxValidators) {
+					LOG.debug("Calling validator " + formFoxValidator.getClass().getName());
+					formFoxValidator.validate(submittedEntity, instance, propertiesMetadata, recordHelper,
+							validateUnsubmittedProperties);
+				}
+			}
+		}
     }
 
     /**
@@ -236,11 +282,4 @@ public class EntityValidatorServiceImpl implements EntityValidatorService, Appli
     public void setGlobalEntityValidators(List<GlobalPropertyValidator> globalEntityValidators) {
         this.globalEntityValidators = globalEntityValidators;
     }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
-    }
-
-
 }


### PR DESCRIPTION
- If you extend BroadleafEntityValidator and specify the Hibernate entity as the generic, you can add custom validation having access to the full entity values prior to insert or update.
- When validation fails, copy over any GlobalValdiationErrors.  This allows BroadleafEntityValidator to create global errors, not just field errors.

As an example you could add product validation like this

    @Component
    public class AdminUserEntityValidator extends BroadleafEntityValidator<AdminUserImpl> {
  
      @Override
      void validate(Entity submittedEntity, AdminUserImpl adminUser, Map<String, FieldMetadata> propertiesMetadata, RecordHelper recordHelper, boolean validateUnsubmittedProperties) {
      
        //Skip validation if basic validation fields (e.g. required fields)
        if(!submittedEntity.isValidationFailure()) {
          if(adminUser.getLogin().equals("admin")) { 
            submittedEntity.addValidationError("login", "User name must not be 'admin'");
          }
        
          boolean similarUserExists = //Query the database with an injected DAO
          if(similarUserExists) {
            submittedEntity.addGlobalValidationError("A user already exists with...);
          }
        }
      }
    }

