### PR TITLE
Fixed missing add button in global admin.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin-init.js
@@ -55,7 +55,7 @@
 
     // Hide address bar on mobile devices (except if #hash present, so we don't mess up deep linking).
     if (Modernizr.touch && !window.location.hash) {
-        $(window).load(function () {
+        $(window).on('load', function () {
             setTimeout(function () {
                 window.scrollTo(0, 1);
             }, 0);

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1382,22 +1382,26 @@ var getCurrentHashVal = function() {
     return hash.substr(1);
 };
 
-function enableEntityButtonsIfReady() {
-// primary entity buttons should be disabled until page is loaded
+function finalPageLoadIfReady() {
     if (BLC.readyEventTriggered && BLC.loadEventTriggered) {
-        $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
+        $(document).trigger("finalPageLoadEvent");
     }
 };
 
+// primary entity buttons should be disabled until page is loaded
+$(document).on('finalPageLoadEvent', function () {
+    $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
+});
+
 $(window).on('load', function () {
     BLC.loadEventTriggered = true;
-    enableEntityButtonsIfReady();
+    finalPageLoadIfReady();
 });
 
 $(document).ready(function() {
 
     BLC.readyEventTriggered = true;
-    enableEntityButtonsIfReady();
+    finalPageLoadIfReady();
 
     //moved show-translations to an initializationHandler so it gets fired for modals as well 
     BLCAdmin.addInitializationHandler(function($container) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -35,6 +35,8 @@ var BLCAdmin = (function($) {
         left: 20,
         top: 20
     };
+    var readyEventTriggered = false;
+    var loadEventTriggered = false;
 
     var fieldSelectors = '>div>input:not([type=hidden]), .custom-checkbox, .foreign-key-value-container, .redactor_box, ' +
                          '.asset-selector-container .media-image, >div>select, div.custom-checkbox, div.small-enum-container, .ace-editor, ' +
@@ -1380,12 +1382,23 @@ var getCurrentHashVal = function() {
     return hash.substr(1);
 };
 
+function enableEntityButtonsIfReady() {
 // primary entity buttons should be disabled until page is loaded
+    if (BLC.readyEventTriggered && BLC.loadEventTriggered) {
+        $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
+    }
+};
+
 $(window).on('load', function () {
-    $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
+    BLC.loadEventTriggered = true;
+    enableEntityButtonsIfReady();
 });
 
 $(document).ready(function() {
+
+    BLC.readyEventTriggered = true;
+    enableEntityButtonsIfReady();
+
     //moved show-translations to an initializationHandler so it gets fired for modals as well 
     BLCAdmin.addInitializationHandler(function($container) {
         $('a.show-translations:not(.always-disabled)').removeClass('disabled');

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1380,12 +1380,12 @@ var getCurrentHashVal = function() {
     return hash.substr(1);
 };
 
-$(document).ready(function() {
-    // primary entity buttons should be disabled until page is loaded
-    $(window).on('load', function () {
-        $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
-    });
+// primary entity buttons should be disabled until page is loaded
+$(window).on('load', function () {
+    $('.button.primary.large:not(.submit-button):not(.modify-production-inventory)').prop('disabled', false).removeClass('disabled');
+});
 
+$(document).ready(function() {
     //moved show-translations to an initializationHandler so it gets fired for modals as well 
     BLCAdmin.addInitializationHandler(function($container) {
         $('a.show-translations:not(.always-disabled)').removeClass('disabled');

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/responsive-tables.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/responsive-tables.js
@@ -15,8 +15,8 @@ $(document).ready(function() {
       });
     }
   };
-   
-  $(window).load(updateTables);
+
+  $(window).on('load', updateTables);
   $(window).bind("resize", updateTables);
    
 	


### PR DESCRIPTION
BroadleafCommerce/QA#3664

The problem can be occur when using/switching to jQuery 3. It's because all ready states in the new jQuery 3 are now fully asynchron. This means, that there is no given order for your code to be executed.

Because of this, it could happen, that load is been triggered before your ready state has been executed. When your ready function now finally gets triggered, your load listener is too late and will not be executed.