### PR TITLE
Prevent incorrect validation warning from programmatic sorts

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -769,7 +769,9 @@ public class SolrHelperServiceImpl implements SolrHelperService {
                     }
 
                 }
-                if (!foundNotTokenizedField) {
+
+                // In the case of programmatically generated sorts, there will be no fieldtypes.
+                if (!foundNotTokenizedField && fieldTypes.size() > 0) {
                     LOG.warn(String.format("Sorting on a tokenized field, this could have adverse effects on the ordering of results. " +
                                     "Add a field type for this field from the following list to ensure proper result ordering: [%s]",
                             StringUtils.join(sortableFieldTypes, ", ")));


### PR DESCRIPTION
Programmatic sorts do not have any field types, so an incorrect warning is logged.