### PR TITLE
The content targeting functionality that swaps out the theme was moved to separate filter

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.web;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.classloader.release.ThreadLocalManager;
+import org.broadleafcommerce.common.site.domain.Theme;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+import javax.annotation.Resource;
+
+/**
+ *
+ * @author Stanislav Fedorov
+ * @see {@link BroadleafThemeResolverFilter}
+ */
+@Component("blThemeProcessor")
+public class BroadleafThemeProcessor extends AbstractBroadleafWebRequestProcessor {
+
+    protected final Log LOG = LogFactory.getLog(getClass());
+
+    @Resource(name = "blThemeResolver")
+    protected BroadleafThemeResolver themeResolver;
+
+    @Override
+    public void process(WebRequest request) {
+
+        BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
+
+        // Note that this must happen after the request context is set up as resolving a theme is dependent on site
+        Theme theme = themeResolver.resolveTheme(request);
+        brc.setTheme(theme);
+
+    }
+
+    @Override
+    public void postProcess(WebRequest request) {
+        ThreadLocalManager.remove();
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeResolverFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeResolverFilter.java
@@ -1,0 +1,154 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.web;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.admin.condition.ConditionalOnNotAdmin;
+import org.broadleafcommerce.common.exception.SiteNotFoundException;
+import org.broadleafcommerce.common.web.exception.HaltFilterChainException;
+import org.broadleafcommerce.common.web.filter.AbstractIgnorableOncePerRequestFilter;
+import org.broadleafcommerce.common.web.filter.FilterOrdered;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Responsible for setting up the theme used by Broadleaf Commerce components.
+ *
+ * @author Stanislav Fedorov
+ */
+@Component("blThemeResolvertFilter")
+@ConditionalOnNotAdmin
+public class BroadleafThemeResolverFilter extends AbstractIgnorableOncePerRequestFilter {
+
+    private final Log LOG = LogFactory.getLog(getClass());
+
+    // Properties to manage URLs that will not be processed by this filter.
+    private static final String BLC_ADMIN_GWT = "org.broadleafcommerce.admin";
+    private static final String BLC_ADMIN_PREFIX = "blcadmin";
+    private static final String BLC_ADMIN_SERVICE = ".service";
+
+    private Set<String> ignoreSuffixes;
+
+    @Autowired
+    @Qualifier("blThemeProcessor")
+    protected BroadleafThemeProcessor themeProcessor;
+
+    @Override
+    protected void doFilterInternalUnlessIgnored(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        if (!shouldProcessURL(request, request.getRequestURI())) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(String.format("%s not processing URL %s", getClass().getName(), request.getRequestURI()));
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (LOG.isTraceEnabled()) {
+            String requestURIWithoutContext;
+
+            if (request.getContextPath() != null) {
+                requestURIWithoutContext = request.getRequestURI().substring(request.getContextPath().length());
+            } else {
+                requestURIWithoutContext = request.getRequestURI();
+            }
+
+            // Remove JSESSION-ID or other modifiers
+            int pos = requestURIWithoutContext.indexOf(";");
+            if (pos >= 0) {
+                requestURIWithoutContext = requestURIWithoutContext.substring(0, pos);
+            }
+
+            LOG.trace("Process URL Filter Begin " + requestURIWithoutContext);
+        }
+
+        try {
+            themeProcessor.process(new ServletWebRequest(request, response));
+            filterChain.doFilter(request, response);
+        } catch (HaltFilterChainException e) {
+            return;
+        } catch (SiteNotFoundException e) {
+            LOG.warn("Could not resolve a site for the given request, returning not found");
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        } finally {
+            themeProcessor.postProcess(new ServletWebRequest(request, response));
+        }
+    }
+
+    /**
+     * Determines if the passed in URL should be processed by the content management system.
+     * <p/>
+     * By default, this method returns false for any BLC-Admin URLs and service calls and for all common image/digital mime-types (as determined by an internal call to {@code getIgnoreSuffixes}.
+     * <p/>
+     * This check is called with the {@code doFilterInternal} method to short-circuit the content processing which can be expensive for requests that do not require it.
+     *
+     * @param requestURI
+     *            - the HttpServletRequest.getRequestURI
+     * @return true if the {@code HttpServletRequest} should be processed
+     */
+    protected boolean shouldProcessURL(HttpServletRequest request, String requestURI) {
+        return shouldProcessURL(request, requestURI, false);
+    }
+
+    protected boolean shouldProcessURL(HttpServletRequest request, String requestURI, boolean ignoreSessionCheck) {
+        if (requestURI.contains(BLC_ADMIN_GWT) || requestURI.endsWith(BLC_ADMIN_SERVICE) || requestURI.contains(BLC_ADMIN_PREFIX)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns a set of suffixes that can be ignored by content processing. The following are returned:
+     * <p/>
+     * <B>List of suffixes ignored:</B>
+     *
+     * ".aif", ".aiff", ".asf", ".avi", ".bin", ".bmp", ".doc", ".eps", ".gif", ".hqx", ".jpg", ".jpeg", ".mid", ".midi", ".mov", ".mp3", ".mpg", ".mpeg", ".p65", ".pdf", ".pic", ".pict", ".png", ".ppt", ".psd", ".qxd", ".ram", ".ra", ".rm", ".sea", ".sit", ".stk", ".swf", ".tif", ".tiff", ".txt", ".rtf", ".vob", ".wav", ".wmf", ".xls", ".zip";
+     *
+     * @return set of suffixes to ignore.
+     */
+    protected Set getIgnoreSuffixes() {
+        if (ignoreSuffixes == null || ignoreSuffixes.isEmpty()) {
+            String[] ignoreSuffixList = { ".aif", ".aiff", ".asf", ".avi", ".bin", ".bmp", ".css", ".doc", ".eps", ".gif", ".hqx", ".js", ".jpg", ".jpeg", ".mid", ".midi", ".mov", ".mp3", ".mpg", ".mpeg", ".p65", ".pdf", ".pic", ".pict", ".png", ".ppt", ".psd", ".qxd", ".ram", ".ra", ".rm", ".sea", ".sit", ".stk", ".swf", ".tif", ".tiff", ".txt", ".rtf", ".vob", ".wav", ".wmf", ".xls", ".zip" };
+            ignoreSuffixes = new HashSet<>(Arrays.asList(ignoreSuffixList));
+        }
+        return ignoreSuffixes;
+    }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
+    @Override
+    public int getOrder() {
+        return FilterOrdered.POST_SECURITY_HIGH + 100;
+    }
+}


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/3682

**A Brief Overview**
Current solution was based on these recomendations:

//danielcolgrove https://github.com/BroadleafCommerce/QA/issues/3639#issuecomment-499506999

> "..I believe it would be best to add a separate filter. ContentTargeters are from the advancedCMS module and may not exist in all implementations.."

I have created a new filter that works after CustomerStateFilter and have only one function - to resolve Theme and to set it in BroadleafRequestContext.

//phillipuniverse https://github.com/BroadleafCommerce/QA/issues/3639#issuecomment-499485674

> "..I think we need to keep the existing resolution the same for backwards compatibility purposes, and then swap it out once we resolve the customer, if there are things that are targeting a customer. .."

I have not changed BroadleafRequestContext, so now we resolve Theme twice: 
1) In BroadleafRequestFilter before SpringSecurity
2) In BroadleafThemeResolverFilter after SpringSecurity

//phillipuniverse https://github.com/BroadleafCommerce/QA/issues/3639#issuecomment-499485674

> "Perhaps it is also worth making this check and only doing it if there exists a targeter that contains customer segments, otherwise leave the resolved Theme untouched."

From my point of view to check if we have CustomerSegment for ContentTargeter we need to use functionality of AdvancedCMS module that works with it now. But it is amost the same that simply to swap out Theme. Or am i wrong? So now we call Theme resolver without check.

//phillipuniverse https://github.com/BroadleafCommerce/QA/issues/3639#issuecomment-499485674

> "Add null-safety to the existing ability to swap out a theme configuration based on a customer. You can see how this happens in CustomerSegmentContentTargeterResolverExtensionHandler where CustomerState.getCustomer() is null on resource requests"

Now CustomerSegmentContentTargeterResolverExtensionHandler take a part in "Theme resolve" flow before the call of MvelHelper. And in case of CustomerState.getCustomer() is null we have just this message in console:
_org.mvel2.UnresolveablePropertyException: unable to resolve token: unable to resolve variable 'customer'_
Is it normal "null-safety" or should we do something with this?






