### PR TITLE
Override protobuf dependency to use latest version

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -361,9 +361,20 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.javascript</groupId>
             <artifactId>closure-compiler-unshaded</artifactId>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Security vulnerability reported for protobuf. Override it to use latest version.

**Link to QA issue**
https://github.com/BroadleafCommerce/QA/issues/3626
