### PR TITLE
BroadleafCommerce/QA#3539 - Fix to OrderItemPriceDetail not syncd from OrderItem when OrderItem.isDiscountingAllowed is false

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
@@ -340,7 +340,7 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
     @Override
     public Map<OrderItem, PromotableOrderItem> buildPromotableItemMap(PromotableOrder promotableOrder) {
         Map<OrderItem, PromotableOrderItem> promotableItemMap = new HashMap<OrderItem, PromotableOrderItem>();
-        for (PromotableOrderItem item : promotableOrder.getDiscountableOrderItems()) {
+        for (PromotableOrderItem item : promotableOrder.getAllOrderItems()) {
             promotableItemMap.put(item.getOrderItem(), item);
         }
         return promotableItemMap;


### PR DESCRIPTION
QA [#3539](https://github.com/BroadleafCommerce/QA/issues/3539)
