### PR TITLE
Upgraded Xstream from 1.3.1 to 1.4.11.1 due to published security issue (CVE-2013-7285)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -817,7 +817,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.3.1</version>
+                <version>1.4.11.1</version>
                 <type>jar</type>
                 <scope>runtime</scope>
             </dependency>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/3759
