### PR TITLE
Was not able to add new translations for CustomField FriendlyName field

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -170,7 +170,7 @@ public class AdminTranslationController extends AdminAbstractController {
 
         String ceilingEntity = form.getCeilingEntity();
 
-        TranslatedEntity translatedEntity = TranslatedEntity.getInstance(ceilingEntity);
+        TranslatedEntity translatedEntity = translationService.getAssignableEntityType(ceilingEntity);
         if (translatedEntity == null && ceilingEntity.endsWith("Impl")) {
             int pos = ceilingEntity.lastIndexOf("Impl");
             ceilingEntity = ceilingEntity.substring(0, pos);

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationService.java
@@ -106,6 +106,15 @@ public interface TranslationService {
      * @return the translated value of the property for the given entity
      */
     public String getTranslatedValue(Object entity, String property, Locale locale);
+
+    /**
+     * Gets the TranslatedEntity based on the passed className.  The TranslatedEntity may be an assignable.
+     * 
+     * @param className
+     * @return
+     */
+    public TranslatedEntity getAssignableEntityType(String className);
+
     
     /**
      * Remove a translation instance from the translation specific cache (different than level-2 hibernate cache)

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -104,7 +104,7 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
     @Transactional("blTransactionManager")
     public Translation save(String entityType, String entityId, String fieldName, String localeCode, 
             String translatedValue) {
-        TranslatedEntity te = getEntityType(entityType);
+        TranslatedEntity te = getAssignableEntityType(entityType);
         
         Translation translation = getTranslation(te, entityId, fieldName, localeCode);
         
@@ -155,7 +155,7 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
     
     @Override
     public List<Translation> getTranslations(String ceilingEntityClassname, String entityId, String property) {
-        TranslatedEntity entityType = getEntityType(ceilingEntityClassname);
+        TranslatedEntity entityType = getAssignableEntityType(ceilingEntityClassname);
         return dao.readTranslations(entityType, entityId, property);
     }
 
@@ -381,7 +381,7 @@ public class TranslationServiceImpl implements TranslationService, TranslationSu
         return getEntityType(entity.getClass());
     }
     
-    protected TranslatedEntity getEntityType(String className) {
+    public TranslatedEntity getAssignableEntityType(String className) {
         try {
             Class<?> clazz = Class.forName(className);
             return getEntityType(clazz);


### PR DESCRIPTION
When adding a CustomField translation the assignable (parent) class (Field) was not being used as the TranslatedEntity class.  Added ability to find assignable translated entity class to the TranslationService.  Using that new method from the AminTranslationController.  Addresses https://github.com/BroadleafCommerce/QA/issues/3547