### PR TITLE
Fixed Profile Propagation Issues

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -128,9 +128,12 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
+
         FieldGroup cloned = createResponse.getClone();
-        cloned.setInitCollapsedFlag(initCollapsedFlag);
         cloned.setName(name);
+        cloned.setIsMasterFieldGroup(isMasterFieldGroup);
+        cloned.setInitCollapsedFlag(initCollapsedFlag);
+
         for (FieldDefinition fieldDefinition : fieldDefinitions) {
             FieldDefinition clonedDef = fieldDefinition.createOrRetrieveCopyInstance(context).getClone();
             cloned.getFieldDefinitions().add(clonedDef);

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
@@ -116,8 +116,12 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
         
         StructuredContentFieldGroupXref cloned = createResponse.getClone();
         cloned.setGroupOrder(groupOrder);
-        cloned.setTemplate(template);
-        cloned.setFieldGroup(fieldGroup);
+
+        CreateResponse<StructuredContentFieldTemplate> clonedTemplate = template.createOrRetrieveCopyInstance(context);
+        cloned.setTemplate(clonedTemplate.getClone());
+
+        CreateResponse<FieldGroup> clonedFieldGroup = fieldGroup.createOrRetrieveCopyInstance(context);
+        cloned.setFieldGroup(clonedFieldGroup.getClone());
         
         return createResponse;
     }


### PR DESCRIPTION
**Profile Propagation Issues**
- Fixes the issue where `StructuredContentFieldGroupXref`s receive incorrect entities during cloning
- Adds missing `isMasterFieldGroup` to cloning for `FieldGroup`

**A Brief Overview**
When a new profile is inheriting from an existing one, the structured content items are not hooked up correctly due to missing information in the cloning methods.