### PR TITLE
Register SkuProductOptionValueXref bean & Add Sku Generation logging

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -106,8 +106,10 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             }
         }
 
+        LOG.info("Total number of permutations to generate: " + permutationsToGenerate.size());
+
         int numPermutationsCreated = 0;
-        if (extensionManager != null) {
+        if (extensionManager != null && CollectionUtils.isNotEmpty(permutationsToGenerate)) {
             ExtensionResultHolder<Integer> result = new ExtensionResultHolder<Integer>();
             ExtensionResultStatusType resultStatusType = extensionManager.getProxy().persistSkuPermutation(product, permutationsToGenerate, result);
             if (ExtensionResultStatusType.HANDLED == resultStatusType) {
@@ -115,7 +117,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             }
         }
 
-        LOG.info("Finished creating " + allPermutations.size() + " permutations.");
+        LOG.info("Total number of permutations generated: " + numPermutationsCreated);
 
         return numPermutationsCreated;
     }

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -114,6 +114,9 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
                 numPermutationsCreated = result.getResult();
             }
         }
+
+        LOG.info("Finished creating " + allPermutations.size() + " permutations.");
+
         return numPermutationsCreated;
     }
 

--- a/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/product.js
+++ b/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/product.js
@@ -46,7 +46,15 @@
 $(document).ready(function() {
     
     $('body').on('click', 'button.generate-skus', function() {
-        var $container = $(this).closest('div.listgrid-container');
+        var $skuGenerationButton = $(this);
+        var $container = $skuGenerationButton.closest('div.listgrid-container');
+
+        $skuGenerationButton.prop("disabled", true);
+        BLCAdmin.listGrid.showAlert($container, "Generating SKUs...", {
+            alertType: 'save-alert',
+            clearOtherAlerts: true,
+            autoClose: 8000
+        });
         
         BLC.ajax({
             url : $(this).data('actionurl'),
@@ -63,6 +71,8 @@ $(document).ready(function() {
             if (data.skusGenerated > 0) {
                 BLCAdmin.product.refreshSkusGrid($container, data.listGridUrl);
             }
+
+            $skuGenerationButton.prop("disabled", false);
         });
         
         return false;

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-entity.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-entity.xml
@@ -58,6 +58,7 @@
     <bean id="org.broadleafcommerce.core.catalog.domain.SkuBundleItem" class="org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl" scope="prototype" />
     <bean id="org.broadleafcommerce.core.catalog.domain.Sku" class="org.broadleafcommerce.core.catalog.domain.SkuImpl" scope="prototype"/>
     <bean id="org.broadleafcommerce.core.catalog.domain.SkuAttribute" class="org.broadleafcommerce.core.catalog.domain.SkuAttributeImpl" scope="prototype"/>
+    <bean id="org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXref" class="org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXrefImpl" scope="prototype"/>
     <bean id="org.broadleafcommerce.core.catalog.domain.SkuFee" class="org.broadleafcommerce.core.catalog.domain.SkuFeeImpl" scope="prototype"/>
     <bean id="org.broadleafcommerce.core.catalog.domain.ProductOptionXref" class="org.broadleafcommerce.core.catalog.domain.ProductOptionXrefImpl" scope="prototype" />
     <bean id="org.broadleafcommerce.core.payment.domain.secure.BankAccountPayment" class="org.broadleafcommerce.core.payment.domain.secure.BankAccountPaymentImpl" scope="prototype"/>


### PR DESCRIPTION
**A Brief Overview**
- Register SkuProductOptionValueXref bean so that it can be used to determine the implementing class
- Add logging to the end of the Sku generation process to mark the end & communicate execution time

**Link to QA issue**
(https://github.com/BroadleafCommerce/QA/issues/3771)
