### PR TITLE
NameResponse inner class without getters and Setters #3767

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/service/OrderToPaymentRequestDTOServiceImpl.java
@@ -18,6 +18,11 @@
 
 package org.broadleafcommerce.core.payment.service;
 
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,10 +41,7 @@ import org.broadleafcommerce.profile.core.domain.Address;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Resource;
+import lombok.Data;
 
 /**
  * Service that translates various pieces of information such as:
@@ -340,6 +342,7 @@ public class OrderToPaymentRequestDTOServiceImpl implements OrderToPaymentReques
         requestDTO.orderSubtotal(subtotal);
     }
     
+    @Data
     public class NameResponse {
         protected String firstName;
         protected String lastName;


### PR DESCRIPTION
The class
OrderToPaymentRequestDTOServiceImpl containes a inner class called NameResponse which contains firstName and lastName as protected fields.
The inner class has no getters and setters on it's memeber so when trying to extend that class there is no wahy to change the state of the inner class.

Just try to extend OrderToPaymentRequestDTOServiceImpl

Link to HelpScout
https://secure.helpscout.net/conversation/968506277/37884?folderId=2485392

As a workaround.... is possible to create a bean extending OrderToPaymentRequestDTOService, copying the the content of OrderToPaymentRequestDTOServiceImpl and changing the NameResponse innerclass.