### PR TITLE
Use the currency of the order instead of the default currency in checkout

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ValidateAndConfirmPaymentActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ValidateAndConfirmPaymentActivity.java
@@ -247,7 +247,7 @@ public class ValidateAndConfirmPaymentActivity extends BaseActivity<ProcessConte
         // Add authorize and authorize_and_capture transactions;
         // there should only be one or the other in the payment
         // Also add any pending transactions (as these are marked as being AUTH or CAPTURED later)
-        Money paymentSum = new Money(BigDecimal.ZERO);
+        Money paymentSum = new Money(BigDecimal.ZERO, order.getCurrency());
         for (OrderPayment payment : order.getPayments()) {
             if (payment.isActive()) {
                 paymentSum = paymentSum.add(payment.getSuccessfulTransactionAmountForType(PaymentTransactionType.AUTHORIZE))


### PR DESCRIPTION
In the `ValidateAndConfirmPaymentActivity` we need to add the payments up based on the order's currency instead of the default currency since the default/current currency/locale isn't always the same as the order. This is a possible scenario when using the API since there's no sessions and certain payment gateways use redirects which may not allow the locale/currency to be set on the request