### PR TITLE
Added property to allow sorting on a Product's parent Category to be disabled in the Admin due to unresolvable issues.

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
@@ -1,3 +1,20 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2019 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
 package org.broadleafcommerce.admin.web.controller.extension;
 
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
@@ -35,9 +35,9 @@ public class ParentCategorySortExtensionHandler extends AbstractFormBuilderExten
             for (Field f : listGrid.getHeaderFields()) {
                 if (f.getName().equals("defaultCategory")) {
                     f.setFilterSortDisabled(true);
+                    return ExtensionResultStatusType.HANDLED;
                 }
             }
-            return ExtensionResultStatusType.HANDLED;
         }
         return ExtensionResultStatusType.NOT_HANDLED;
     }

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/extension/ParentCategorySortExtensionHandler.java
@@ -1,0 +1,44 @@
+package org.broadleafcommerce.admin.web.controller.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.core.catalog.domain.Product;
+import org.broadleafcommerce.openadmin.web.form.component.ListGrid;
+import org.broadleafcommerce.openadmin.web.form.entity.Field;
+import org.broadleafcommerce.openadmin.web.service.AbstractFormBuilderExtensionHandler;
+import org.broadleafcommerce.openadmin.web.service.FormBuilderExtensionManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+@Service("blParentCategorySortExtensionHandler")
+public class ParentCategorySortExtensionHandler extends AbstractFormBuilderExtensionHandler {
+
+
+    @Value("${allow.product.parent.category.sorting:false}")
+    protected boolean allowProductParentCategorySorting = false;
+
+    @Resource(name = "blFormBuilderExtensionManager")
+    protected FormBuilderExtensionManager extensionManager;
+
+    @PostConstruct
+    public void init() {
+        if (isEnabled()) {
+            extensionManager.registerHandler(this);
+        }
+    }
+
+    @Override
+    public ExtensionResultStatusType modifyListGrid(String className, ListGrid listGrid) {
+        if (Product.class.getName().equals(className) && !allowProductParentCategorySorting) {
+            for (Field f : listGrid.getHeaderFields()) {
+                if (f.getName().equals("defaultCategory")) {
+                    f.setFilterSortDisabled(true);
+                }
+            }
+            return ExtensionResultStatusType.HANDLED;
+        }
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
+}

--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -197,3 +197,7 @@ seo.category.description.pattern='Shop ' + category.name + ' at ' + #seoElement.
 
 # Determines whether to use HTTPS cookie over HTTPS connection or HTTP only
 cookies.use.secure=true
+
+# Allow sorting of product by parent category.
+# Bt default false(not allow).
+allow.product.parent.category.sorting=true

--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -73,6 +73,13 @@ staticResourceBrowserCacheSeconds=31536000
 
 # Settings to control resource minification
 minify.enabled=true
+#deprecated
+minify.allowSingleMinification=false
+minify.linebreak=-1
+minify.munge=true
+minify.verbose=false
+minify.preserveAllSemiColons=true
+minify.disableOptimizations=false
 
 # Settings for the Closure Compiler https://developers.google.com/closure/compiler/
 # Currently supports only following properties

--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -200,4 +200,4 @@ cookies.use.secure=true
 
 # Allow sorting of product by parent category.
 # Bt default false(not allow).
-allow.product.parent.category.sorting=true
+allow.product.parent.category.sorting=false

--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -73,13 +73,6 @@ staticResourceBrowserCacheSeconds=31536000
 
 # Settings to control resource minification
 minify.enabled=true
-#deprecated
-minify.allowSingleMinification=false
-minify.linebreak=-1
-minify.munge=true
-minify.verbose=false
-minify.preserveAllSemiColons=true
-minify.disableOptimizations=false
 
 # Settings for the Closure Compiler https://developers.google.com/closure/compiler/
 # Currently supports only following properties
@@ -199,5 +192,6 @@ seo.category.description.pattern='Shop ' + category.name + ' at ' + #seoElement.
 cookies.use.secure=true
 
 # Allow sorting of product by parent category.
-# Bt default false(not allow).
-allow.product.parent.category.sorting=false
+# By default setting to true
+allow.product.parent.category.sorting=true
+


### PR DESCRIPTION
For BroadleafCommerce/QA#1292

To disable sorting, set `allow.product.parent.category.sorting=false`. In order not to cause unexpected changes in client environments, the default is `true`.