### PR TITLE
Removing the property "bl_merge_cart_response""

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
@@ -208,8 +208,6 @@ public class CartStateRequestProcessor extends AbstractBroadleafWebRequestProces
                     WebRequest.SCOPE_GLOBAL_SESSION);
             request.removeAttribute(CustomerStateRequestProcessor.getAnonymousCustomerIdSessionAttributeName(),
                     WebRequest.SCOPE_GLOBAL_SESSION);
-
-            request.setAttribute(mergeCartResponseKey, mergeCartResponse, WebRequest.SCOPE_GLOBAL_SESSION);
         }
         return mergeCartResponse.getOrder();
     }


### PR DESCRIPTION
1. Setting property "bl_merge_cart_response" course deserialization error in multi node environment
2. There are not cases of getting this property in the Framework
3. So, solution is - to remove it

https://secure.helpscout.net/conversation/724388074/31927/