### PR TITLE
Fix product options performance issue on product form

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -273,7 +273,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
         }
     }
 
-    private String getOwningProductId(SectionCrumb[] sectionCrumbs) {
+    protected String getOwningProductId(SectionCrumb[] sectionCrumbs) {
         if (ArrayUtils.isNotEmpty(sectionCrumbs) && ProductImpl.class.getCanonicalName()
                 .equals(sectionCrumbs[0].getSectionIdentifier())) {
             return sectionCrumbs[0].getSectionId();

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -25,6 +25,7 @@ import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.admin.server.service.SkuMetadataCacheService;
@@ -36,6 +37,7 @@ import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.sandbox.SandBoxHelper;
 import org.broadleafcommerce.common.util.BLCCollectionUtils;
+import org.broadleafcommerce.common.util.StringUtil;
 import org.broadleafcommerce.common.util.TypedTransformer;
 import org.broadleafcommerce.common.util.dao.DynamicDaoHelperImpl;
 import org.broadleafcommerce.core.catalog.domain.Product;
@@ -196,10 +198,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
             PersistencePerspective persistencePerspective = persistencePackage.getPersistencePerspective();
             Map<MergedPropertyType, Map<String, FieldMetadata>> allMergedProperties = new HashMap<>();
 
-            String productIdStr = null;
-            if (persistencePackage.getCustomCriteria() != null && persistencePackage.getCustomCriteria().length > 0) {
-                productIdStr = persistencePackage.getCustomCriteria()[0];
-            }
+            String productIdStr = getOwningProductId(persistencePackage.getSectionCrumbs());
             String cacheKey = skuMetadataCacheService.buildCacheKey(productIdStr);
 
             Map<String, FieldMetadata> properties = null;
@@ -211,9 +210,9 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
                 //Grab the default properties for the Sku
                 properties = helper.getSimpleMergedProperties(SkuImpl.class.getName(), persistencePerspective);
 
-                boolean isFirstCriteriaNAN = persistencePackage.getCustomCriteria() == null || persistencePackage.getCustomCriteria().length == 0;
+                boolean isFirstCriteriaNAN = productIdStr == null;
                 if (!isFirstCriteriaNAN && useToOneLookupSkuProductOptionValue) {
-                    isFirstCriteriaNAN = !DIGIT.matchesAllOf(persistencePackage.getCustomCriteria()[0]);
+                    isFirstCriteriaNAN = !NumberUtils.isParsable(productIdStr);
                 }
                 if (isFirstCriteriaNAN) {
                     //look up all the ProductOptions and then create new fields for each of them
@@ -229,7 +228,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
                 } else {
                     // If we have a product to filter the list of available product options, then use it
                     try {
-                        Long productId = Long.parseLong(persistencePackage.getCustomCriteria()[0]);
+                        Long productId = Long.parseLong(productIdStr);
                         Product product = catalogService.findProductById(productId);
                         for (ProductOption option : product.getProductOptions()) {
                             FieldMetadata md = createIndividualOptionField(option, 0);
@@ -238,7 +237,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
                             }
                         }
                     } catch (NumberFormatException e) {
-                        // the criteria wasn't a product id, just don't do anything
+                        // there wasn't a valid product id, just don't do anything
                     }
                 }
 
@@ -272,6 +271,14 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
                     persistencePackage.getCeilingEntityFullyQualifiedClassname(), e);
             throw ex;
         }
+    }
+
+    private String getOwningProductId(SectionCrumb[] sectionCrumbs) {
+        if (ArrayUtils.isNotEmpty(sectionCrumbs) && ProductImpl.class.getCanonicalName()
+                .equals(sectionCrumbs[0].getSectionIdentifier())) {
+            return sectionCrumbs[0].getSectionId();
+        }
+        return null;
     }
 
     protected void filterOutProductMetadata(Map<String, FieldMetadata> map) {


### PR DESCRIPTION
**A Brief Overview**
When retrieving Product Options to be used in Sku display on a product form, the product ID to retrieve product options for was not being retrieved correctly. This fix updates the product ID to be retrieved from the section ID instead of a custom criteria.

Another cause of this issue is more general - when properties are being extracted from metadata, the properties list was being sorted every single time a property was added. That happened _in addition_ to already doing a binary search to find the position where the property should be inserted, and then that position is just ignored. Instead, this fix will sort any pre-existing properties initially, and then any additional properties added will be placed into the correct sorted position based on the binary search.

**QA Issue**
https://github.com/BroadleafCommerce/QA/issues/3757
