### PR TITLE
Adding ability for domain classes to have audit fields updates from either the site or the admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/audit/AdminAuditableListener.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/audit/AdminAuditableListener.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.openadmin.audit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.audit.AbstractAuditableListener;
+import org.broadleafcommerce.common.audit.CrossAppAuditable;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 
 import java.lang.reflect.Field;
@@ -35,32 +36,30 @@ public class AdminAuditableListener extends AbstractAuditableListener {
     @Override
     public void setAuditCreationAndUpdateData(Object entity) throws Exception {
         BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
-        if (!brc.getAdmin()) {
-            return;
+        if (brc.getAdmin() || (entity instanceof CrossAppAuditable)) {
+            setAuditCreationData(entity, new AdminAuditable());
+            setAuditUpdateData(entity, new AdminAuditable());
         }
-
-        setAuditCreationData(entity, new AdminAuditable());
-        setAuditUpdateData(entity, new AdminAuditable());
     }
 
     @PreUpdate
     @Override
     public void setAuditUpdateData(Object entity) throws Exception {
         BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
-        if (!brc.getAdmin()) {
-            return;
+        if (brc.getAdmin() || (entity instanceof CrossAppAuditable)) {
+            setAuditUpdateData(entity, new AdminAuditable());
         }
-
-        setAuditUpdateData(entity, new AdminAuditable());
     }
 
     @Override
     protected void setAuditValueAgent(Field field, Object entity) throws IllegalArgumentException, IllegalAccessException {
         try {
             BroadleafRequestContext context = BroadleafRequestContext.getBroadleafRequestContext();
-            if (context != null && context.getAdmin() && context.getAdminUserId() != null) {
-                field.setAccessible(true);
-                field.set(entity, context.getAdminUserId());
+            if (context != null && context.getAdminUserId() != null) {
+                if (context.getAdmin() || (entity instanceof CrossAppAuditable)) {
+                    field.setAccessible(true);
+                    field.set(entity, context.getAdminUserId());
+                }
             }
         } catch (IllegalStateException e) {
             //do nothing

--- a/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
+++ b/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
@@ -17,7 +17,12 @@
  */
 package org.broadleafcommerce.common.audit;
 
-
+/**
+ * Marker class that allows the auditable fields to be udpated from either the site or the admin.  Classes should implement the AdminAuditListener.
+ * 
+ * @author dcolgrove
+ *
+ */
 public interface CrossAppAuditable {
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
+++ b/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.common.audit;
 
 /**
- * Marker class that allows the auditable fields to be udpated from either the site or the admin.  Classes should implement the AdminAuditListener.
+ * Marker class that allows the auditable fields to be udpated from either the site or the admin.  Classes should implement the AdminAuditableListener.
  * 
  * @author dcolgrove
  *

--- a/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
+++ b/common/src/main/java/org/broadleafcommerce/common/audit/CrossAppAuditable.java
@@ -1,0 +1,23 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2019 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.audit;
+
+
+public interface CrossAppAuditable {
+
+}


### PR DESCRIPTION
Added a CrossAppAuditable marker interface to support the ability for the audit fields to be updated when an entity is created on either the site or admin

Fixes https://github.com/BroadleafCommerce/QA/issues/3587