### PR TITLE
Fixed JS error on Category reorder

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -930,9 +930,11 @@ $(document).ready(function () {
                             parentId: parentId
                         }
                     }, function (data) {
-                        // escape dots in the id selector
-                        var idSelector = data.field.replace(/\./g, '\\\.');
-                        var $container = $('div.listgrid-container#' + idSelector);
+                        if (data.field) {
+                            // escape dots in the id selector
+                            var idSelector = data.field.replace(/\./g, '\\\.');
+                            $container = $('div.listgrid-container#' + idSelector);
+                        }
 
                         BLCAdmin.workflow.updateSandboxRibbon();
                         BLCAdmin.listGrid.showAlert($container, BLCAdmin.messages.saved + '!', {
@@ -941,7 +943,7 @@ $(document).ready(function () {
                             autoClose: 3000
                         });
                         $container = $this.closest('.listgrid-container');
-                        if ($container.prev().length) {
+                        if ($container.prev().length || !data.field) {
                             var $parent = ui.item;
                             if (!$parent.hasClass('dirty')) {
                                 $parent.addClass('dirty');


### PR DESCRIPTION
Added check to see if the callback payload had a "field" field. If it doesn't then we'll simply use the container that was previously already defined. Added another check lower as well

Couple notes on this
- I don't think we need to refind the container anyways. This seems unnecessary but it was left so that this change doesn't break something on accident
- The !data.find check was added as a one off for the Category page. The container.prev call seems unnecessary but in order to reduce scope I went ahead and left it

Related to BroadleafCommerce/QA#3631 