### PR TITLE
Feature rating summary - total - last update

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummary.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummary.java
@@ -17,9 +17,10 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import org.broadleafcommerce.core.rating.service.type.RatingType;
-
+import java.util.Date;
 import java.util.List;
+
+import org.broadleafcommerce.core.rating.service.type.RatingType;
 
 public interface RatingSummary {
     
@@ -50,5 +51,12 @@ public interface RatingSummary {
     public List<RatingDetail> getRatings();
     
     public void setRatings(List<RatingDetail> ratings);
+    
+    public void setTotalRatings(Integer totalRatings);
+    
+    public Integer getTotalRatings(Integer totalRatings);
 
+    public void setDate(Date date);
+    
+    public Date getDate();
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummary.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummary.java
@@ -54,7 +54,7 @@ public interface RatingSummary {
     
     public void setTotalRatings(Integer totalRatings);
     
-    public Integer getTotalRatings(Integer totalRatings);
+    public Integer getTotalRatings();
 
     public void setDate(Date date);
     

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -204,7 +204,6 @@ public class RatingSummaryImpl implements RatingSummary, Serializable {
 
     @Override
     public Date getDate() {
-        // TODO Auto-generated method stub
         return (timestamp == null) ? null : timestamp;
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -185,4 +185,27 @@ public class RatingSummaryImpl implements RatingSummary, Serializable {
         this.reviews = reviews;
     }
 
+    @Override
+    public void setTotalRatings(Integer totalRatings) {
+        this.totalRatings = totalRatings; 
+        
+    }
+
+    @Override
+    public Integer getTotalRatings() {
+        return (totalRatings == null) ? 0 : totalRatings ;
+    }
+
+    @Override
+    public void setDate(Date timestamp) {
+        this.timestamp= timestamp; 
+        
+    }
+
+    @Override
+    public Date getDate() {
+        // TODO Auto-generated method stub
+        return (timestamp == null) ? null : timestamp;
+    }
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -17,18 +17,11 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.broadleafcommerce.core.rating.service.type.RatingType;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -38,6 +31,18 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.core.rating.service.type.RatingType;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -88,6 +93,19 @@ public class RatingSummaryImpl implements RatingSummary, Serializable {
     @Override
     public Long getId() {
         return id;
+    }
+
+    @Column(name = "TOTAL_RATINGS")
+    @AdminPresentation(friendlyName = "RatingSummary_totalRatings", prominent = true)
+    protected Integer totalRatings = new Integer(0);
+
+    @Column(name = "DATE_UPDATED")
+    @Temporal(TemporalType.TIMESTAMP)
+    @AdminPresentation(friendlyName = "Date",  prominent=true)    
+    protected Date timestamp;
+
+    public void setAverageRating(Double averageRating) {
+        this.averageRating = averageRating;
     }
 
     /**


### PR DESCRIPTION


**A Brief Overview**
RatingSummary as is, does not include a totalratings and the date where the rating were added, since the entity contains the average is common to have the total rating in this entity as well.

This has impact in the performance as well as secondary-inheriting entity doesn't have the same performance regarding caches.
 
**Additional context**
This came out in the context of the performance enhanctment that are being done in gopher.