### PR TITLE
BroadleafEntityValidator.validate() should be public

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
@@ -16,21 +16,21 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordH
  * The persistent entity class that Hibernate is aware of should be used as the generic type. For example,
  * SomeEntityImpl instead of SomeEntity interface.
  * 
- * In the implementation of valdate {@link Entity#addValidationError(String, String)} and
+ * In the implementation of validate {@link Entity#addValidationError(String, String)} and
  * {@link Entity#addValidationError(String, String)} can be used to create an error that is displayed to the user before
- * an add or update cocurs. {@link Entity#isValidationFailure()} can be used to see if there core validation found any
+ * an add or update occurs. {@link Entity#isValidationFailure()} can be used to see if there core validation found any
  * issues like required fields being blank to decide if any additional validation should be executed.
  * 
- * @param <T>
- *            Persistence Entity implementation to validate
+ * @param <T> Persistence Entity implementation to validate
  */
 public abstract class BroadleafEntityValidator<T> {
 
 	/**
 	 * Validation that should be done on the specified entity after core validation is completed.
 	 */
-	abstract void validate(Entity submittedEntity, @Nonnull T instance, Map<String, FieldMetadata> propertiesMetadata,
-			RecordHelper recordHelper, boolean validateUnsubmittedProperties);
+	public abstract void validate(Entity submittedEntity, @Nonnull T instance,
+			Map<String, FieldMetadata> propertiesMetadata, RecordHelper recordHelper,
+			boolean validateUnsubmittedProperties);
 
 	@SuppressWarnings("unchecked")
 	void validate(Entity submittedEntity, @Nonnull Serializable instance, Map<String, FieldMetadata> propertiesMetadata,

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BroadleafEntityValidator.java
@@ -18,7 +18,7 @@ import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordH
  * 
  * In the implementation of validate {@link Entity#addValidationError(String, String)} and
  * {@link Entity#addValidationError(String, String)} can be used to create an error that is displayed to the user before
- * an add or update occurs. {@link Entity#isValidationFailure()} can be used to see if there core validation found any
+ * an add or update occurs. {@link Entity#isValidationFailure()} can be used to see if the core validation found any
  * issues like required fields being blank to decide if any additional validation should be executed.
  * 
  * @param <T> Persistence Entity implementation to validate

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -115,11 +115,9 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 			}
 		}
 		Entity entity;
-		boolean isUpdateRequest;
 		if (idValue == null) {
 			// This is for an add, or if the instance variable is null (e.g. PageTemplateCustomPersistenceHandler)
 			entity = submittedEntity;
-			isUpdateRequest = false;
 		} else {
 			if (validateUnsubmittedProperties) {
 				// This is for an update, as the submittedEntity instance will likely only contain the dirty properties
@@ -142,7 +140,6 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 			} else {
 				entity = submittedEntity;
 			}
-			isUpdateRequest = true;
 		}
 
 		List<String> types = getTypeHierarchy(entity);
@@ -224,12 +221,12 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 			}
 		}
 		if (instance != null) {
-			List<BroadleafEntityValidator<?>> formFoxValidators = broadleafValidatorMap
+			List<BroadleafEntityValidator<?>> broadleafValidators = broadleafValidatorMap
 					.get(instance.getClass().getName());
-			if (formFoxValidators != null) {
-				for (BroadleafEntityValidator<?> formFoxValidator : formFoxValidators) {
-					LOG.debug("Calling validator " + formFoxValidator.getClass().getName());
-					formFoxValidator.validate(submittedEntity, instance, propertiesMetadata, recordHelper,
+			if (broadleafValidators != null) {
+				for (BroadleafEntityValidator<?> broadleafValidator : broadleafValidators) {
+					LOG.debug("Calling validator " + broadleafValidator.getClass().getName());
+					broadleafValidator.validate(submittedEntity, instance, propertiesMetadata, recordHelper,
 							validateUnsubmittedProperties);
 				}
 			}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -68,32 +68,32 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 	@Resource(name = "blRowLevelSecurityService")
 	protected RowLevelSecurityService securityService;
 
-	private Map<String, List<BroadleafEntityValidator<?>>> broadLeafValidatorMap;
+	private Map<String, List<BroadleafEntityValidator<?>>> broadleafValidatorMap;
 
 	@PostConstruct
 	public void populateBroadleafValidatorMap() {
 		String[] beanNames = applicationContext.getBeanNamesForType(BroadleafEntityValidator.class);
-		broadLeafValidatorMap = new HashMap<>(beanNames.length);
+		broadleafValidatorMap = new HashMap<>(beanNames.length);
 
 		for (String beanName : beanNames) {
-			BroadleafEntityValidator<?> formFoxValidator = applicationContext.getBean(beanName,
+			BroadleafEntityValidator<?> broadleafValidator = applicationContext.getBean(beanName,
 					BroadleafEntityValidator.class);
-			Class<?> entityType = GenericTypeResolver.resolveTypeArgument(formFoxValidator.getClass(),
+			Class<?> entityType = GenericTypeResolver.resolveTypeArgument(broadleafValidator.getClass(),
 					BroadleafEntityValidator.class);
 			if (entityType != null) {
 				String entityClassName = entityType.getName();
 				LOG.info(String.format("Registering validator %s for entity type %s",
-						formFoxValidator.getClass().getName(), entityClassName));
+						broadleafValidator.getClass().getName(), entityClassName));
 
-				List<BroadleafEntityValidator<?>> registeredValidatorsForType = broadLeafValidatorMap
+				List<BroadleafEntityValidator<?>> registeredValidatorsForType = broadleafValidatorMap
 						.get(entityClassName);
 				if (registeredValidatorsForType == null) {
 					registeredValidatorsForType = new ArrayList<>();
-					broadLeafValidatorMap.put(entityClassName, registeredValidatorsForType);
+					broadleafValidatorMap.put(entityClassName, registeredValidatorsForType);
 				}
-				registeredValidatorsForType.add(formFoxValidator);
+				registeredValidatorsForType.add(broadleafValidator);
 			} else {
-				LOG.warn("Could not determine entity type for " + formFoxValidator.getClass().getName());
+				LOG.warn("Could not determine entity type for " + broadleafValidator.getClass().getName());
 			}
 		}
 	}
@@ -125,8 +125,7 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 				// This is for an update, as the submittedEntity instance will likely only contain the dirty properties
 				entity = recordHelper.getRecord(propertiesMetadata, instance, null, null);
 				// acquire any missing properties not harvested from the instance and add to the entity. A use case for
-				// this
-				// would be the confirmation field for a password validation
+				// this would be the confirmation field for a password validation
 				for (Map.Entry<String, FieldMetadata> entry : propertiesMetadata.entrySet()) {
 					if (entity.findProperty(entry.getKey()) == null) {
 						Property myProperty = submittedEntity.findProperty(entry.getKey());
@@ -165,8 +164,7 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 				}
 
 				// for radio buttons, it's possible that the entity property was never populated in the first place from
-				// the POST
-				// and so it will be null
+				// the POST and so it will be null
 				String propertyName = metadataEntry.getKey();
 				String propertyValue = (property == null) ? null : property.getValue();
 
@@ -226,7 +224,7 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 			}
 		}
 		if (instance != null) {
-			List<BroadleafEntityValidator<?>> formFoxValidators = broadLeafValidatorMap
+			List<BroadleafEntityValidator<?>> formFoxValidators = broadleafValidatorMap
 					.get(instance.getClass().getName());
 			if (formFoxValidators != null) {
 				for (BroadleafEntityValidator<?> formFoxValidator : formFoxValidators) {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -17,6 +17,17 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.validation;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,18 +47,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.stereotype.Service;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
-
-
 /**
  * This implementation validates each {@link Property} from the given {@link Entity} according to the
  * {@link ValidationConfiguration}s associated with it.
@@ -59,22 +58,22 @@ import javax.annotation.Resource;
 @Service("blEntityValidatorService")
 public class EntityValidatorServiceImpl implements EntityValidatorService {
 	protected static final Log LOG = LogFactory.getLog(EntityValidatorServiceImpl.class);
-    
-    @Resource(name = "blGlobalEntityPropertyValidators")
-    protected List<GlobalPropertyValidator> globalEntityValidators;
 
-    @Autowired
-    protected ApplicationContext applicationContext;
-    
-    @Resource(name = "blRowLevelSecurityService")
-    protected RowLevelSecurityService securityService;
-    
-    private Map<String, List<BroadleafEntityValidator<?>>> formFoxValidatorMap;
+	@Resource(name = "blGlobalEntityPropertyValidators")
+	protected List<GlobalPropertyValidator> globalEntityValidators;
+
+	@Autowired
+	protected ApplicationContext applicationContext;
+
+	@Resource(name = "blRowLevelSecurityService")
+	protected RowLevelSecurityService securityService;
+
+	private Map<String, List<BroadleafEntityValidator<?>>> broadLeafValidatorMap;
 
 	@PostConstruct
-	public void populateFormFoxValidatorMap() {
+	public void populateBroadleafValidatorMap() {
 		String[] beanNames = applicationContext.getBeanNamesForType(BroadleafEntityValidator.class);
-		formFoxValidatorMap = new HashMap<>(beanNames.length);
+		broadLeafValidatorMap = new HashMap<>(beanNames.length);
 
 		for (String beanName : beanNames) {
 			BroadleafEntityValidator<?> formFoxValidator = applicationContext.getBean(beanName,
@@ -86,11 +85,11 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 				LOG.info(String.format("Registering validator %s for entity type %s",
 						formFoxValidator.getClass().getName(), entityClassName));
 
-				List<BroadleafEntityValidator<?>> registeredValidatorsForType = formFoxValidatorMap
+				List<BroadleafEntityValidator<?>> registeredValidatorsForType = broadLeafValidatorMap
 						.get(entityClassName);
 				if (registeredValidatorsForType == null) {
 					registeredValidatorsForType = new ArrayList<>();
-					formFoxValidatorMap.put(entityClassName, registeredValidatorsForType);
+					broadLeafValidatorMap.put(entityClassName, registeredValidatorsForType);
 				}
 				registeredValidatorsForType.add(formFoxValidator);
 			} else {
@@ -98,139 +97,136 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 			}
 		}
 	}
-    
-    
-    @Override
-    public void validate(Entity submittedEntity, @Nullable Serializable instance, Map<String, FieldMetadata> propertiesMetadata,
-            RecordHelper recordHelper, boolean validateUnsubmittedProperties) {
-        Object idValue = null;
-        if (instance != null) {
-            String idField = (String) ((BasicPersistenceModule) recordHelper.getCompatibleModule(OperationType.BASIC)).
-                getPersistenceManager().getDynamicEntityDao().getIdMetadata(instance.getClass()).get("name");
-            try {
-                idValue = recordHelper.getFieldManager().getFieldValue(instance, idField);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            } catch (FieldNotAvailableException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        Entity entity;
-        boolean isUpdateRequest;
-        if (idValue == null) {
-            //This is for an add, or if the instance variable is null (e.g. PageTemplateCustomPersistenceHandler)
-            entity = submittedEntity;
-            isUpdateRequest = false;
-        } else {
-            if (validateUnsubmittedProperties) {
-                //This is for an update, as the submittedEntity instance will likely only contain the dirty properties
-                entity = recordHelper.getRecord(propertiesMetadata, instance, null, null);
-                //acquire any missing properties not harvested from the instance and add to the entity. A use case for this
-                //would be the confirmation field for a password validation
-                for (Map.Entry<String, FieldMetadata> entry : propertiesMetadata.entrySet()) {
-                    if (entity.findProperty(entry.getKey()) == null) {
-                        Property myProperty = submittedEntity.findProperty(entry.getKey());
-                        if (myProperty != null) {
-                            entity.addProperty(myProperty);
-                        }
-                    } else if (submittedEntity.findProperty(entry.getKey()) != null) {
-                        entity.findProperty(entry.getKey()).setValue(submittedEntity.findProperty(entry.getKey()).getValue());
-                        entity.findProperty(entry.getKey()).setIsDirty(submittedEntity.findProperty(entry.getKey()).getIsDirty());
-                    }
-                }
-            } else {
-                entity = submittedEntity;
-            }
-            isUpdateRequest = true;
-        }
-            
-        List<String> types = getTypeHierarchy(entity);
-        //validate each individual property according to their validation configuration
-        for (Entry<String, FieldMetadata> metadataEntry : propertiesMetadata.entrySet()) {
-            FieldMetadata metadata = metadataEntry.getValue();
 
-            //Don't test this field if it was not inherited from our polymorphic type (or supertype)
-            if (instance != null && (types.contains(metadata.getInheritedFromType())
-                    || instance.getClass().getName().equals(metadata.getInheritedFromType()))) {
-                
-                Property property = entity.getPMap().get(metadataEntry.getKey());
+	@Override
+	public void validate(Entity submittedEntity, @Nullable Serializable instance,
+			Map<String, FieldMetadata> propertiesMetadata, RecordHelper recordHelper,
+			boolean validateUnsubmittedProperties) {
+		Object idValue = null;
+		if (instance != null) {
+			String idField = (String) ((BasicPersistenceModule) recordHelper.getCompatibleModule(OperationType.BASIC))
+					.getPersistenceManager().getDynamicEntityDao().getIdMetadata(instance.getClass()).get("name");
+			try {
+				idValue = recordHelper.getFieldManager().getFieldValue(instance, idField);
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException(e);
+			} catch (FieldNotAvailableException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		Entity entity;
+		boolean isUpdateRequest;
+		if (idValue == null) {
+			// This is for an add, or if the instance variable is null (e.g. PageTemplateCustomPersistenceHandler)
+			entity = submittedEntity;
+			isUpdateRequest = false;
+		} else {
+			if (validateUnsubmittedProperties) {
+				// This is for an update, as the submittedEntity instance will likely only contain the dirty properties
+				entity = recordHelper.getRecord(propertiesMetadata, instance, null, null);
+				// acquire any missing properties not harvested from the instance and add to the entity. A use case for
+				// this
+				// would be the confirmation field for a password validation
+				for (Map.Entry<String, FieldMetadata> entry : propertiesMetadata.entrySet()) {
+					if (entity.findProperty(entry.getKey()) == null) {
+						Property myProperty = submittedEntity.findProperty(entry.getKey());
+						if (myProperty != null) {
+							entity.addProperty(myProperty);
+						}
+					} else if (submittedEntity.findProperty(entry.getKey()) != null) {
+						entity.findProperty(entry.getKey())
+								.setValue(submittedEntity.findProperty(entry.getKey()).getValue());
+						entity.findProperty(entry.getKey())
+								.setIsDirty(submittedEntity.findProperty(entry.getKey()).getIsDirty());
+					}
+				}
+			} else {
+				entity = submittedEntity;
+			}
+			isUpdateRequest = true;
+		}
 
-                // This property should be set to false only in the case where we are adding a member to a collection
-                // that has type of lookup. In this case, we don't have the properties from the target in our entity,
-                // and we don't need to validate them.
-                if (!validateUnsubmittedProperties && property == null) {
-                    continue;
-                }
+		List<String> types = getTypeHierarchy(entity);
+		// validate each individual property according to their validation configuration
+		for (Entry<String, FieldMetadata> metadataEntry : propertiesMetadata.entrySet()) {
+			FieldMetadata metadata = metadataEntry.getValue();
 
-                //for radio buttons, it's possible that the entity property was never populated in the first place from the POST
-                //and so it will be null
-                String propertyName = metadataEntry.getKey();
-                String propertyValue = (property == null) ? null : property.getValue();
+			// Don't test this field if it was not inherited from our polymorphic type (or supertype)
+			if (instance != null && (types.contains(metadata.getInheritedFromType())
+					|| instance.getClass().getName().equals(metadata.getInheritedFromType()))) {
 
-                if (metadata instanceof BasicFieldMetadata) {
-                    //First execute the global field validators
-                    if (CollectionUtils.isNotEmpty(globalEntityValidators)) {
-                        for (GlobalPropertyValidator validator : globalEntityValidators) {
-                            PropertyValidationResult result = validator.validate(entity,
-                                    instance,
-                                    propertiesMetadata,
-                                    (BasicFieldMetadata)metadata,
-                                    propertyName,
-                                    propertyValue);
-                            if (!result.isValid()) {
-                                submittedEntity.addValidationError(propertyName, result.getErrorMessage());
-                            }
-                        }
-                    }
+				Property property = entity.getPMap().get(metadataEntry.getKey());
 
-                    //Now execute the validators configured for this particular field
-                    Map<String, List<Map<String, String>>> validations =
-                            ((BasicFieldMetadata) metadata).getValidationConfigurations();
-                    for (Map.Entry<String, List<Map<String, String>>> validation : validations.entrySet()) {
-                        String validationImplementation = validation.getKey();
-                        
-                        for (Map<String, String> configuration : validation.getValue()) {
+				// This property should be set to false only in the case where we are adding a member to a collection
+				// that has type of lookup. In this case, we don't have the properties from the target in our entity,
+				// and we don't need to validate them.
+				if (!validateUnsubmittedProperties && property == null) {
+					continue;
+				}
 
-                            PropertyValidator validator = null;
-    
-                            //attempt bean resolution to find the validator
-                            if (applicationContext.containsBean(validationImplementation)) {
-                                validator = applicationContext.getBean(validationImplementation, PropertyValidator.class);
-                            }
-    
-                            //not a bean, attempt to instantiate the class
-                            if (validator == null) {
-                                try {
-                                    validator = (PropertyValidator) Class.forName(validationImplementation).newInstance();
-                                } catch (Exception e) {
-                                    //do nothing
-                                }
-                            }
-    
-                            if (validator == null) {
-                                throw new PersistenceException("Could not find validator: " + validationImplementation +
-                                        " for property: " + propertyName);
-                            }
-    
-                            PropertyValidationResult result = validator.validate(entity,
-                                                                            instance,
-                                                                            propertiesMetadata,
-                                                                            configuration,
-                                                                            (BasicFieldMetadata)metadata,
-                                                                            propertyName,
-                                                                            propertyValue);
-                            if (!result.isValid()) {
-                                for (String message : result.getErrorMessages()) {
-                                    submittedEntity.addValidationError(propertyName, message);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if (instance != null) {
-			List<BroadleafEntityValidator<?>> formFoxValidators = formFoxValidatorMap
+				// for radio buttons, it's possible that the entity property was never populated in the first place from
+				// the POST
+				// and so it will be null
+				String propertyName = metadataEntry.getKey();
+				String propertyValue = (property == null) ? null : property.getValue();
+
+				if (metadata instanceof BasicFieldMetadata) {
+					// First execute the global field validators
+					if (CollectionUtils.isNotEmpty(globalEntityValidators)) {
+						for (GlobalPropertyValidator validator : globalEntityValidators) {
+							PropertyValidationResult result = validator.validate(entity, instance, propertiesMetadata,
+									(BasicFieldMetadata) metadata, propertyName, propertyValue);
+							if (!result.isValid()) {
+								submittedEntity.addValidationError(propertyName, result.getErrorMessage());
+							}
+						}
+					}
+
+					// Now execute the validators configured for this particular field
+					Map<String, List<Map<String, String>>> validations = ((BasicFieldMetadata) metadata)
+							.getValidationConfigurations();
+					for (Map.Entry<String, List<Map<String, String>>> validation : validations.entrySet()) {
+						String validationImplementation = validation.getKey();
+
+						for (Map<String, String> configuration : validation.getValue()) {
+
+							PropertyValidator validator = null;
+
+							// attempt bean resolution to find the validator
+							if (applicationContext.containsBean(validationImplementation)) {
+								validator = applicationContext.getBean(validationImplementation,
+										PropertyValidator.class);
+							}
+
+							// not a bean, attempt to instantiate the class
+							if (validator == null) {
+								try {
+									validator = (PropertyValidator) Class.forName(validationImplementation)
+											.newInstance();
+								} catch (Exception e) {
+									// do nothing
+								}
+							}
+
+							if (validator == null) {
+								throw new PersistenceException("Could not find validator: " + validationImplementation
+										+ " for property: " + propertyName);
+							}
+
+							PropertyValidationResult result = validator.validate(entity, instance, propertiesMetadata,
+									configuration, (BasicFieldMetadata) metadata, propertyName, propertyValue);
+							if (!result.isValid()) {
+								for (String message : result.getErrorMessages()) {
+									submittedEntity.addValidationError(propertyName, message);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		if (instance != null) {
+			List<BroadleafEntityValidator<?>> formFoxValidators = broadLeafValidatorMap
 					.get(instance.getClass().getName());
 			if (formFoxValidators != null) {
 				for (BroadleafEntityValidator<?> formFoxValidator : formFoxValidators) {
@@ -240,48 +236,49 @@ public class EntityValidatorServiceImpl implements EntityValidatorService {
 				}
 			}
 		}
-    }
+	}
 
-    /**
-     * <p>
-     * Returns the type hierarchy of the given <b>entity</b> in ascending order of type, stopping at Object
-     * 
-     * <p>
-     * For instance, if this entity's {@link Entity#getType()} is {@link ProductBundleImpl}, then the result will be:
-     * 
-     * [org.broadleafcommerce.core.catalog.domain.ProductBundleImpl, org.broadleafcommerce.core.catalog.domain.ProductImpl]
-     * 
-     * @param entity
-     * @return
-     */
-    protected List<String> getTypeHierarchy(Entity entity) {
-        List<String> types = new ArrayList<String>();
-        Class<?> myType;
-        try {
-            myType = Class.forName(entity.getType()[0]);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-        types.add(myType.getName());
-        boolean eof = false;
-        while (!eof) {
-            myType = myType.getSuperclass();
-            if (myType != null && !myType.getName().equals(Object.class.getName())) {
-                types.add(myType.getName());
-            } else {
-                eof = true;
-            }
-        }
-        return types;
-    }
+	/**
+	 * <p>
+	 * Returns the type hierarchy of the given <b>entity</b> in ascending order of type, stopping at Object
+	 * 
+	 * <p>
+	 * For instance, if this entity's {@link Entity#getType()} is {@link ProductBundleImpl}, then the result will be:
+	 * 
+	 * [org.broadleafcommerce.core.catalog.domain.ProductBundleImpl,
+	 * org.broadleafcommerce.core.catalog.domain.ProductImpl]
+	 * 
+	 * @param entity
+	 * @return
+	 */
+	protected List<String> getTypeHierarchy(Entity entity) {
+		List<String> types = new ArrayList<String>();
+		Class<?> myType;
+		try {
+			myType = Class.forName(entity.getType()[0]);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+		types.add(myType.getName());
+		boolean eof = false;
+		while (!eof) {
+			myType = myType.getSuperclass();
+			if (myType != null && !myType.getName().equals(Object.class.getName())) {
+				types.add(myType.getName());
+			} else {
+				eof = true;
+			}
+		}
+		return types;
+	}
 
-    @Override
-    public List<GlobalPropertyValidator> getGlobalEntityValidators() {
-        return globalEntityValidators;
-    }
+	@Override
+	public List<GlobalPropertyValidator> getGlobalEntityValidators() {
+		return globalEntityValidators;
+	}
 
-    @Override
-    public void setGlobalEntityValidators(List<GlobalPropertyValidator> globalEntityValidators) {
-        this.globalEntityValidators = globalEntityValidators;
-    }
+	@Override
+	public void setGlobalEntityValidators(List<GlobalPropertyValidator> globalEntityValidators) {
+		this.globalEntityValidators = globalEntityValidators;
+	}
 }


### PR DESCRIPTION
**Changes**
Removed references to FormFox
Formatted EntityValidatorService

**A Brief Overview**
This required for custom validators to live in alternative packages.  Originally a interface where public is inherited.

**Background**
Checking into 5.2.x because I did not see the class in 5.3.x, 5.4.x, and 6.0.x