### PR TITLE
Fix issue that prevented extended classes from participating in tab and field creation

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/DynamicEntityDaoImpl.java
@@ -933,7 +933,7 @@ public class DynamicEntityDaoImpl implements DynamicEntityDao, ApplicationContex
     public Map<String, TabMetadata> getTabAndGroupMetadata(Class<?>[] entities, ClassMetadata cmd) {
         Class<?>[] superClassEntities = getSuperClassHierarchy(entities[entities.length-1]);
 
-        Map<String, TabMetadata> mergedTabAndGroupMetadata = metadata.getBaseTabAndGroupMetadata(superClassEntities);
+        Map<String, TabMetadata> mergedTabAndGroupMetadata = metadata.getBaseTabAndGroupMetadata(entities);
         metadata.applyTabAndGroupMetadataOverrides(superClassEntities, mergedTabAndGroupMetadata);
         metadata.buildAdditionalTabAndGroupMetadataFromCmdProperties(cmd, mergedTabAndGroupMetadata);
 


### PR DESCRIPTION
BroadleafCommerce/QA#3500 

- Use full entities list to build tabs to allow for extended classes usage. This allows the system to create the initial merge tab/group metadata and override as needed.
