### PR TITLE
Optionally autowire the EmailServiceProducer into the EmailService

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/email/service/EmailServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/EmailServiceImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.common.email.service;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.annotation.Resource;
-
 import org.broadleafcommerce.common.email.dao.EmailReportingDao;
 import org.broadleafcommerce.common.email.domain.EmailTarget;
 import org.broadleafcommerce.common.email.service.exception.EmailException;
@@ -31,7 +26,13 @@ import org.broadleafcommerce.common.email.service.info.ServerInfo;
 import org.broadleafcommerce.common.email.service.message.EmailPropertyType;
 import org.broadleafcommerce.common.email.service.message.EmailServiceProducer;
 import org.broadleafcommerce.common.email.service.message.MessageCreator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Resource;
 
 /**
  * @author jfischer
@@ -45,6 +46,7 @@ public class EmailServiceImpl implements EmailService {
     @Resource(name = "blServerInfo")
     protected ServerInfo serverInfo;
 
+    @Autowired(required = false)
     protected EmailServiceProducer emailServiceProducer;
 
     @Resource(name = "blMessageCreator")
@@ -53,6 +55,7 @@ public class EmailServiceImpl implements EmailService {
     @Resource(name = "blEmailReportingDao")
     protected EmailReportingDao emailReportingDao;
 
+    @Override
     public boolean sendTemplateEmail(EmailTarget emailTarget, EmailInfo emailInfo, Map<String, Object> props) {
         if (props == null) {
             props = new HashMap<String, Object>();
@@ -69,6 +72,7 @@ public class EmailServiceImpl implements EmailService {
         return sendBasicEmail(emailInfo, emailTarget, props);
     }
 
+    @Override
     public boolean sendTemplateEmail(String emailAddress, EmailInfo emailInfo, Map<String, Object> props) {
         if (!(emailInfo instanceof NullEmailInfo)) {
             EmailTarget emailTarget = emailReportingDao.createTarget();
@@ -79,6 +83,7 @@ public class EmailServiceImpl implements EmailService {
         }
     }
 
+    @Override
     public boolean sendBasicEmail(EmailInfo emailInfo, EmailTarget emailTarget, Map<String, Object> props) {
         if (props == null) {
             props = new HashMap<String, Object>();


### PR DESCRIPTION
Currently sending async emails is not intuitive because we create the `blEmailService` bean using component scanning but we don't autowire the `EmailServiceProducer`. This leaves implementors in an odd situation where they have to modify a singleton bean that's already been created or override the bean definition even though they're not doing anything different than out of the box outside of just setting the `EmailServiceProducer` which could easily be done by optionally autowiring that dependency.