### PR TITLE
 fix exception when reverting new product

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/applicationContext-servlet-open-admin.xml
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/applicationContext-servlet-open-admin.xml
@@ -40,6 +40,7 @@
 
     <bean id="blAdminExceptionResolver" class="org.broadleafcommerce.openadmin.web.handler.AdminMappingExceptionResolver">
         <property name="showDebugMessage" value="${exception.showDebugMessage}" />
+        <property name="order" value="#{T(org.springframework.core.Ordered).LOWEST_PRECEDENCE - 50}" />
     </bean>
     
     <bean id="blAdminTranslationControllerExtensionListeners" class="org.springframework.beans.factory.config.ListFactoryBean">


### PR DESCRIPTION
**A Brief Overview**
The problem was in ordering in exception resolver. BroadleafSimpleMappingExceptionResolver was resolving an EntityNotFoundException before of
AdminMappingExceptionResolver.

**Link**
QA-3285 - https://github.com/BroadleafCommerce/QA/issues/3191
