### PR TITLE
Added a readOfferCodesByIds method to reduce multiple trips to the database

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferCodeDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferCodeDao.java
@@ -19,11 +19,14 @@ package org.broadleafcommerce.core.offer.dao;
 
 import org.broadleafcommerce.core.offer.domain.OfferCode;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface OfferCodeDao {
 
     public OfferCode readOfferCodeById(Long offerCode);
+
+    public List<OfferCode> readOfferCodesByIds(Collection<Long> offerCodeIds);
 
     public OfferCode readOfferCodeByCode(String code);
 
@@ -36,4 +39,5 @@ public interface OfferCodeDao {
     public Boolean offerCodeIsUsed(OfferCode code);
 
     public List<OfferCode> readAllOfferCodesByCode(String code);
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferCodeDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferCodeDaoImpl.java
@@ -27,6 +27,7 @@ import org.broadleafcommerce.core.order.domain.OrderImpl;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -73,6 +74,13 @@ public class OfferCodeDaoImpl implements OfferCodeDao {
     @Override
     public OfferCode readOfferCodeById(Long offerCodeId) {
         return em.find(OfferCodeImpl.class, offerCodeId);
+    }
+
+    @Override
+    public List<OfferCode> readOfferCodesByIds(Collection<Long> offerCodeIds) {
+        TypedQuery<OfferCode> query = em.createQuery("SELECT code FROM " + OfferCode.class.getName() + " code WHERE code.id in :offerCodeIds", OfferCode.class);
+        query.setParameter("offerCodeIds", offerCodeIds);
+        return query.getResultList();
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferService.java
@@ -32,6 +32,7 @@ import org.broadleafcommerce.core.order.service.OrderService;
 import org.broadleafcommerce.core.pricing.service.exception.PricingException;
 import org.broadleafcommerce.profile.core.domain.Customer;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -288,6 +289,8 @@ public interface OfferService {
     public Boolean deleteOfferCode(OfferCode code);
 
     public Offer findOfferById(Long offerId);
+
+    public List<OfferCode> findOfferCodesByIds(Collection<Long> ids);
 
     /**
      * Make a production copy of an offer.

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -55,6 +55,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -707,6 +708,11 @@ public class OfferServiceImpl implements OfferService {
     @Override
     public OfferCode findOfferCodeById(Long id) {
         return offerCodeDao.readOfferCodeById(id);
+    }
+
+    @Override
+    public List<OfferCode> findOfferCodesByIds(Collection<Long> ids) {
+        return offerCodeDao.readOfferCodesByIds(ids);
     }
 
     @Override


### PR DESCRIPTION
This method was added, in particular, for https://github.com/BroadleafCommerce/AdvancedOffer/pull/120 so that we don't make multiple trips to the database. The performance improvement for that exact situation is minimal but it's a nice method to have just in case.

BroadleafCommerce/QA#3435