### PR TITLE
Added readOnly attribute validation because Offer Restriction Rules do not honor admin privileges

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -814,7 +814,7 @@
                 if (data == null || data.length == 0) {
                     var noRules = $("<span>", {'class': 'readable-no-rule', 'html': 'No rules applied yet'});
 
-                    if ($('#' + "rule-disabled").val() == "false") {
+                    if ($("#"+ hiddenId + "-rule-disabled").val() == "false") {
                         var addRules = $('<span>', {
                             'data-hiddenId': hiddenId,
                             'data-ruleType': ruleBuilder.ruleType,

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -812,17 +812,19 @@
 
                 // If no data, set "No rules applied"
                 if (data == null || data.length == 0) {
-                    var noRules = $("<span>", {'class': 'readable-no-rule', 'html' : 'No rules applied yet,'});
+                    var noRules = $("<span>", {'class': 'readable-no-rule', 'html': 'No rules applied yet'});
 
-                    var addRules = $('<span>', {
-                        'data-hiddenId':  hiddenId,
-                        'data-ruleType': ruleBuilder.ruleType,
-                        'data-ruleTitleId': ruleBuilder.containerId + '-header',
-                        'html': '&nbsp;add some',
-                        'class': 'launch-modal-rule-builder launch-link'
-                    });
+                    if ($('#' + "rule-disabled").val() == "false") {
+                        var addRules = $('<span>', {
+                            'data-hiddenId': hiddenId,
+                            'data-ruleType': ruleBuilder.ruleType,
+                            'data-ruleTitleId': ruleBuilder.containerId + '-header',
+                            'html': ',&nbsp;add some',
+                            'class': 'launch-modal-rule-builder launch-link'
+                        });
 
-                    noRules.append(addRules);
+                        noRules.append(addRules);
+                    }
                     $(readableElement).append(noRules);
                     $(readableElement).parent().removeClass('can-edit');
                 // else fill in data

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/ruleBuilder.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/ruleBuilder.html
@@ -10,6 +10,8 @@
     If the "displayType" is not present, it will just render the RULE_SIMPLE or RULE_WITH_QUANTITY as "NORMAL".
     */-->
 
+    <input id="rule-disabled" type="hidden" th:value="${field.readOnly}">
+
     <div class="field-label inline" th:if="${field.displayType != null
     AND (field.displayType == 'RADIO' OR field.displayType == 'MODAL')}">
         <label>
@@ -65,7 +67,7 @@
             </div>
 
             <div class="launch-modal-rule-builder"
-                 th:if="${field.displayType != null AND field.displayType == 'MODAL'}"
+                 th:if="${field.displayType != null AND field.displayType == 'MODAL' AND field.readOnly == false}"
                  th:attr="data-hiddenId=${field.jsonFieldName},
                          data-ruleType=${field.ruleType},
                          data-ruleTitleId=${field.name + '-header'}">
@@ -74,7 +76,7 @@
             </div>
 
             <div class="clear-rule-builder"
-                 th:if="${field.displayType != null AND field.displayType == 'MODAL'}"
+                 th:if="${field.displayType != null AND field.displayType == 'MODAL' AND field.readOnly == false}"
                  th:attr="data-hiddenId=${field.jsonFieldName},
                          data-ruleType=${(field.ruleType == 'rule-builder-simple') ? 'add-main-rule' : 'add-main-item-rule'},
                          data-ruleTitleId=${field.name + '-header'}">

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/ruleBuilder.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/ruleBuilder.html
@@ -10,7 +10,7 @@
     If the "displayType" is not present, it will just render the RULE_SIMPLE or RULE_WITH_QUANTITY as "NORMAL".
     */-->
 
-    <input id="rule-disabled" type="hidden" th:value="${field.readOnly}">
+    <input th:id="${field.jsonFieldName + '-rule-disabled'}" type="hidden" th:value="${field.readOnly}">
 
     <div class="field-label inline" th:if="${field.displayType != null
     AND (field.displayType == 'RADIO' OR field.displayType == 'MODAL')}">


### PR DESCRIPTION
BroadleafCommerce/QA#3570
Offer Restriction Rules do not honor admin privileges. Added readOnly attribute validation.