### PR TITLE
Allows not initial resource bundle requests to not specify mapping prefix and file list.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/request/ResourcesRequest.java
@@ -51,14 +51,16 @@ public class ResourcesRequest {
             //names are same
             if (name.equals(resourcesRequestBundle.getBundleName())) {
 
-                if (!StringUtils.equalsIgnoreCase(mappingPrefix, resourcesRequestBundle.getMappingPrefix())) {
+                if (mappingPrefix != null && 
+                    !StringUtils.equalsIgnoreCase(mappingPrefix, resourcesRequestBundle.getMappingPrefix())) {
                     //the prefixes are different
                     continue;
                 }
 
                 final List<String> bundleFiles = resourcesRequestBundle.getFiles();
 
-                if (!CollectionUtils.isEqualCollection(files, bundleFiles)) {
+                if (!CollectionUtils.isEmpty(files) && 
+                    !CollectionUtils.isEqualCollection(files, bundleFiles)) {
                     //files are different
                     continue;
                 }


### PR DESCRIPTION
Resolves https://github.com/BroadleafCommerce/QA/issues/3686

Non initial bundle requests were failing due to file list and mapping prefix not being specified. Since they are not the initial request, they do not need to specify these attributes as noted in the Javadocs.
These changes allow for the mapping prefix and file list to be null - not specified - on not initial resource bundle requests.
