### PR TITLE
Year rendered in list grids might be next year from selected

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -792,7 +792,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
         }
 
         // format date list grid cells
-        SimpleDateFormat formatter = new SimpleDateFormat("MMM d, Y @ hh:mma");
+        SimpleDateFormat formatter = new SimpleDateFormat("MMM d, y @ hh:mma");
         DateFormatSymbols symbols = new DateFormatSymbols(Locale.getDefault());
         symbols.setAmPmStrings(new String[] { "am", "pm" });
         formatter.setDateFormatSymbols(symbols);


### PR DESCRIPTION
BroadleafCommerce/QA#3524
Changed date format to use calendar year instead of week year so 31 Dec 2018 will not become 2019