### PR TITLE
Set the Sku's Product as the Product on the OrderItem if Product not provided

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
@@ -489,6 +489,8 @@ public class OrderItemServiceImpl implements OrderItemService {
         Product product = null;
         if (orderItemRequestDTO.getProductId() != null) {
             product = catalogService.findProductById(orderItemRequestDTO.getProductId());
+        } else if (sku != null) {
+            product = sku.getProduct();
         }
 
         Category category = null;


### PR DESCRIPTION
This change is made to support only setting the Sku on the OrderItemRequest in order to circumvent unnecessary ProductOption validation. Currently if only the Sku is set on the OrderItemRequest we don't set it on the OrderItem which causes errors further down the line that assume that if the OrderItem is a DiscreteOrderItem that the Product is set on the entity. This change shouldn't have any side affects since without it adding only a Sku to the OrderItem causes errors.

Related to https://github.com/BroadleafCommerce/QA/issues/3542