### PR TITLE
remove PaymentTransaction from purge

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDao.java
@@ -59,6 +59,8 @@ public interface OrderDao {
 
     void delete(Order order);
 
+    void deleteOrderWithoutTransactions(Order salesOrder);
+
     Order submitOrder(Order cartOrder);
 
     Order create();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -184,6 +184,14 @@ public class OrderDaoImpl implements OrderDao {
 
         em.remove(salesOrder);
     }
+    @Override
+    public void deleteOrderWithoutTransactions(Order salesOrder) {
+        if (!em.contains(salesOrder)) {
+            salesOrder = readOrderById(salesOrder.getId());
+        }
+
+        em.remove(salesOrder);
+    }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderService.java
@@ -541,6 +541,8 @@ public interface OrderService {
 
     public void deleteOrder(Order cart);
 
+    void deleteOrderWithoutTransactions(Order order);
+
     Order removeInactiveItems(Long orderId, boolean priceOrder) throws RemoveFromCartException;
 
     /**

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -442,6 +442,13 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional("blTransactionManager")
+    public void deleteOrderWithoutTransactions(Order order) {
+        orderMultishipOptionService.deleteAllOrderMultishipOptions(order);
+        orderDao.deleteOrderWithoutTransactions(order);
+    }
+
+    @Override
+    @Transactional("blTransactionManager")
     public Order addOfferCode(Order order, OfferCode offerCode, boolean priceOrder) throws PricingException, OfferException {
         ArrayList<OfferCode> offerCodes = new ArrayList<OfferCode>();
         offerCodes.add(offerCode);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/service/ResourcePurgeServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/service/ResourcePurgeServiceImpl.java
@@ -225,7 +225,7 @@ public class ResourcePurgeServiceImpl implements ResourcePurgeService {
      */
     protected void deleteCart(Order cart) {
         //We delete the order this way (rather than with a delete query) in order to ensure the cascades take place
-        orderService.deleteOrder(cart);
+        orderService.deleteOrderWithoutTransactions(cart);
     }
 
     /**


### PR DESCRIPTION

**A Brief Overview**
Delete order without PaymentTransaction for save history.

**Issue Link**
QA-3405 - https://github.com/BroadleafCommerce/QA/issues/3405

