### PR TITLE
Fixed an issue where Category Relevancy Rules don't boost results

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/dao/SolrIndexDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/dao/SolrIndexDaoImpl.java
@@ -99,7 +99,7 @@ public class SolrIndexDaoImpl implements SolrIndexDao {
                     }
 
                     // Cache the display order bigdecimals
-                    BigDecimal displayOrder = (item.getDisplayOrder() == null) ? new BigDecimal("1.00000") : item.getDisplayOrder();
+                    BigDecimal displayOrder = (item.getDisplayOrder() == null) ? new BigDecimal("100.00000") : item.getDisplayOrder();
                     catalogStructure.getDisplayOrdersByCategoryProduct().put(item.getCategory() + "-" + item.getProduct(), displayOrder);
                 }
                 for (Map.Entry<Long, Set<Long>> entry : parentCategoriesByProduct.entrySet()) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -112,6 +112,9 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
     @Value("${solr.global.facets.category.search:false}")
     protected boolean globalFacetsForCategorySearch;
 
+    @Value("${solr.boost.category.results:false}")
+    protected boolean boostSearchResultsCategory;
+
     /**
      * @return whether or not to enable debug query info for the SolrQuery
      */
@@ -219,7 +222,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
         // If there is a sort, remove all boosting that has been applied before we apply the sort clause.
         // We do this in order to support cases where we use boosting for enforcing a sort, specifically when sorting
         // on child documents.
-        if (StringUtils.isNotBlank(defaultSort) || StringUtils.isNotBlank(searchCriteria.getSortQuery())) {
+        if ((StringUtils.isNotBlank(defaultSort) || StringUtils.isNotBlank(searchCriteria.getSortQuery())) && !boostSearchResultsCategory) {
             solrQuery.remove("bq");
             solrQuery.remove("bf");
             solrQuery.remove("boost");
@@ -294,7 +297,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
     }
 
     protected String getDefaultSort(SearchCriteria criteria) {
-        if (criteria.getCategory() != null) {
+        if (criteria.getCategory() != null && !boostSearchResultsCategory) {
             return shs.getCategorySortFieldName(criteria.getCategory()) + " asc";
         }
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/3649

**A Brief Overview**
1. Added global property
1.1 solr.boost.category.results default to false
1.2 if false -> use default sort and remove boosts
1.3 if true -> keep boosts and don't add default sort

2. Updated default displayOrder to 100

