### PR TITLE
Incorrectly sending transactions to Google Analytics on "reorder" page

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafOrderConfirmationController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/checkout/BroadleafOrderConfirmationController.java
@@ -47,6 +47,7 @@ public class BroadleafOrderConfirmationController extends BroadleafAbstractContr
                 extensionManager.getProxy().processAdditionalConfirmationActions(order);
 
                 model.addAttribute("order", order);
+                model.addAttribute("analyticsOrder", order);
                 return getOrderConfirmationView();
             }
         }
@@ -63,6 +64,7 @@ public class BroadleafOrderConfirmationController extends BroadleafAbstractContr
                 extensionManager.getProxy().processAdditionalConfirmationActions(order);
 
                 model.addAttribute("order", order);
+                model.addAttribute("analyticsOrder", order);
                 return getOrderConfirmationView();
             }
         }


### PR DESCRIPTION
BroadleafCommerce/QA#3257
Google analytics on reorder is sent which is wrong
Change model attribute name and do correspongin changes in UI