### PR TITLE
Fixed an issue where Read only table still allows reorder edits

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -203,7 +203,7 @@
                             <a href="#" class="sub-list-grid-reorder"
                                style="visibility: hidden;"
                                th:if="${headerFieldStat.first} and ${listGrid.isSortable()}"
-                               th:unless="${isLookup}">
+                               th:unless="${isLookup} or ${listGrid.getIsReadOnly()}">
                                 <i class="fa fa-arrows-v fa-lg"></i>
                             </a>
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/3183

I have removed drag-and-drop if listgrid. isReadOnly = true