### PR TITLE
Upgrade spring security to latest release

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2019 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.openadmin.server.service.persistence.validation;
 
 import java.io.Serializable;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.0.8.RELEASE</spring.version>
-        <spring.security.version>5.0.7.RELEASE</spring.security.version>
+        <spring.security.version>5.0.12.RELEASE</spring.security.version>
         <spring.boot.version>2.0.4.RELEASE</spring.boot.version>
         <spring.mobile.version>2.0.0.M3</spring.mobile.version>
         <jackson.version>2.9.8</jackson.version>


### PR DESCRIPTION
**A Brief Overview**
6.0 is currently on 5.0.7.Release. Vulnerability is reported for version 5.0.0 < 5.0.12. Upgrade to 5.0.12 which is latest released version.

**Link to QA issue**
https://github.com/BroadleafCommerce/QA/issues/3641
