### PR TITLE
Fixes issue where Cart purge process fails due to duplicate OrderAttributes 

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/payment/service/DefaultCurrentOrderPaymentRequestService.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/payment/service/DefaultCurrentOrderPaymentRequestService.java
@@ -69,7 +69,11 @@ public class DefaultCurrentOrderPaymentRequestService implements CurrentOrderPay
             currentCart = orderService.findOrderById(orderId);
         }
 
-        OrderAttribute orderAttribute = new OrderAttributeImpl();
+        OrderAttribute orderAttribute = currentCart.getOrderAttributes().get(orderAttributeKey);
+
+        if (orderAttribute == null) {
+            orderAttribute = new OrderAttributeImpl();
+        }
         orderAttribute.setName(orderAttributeKey);
         orderAttribute.setValue(orderAttributeValue);
         orderAttribute.setOrder(currentCart);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderAttributeImpl.java
@@ -39,6 +39,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 /**
  * The Class OrderAttributeImpl
@@ -46,7 +47,8 @@ import javax.persistence.Table;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_ORDER_ATTRIBUTE")
+@Table(name="BLC_ORDER_ATTRIBUTE",
+                uniqueConstraints = @UniqueConstraint(name = "ATTR_NAME_ORDER_ID", columnNames = {"NAME", "ORDER_ID"}))
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOrderElements")
 @AdminPresentationMergeOverrides(
     {


### PR DESCRIPTION
BroadleafCommerce/QA#3477
Not able to purge Cart because of duplicate OrderAttributes 