### PR TITLE
Fix startup error when deploying to Tomcat as a WAR

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/ThemeUrlEncodingFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/ThemeUrlEncodingFilter.java
@@ -19,12 +19,13 @@ package org.broadleafcommerce.common.web;
 
 import org.broadleafcommerce.common.admin.condition.ConditionalOnNotAdmin;
 import org.broadleafcommerce.common.site.domain.Theme;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter;
 
 import java.io.IOException;
 
-import javax.annotation.Resource;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -37,7 +38,8 @@ import javax.servlet.http.HttpServletResponseWrapper;
 @ConditionalOnNotAdmin
 public class ThemeUrlEncodingFilter extends ResourceUrlEncodingFilter {
 
-    @Resource(name = "blThemeResolver")
+    @Autowired
+    @Qualifier("blThemeResolver")
     protected BroadleafThemeResolver themeResolver;
 
     @Override
@@ -60,6 +62,7 @@ public class ThemeUrlEncodingFilter extends ResourceUrlEncodingFilter {
             this.themeResolver = themeResolver;
         }
 
+        @Override
         public String encodeURL(String url) {
             BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
             Theme theme = this.themeResolver.resolveTheme(brc.getWebRequest());


### PR DESCRIPTION
Changed `@Resource` to `@Autowired` and `@Qualifier` to prevent Tomcat from trying to look up `blThemeResolver` as a Tomcat resource.

Without this change when you try to deploy the application as a WAR with Tomcat you get the following exception on startup.

```
31-Jul-2019 15:40:29.885 SEVERE [localhost-startStop-1] org.apache.catalina.core.StandardContext.filterStart Exception starting filter [themeUrlEncodingFilter]
	javax.naming.NameNotFoundException: Name [blThemeResolver] is not bound in this Context. Unable to find [blThemeResolver].
		at org.apache.naming.NamingContext.lookup(NamingContext.java:816)
		at org.apache.naming.NamingContext.lookup(NamingContext.java:173)
		at org.apache.catalina.core.DefaultInstanceManager.lookupFieldResource(DefaultInstanceManager.java:587)
		at org.apache.catalina.core.DefaultInstanceManager.processAnnotations(DefaultInstanceManager.java:487)
		at org.apache.catalina.core.DefaultInstanceManager.newInstance(DefaultInstanceManager.java:174)
		at org.apache.catalina.core.DefaultInstanceManager.newInstance(DefaultInstanceManager.java:166)
		at org.apache.catalina.core.ApplicationFilterConfig.<init>(ApplicationFilterConfig.java:111)
		at org.apache.catalina.core.StandardContext.filterStart(StandardContext.java:4546)
		at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5191)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
		at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:743)
		at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:719)
		at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:714)
		at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:970)
		at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1841)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
		at java.lang.Thread.run(Thread.java:748)
```