### PR TITLE
Removed an unnecessary trailing forward slash when creating reset password url

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafLoginController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafLoginController.java
@@ -329,7 +329,7 @@ public class BroadleafLoginController extends BroadleafAbstractController {
     }
     
     public String getResetPasswordUrl(HttpServletRequest request) {     
-        String url = request.getScheme() + "://" + request.getServerName() + getResetPasswordPort(request, request.getScheme() + "/");
+        String url = request.getScheme() + "://" + request.getServerName() + getResetPasswordPort(request, request.getScheme());
         
         if (request.getContextPath() != null && ! "".equals(request.getContextPath())) {
             url = url + request.getContextPath() + getResetPasswordView();


### PR DESCRIPTION
The trailing slash would effectively make the code in `getResetPasswordPort` always return an empty string because we check for "http" and "https" when we're always going to send "http/" or "https/" by adding the trailing forward slash to the request scheme therefore the `getResetPasswordUrl` would only generate a correct url if the server was running on ports 80 and/or 443.