### PR TITLE
Fixed bug where category sequence was calculated incorrectly

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
@@ -526,10 +526,13 @@
         },
 
         getActualRowIndex : function($tr) {
-            var trPlacementTop = $tr.position().top;
-            var rowHeight = this.getRowHeight($tr.closest('tbody'));
-            // The division should produce an integer, assuming the row heights are consistent.
-            return trPlacementTop / rowHeight;
+            var targetRow = $tr[0];
+            var rows = $tr.closest('tbody').find('tr');
+            for(var i = 0; i < rows.length; i++){
+                if(rows[i].isSameNode(targetRow)){
+                    return i;
+                }
+            }
         },
         
         getTopVisibleIndex : function($tbody) {


### PR DESCRIPTION
**A Brief Overview**
Fixes calculation of row index on a listgrid.

**Additional context**
https://github.com/BroadleafCommerce/QA/issues/3743 
