### PR TITLE
Content Items are showing duplicates of all the fields (carried over …

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroup.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroup.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
+import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXref;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 
 import java.io.Serializable;
@@ -26,6 +27,10 @@ import java.util.List;
  * Created by bpolster.
  */
 public interface FieldGroup extends Serializable, MultiTenantCloneable<FieldGroup> {
+
+    public List<StructuredContentFieldGroupXref> getFieldGroupXrefs();
+
+    public void setFieldGroupXrefs(List<StructuredContentFieldGroupXref> fieldGroupXrefs);
 
     public Long getId();
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -17,6 +17,8 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
+import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXref;
+import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyArchive;
@@ -81,6 +83,22 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Column (name = "IS_MASTER_FIELD_GROUP")
     protected Boolean isMasterFieldGroup = false;
 
+    @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "fieldGroup", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @OrderBy("groupOrder")
+    @BatchSize(size = 20)
+    protected List<StructuredContentFieldGroupXref> fieldGroupXrefs = new ArrayList<StructuredContentFieldGroupXref>();
+
+    @Override
+    public List<StructuredContentFieldGroupXref> getFieldGroupXrefs() {
+        return fieldGroupXrefs;
+    }
+
+    @Override
+    public void setFieldGroupXrefs(List<StructuredContentFieldGroupXref> fieldGroupXrefs) {
+        this.fieldGroupXrefs = fieldGroupXrefs;
+    }
+
     @Override
     public Long getId() {
         return id;
@@ -134,6 +152,14 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
         for (FieldDefinition fieldDefinition : fieldDefinitions) {
             FieldDefinition clonedDef = fieldDefinition.createOrRetrieveCopyInstance(context).getClone();
             cloned.getFieldDefinitions().add(clonedDef);
+        }
+        for (StructuredContentFieldGroupXref entry : fieldGroupXrefs) {
+            CreateResponse<StructuredContentFieldGroupXref>  clonedDef = entry.createOrRetrieveCopyInstance(context);
+            clonedDef.getClone().setFieldGroup(cloned);
+            //For the created StructuredContentFieldGroupXref StructuredContentFieldTemplate is not created yet,
+            // it will be populated during copy of StructuredContentFieldTemplate.
+            clonedDef.getClone().setTemplate(null);
+            cloned.getFieldGroupXrefs().add(clonedDef.getClone());
         }
         return createResponse;
     }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
@@ -140,6 +140,7 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
         cloned.setName(name);
         for (StructuredContentFieldGroupXref entry : fieldGroupXrefs) {
             CreateResponse<StructuredContentFieldGroupXref> clonedGroupRsp = entry.createOrRetrieveCopyInstance(context);
+            clonedGroupRsp.getClone().setTemplate(cloned);
             cloned.getFieldGroupXrefs().add(clonedGroupRsp.getClone());
         }
 


### PR DESCRIPTION
BroadleafCommerce/QA#3655
Content Items are showing duplicates of all the fields (carried over from base profile).
Caused by duplicate fields in blc_sc_fldgrp_xref. 