### PR TITLE
Refactor default CustomerAddressService/DAO logic to improve performance

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafManageCustomerAddressesController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/account/BroadleafManageCustomerAddressesController.java
@@ -79,9 +79,6 @@ public class BroadleafManageCustomerAddressesController extends AbstractCustomer
         customerAddress.setAddressName(form.getAddressName());
         customerAddress.setCustomer(CustomerState.getCustomer());
         customerAddress = customerAddressService.saveCustomerAddress(customerAddress);
-        if (form.getAddress().isDefault()) {
-            customerAddressService.makeCustomerAddressDefault(customerAddress.getId(), customerAddress.getCustomer().getId());
-        }
 
         form.setCustomerAddressId(customerAddress.getId());
 
@@ -121,10 +118,8 @@ public class BroadleafManageCustomerAddressesController extends AbstractCustomer
 
         customerAddress.setAddress(form.getAddress());
         customerAddress.setAddressName(form.getAddressName());
-        customerAddress = customerAddressService.saveCustomerAddress(customerAddress);
-        if (form.getAddress().isDefault()) {
-            customerAddressService.makeCustomerAddressDefault(customerAddress.getId(), customerAddress.getCustomer().getId());
-        }
+        customerAddressService.saveCustomerAddress(customerAddress);
+
         redirectAttributes.addFlashAttribute("successMessage", getAddressUpdatedMessage());
         return getCustomerAddressesRedirect();
     }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDao.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDao.java
@@ -23,21 +23,23 @@ import java.util.List;
 
 public interface CustomerAddressDao {
 
-    public List<CustomerAddress> readActiveCustomerAddressesByCustomerId(Long customerId);
+    List<CustomerAddress> readActiveCustomerAddressesByCustomerId(Long customerId);
 
-    public CustomerAddress save(CustomerAddress customerAddress);
+    CustomerAddress save(CustomerAddress customerAddress);
 
-    public CustomerAddress readCustomerAddressById(Long customerAddressId);
+    CustomerAddress readCustomerAddressById(Long customerAddressId);
 
-    public void makeCustomerAddressDefault(Long customerAddressId, Long customerId);
+    CustomerAddress readCustomerAddressByIdAndCustomerId(Long customerAddressId, Long customerId);
 
-    public void deleteCustomerAddressById(Long customerAddressId);
+    void makeCustomerAddressDefault(Long customerAddressId, Long customerId);
 
-    public CustomerAddress findDefaultCustomerAddress(Long customerId);
+    void deleteCustomerAddressById(Long customerAddressId);
 
-    public CustomerAddress create();
+    CustomerAddress findDefaultCustomerAddress(Long customerId);
 
-    public List<CustomerAddress> readBatchCustomerAddresses(int start, int pageSize);
+    CustomerAddress create();
+
+    List<CustomerAddress> readBatchCustomerAddresses(int start, int pageSize);
 
     Long readNumberOfAddresses();
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDaoImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDaoImpl.java
@@ -23,6 +23,7 @@ import org.broadleafcommerce.profile.core.domain.CustomerAddressImpl;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Resource;
@@ -32,6 +33,7 @@ import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 @Repository("blCustomerAddressDao")
@@ -51,10 +53,12 @@ public class CustomerAddressDaoImpl implements CustomerAddressDao {
         return query.getResultList();
     }
 
+    @Override
     public CustomerAddress save(CustomerAddress customerAddress) {
             return em.merge(customerAddress);
     }
 
+    @Override
     public CustomerAddress create() {
         return (CustomerAddress) entityConfiguration.createEntityInstance(CustomerAddress.class.getName());
     }
@@ -85,18 +89,52 @@ public class CustomerAddressDaoImpl implements CustomerAddressDao {
         return query.getSingleResult();
     }
 
+    @Override
     public CustomerAddress readCustomerAddressById(Long customerAddressId) {
         return (CustomerAddress) em.find(CustomerAddressImpl.class, customerAddressId);
     }
 
+    @Override
     public void makeCustomerAddressDefault(Long customerAddressId, Long customerId) {
-        List<CustomerAddress> customerAddresses = readActiveCustomerAddressesByCustomerId(customerId);
-        for (CustomerAddress customerAddress : customerAddresses) {
-            customerAddress.getAddress().setDefault(customerAddress.getId().equals(customerAddressId));
-            em.merge(customerAddress);
+        // Throws a RuntimeException if the CustomerAddress is not found
+        CustomerAddress customerAddress = readCustomerAddressByIdAndCustomerId(customerAddressId, customerId);
+
+        if (customerAddress != null) {
+            clearDefaultAddressForCustomer(customerId);
+
+            em.refresh(customerAddress);
+            customerAddress.getAddress().setDefault(true);
+
+            save(customerAddress);
         }
     }
 
+    @Override
+    public CustomerAddress readCustomerAddressByIdAndCustomerId(Long customerAddressId, Long customerId) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<CustomerAddress> criteria = builder.createQuery(CustomerAddress.class);
+        Root<CustomerAddressImpl> customerAddress = criteria.from(CustomerAddressImpl.class);
+        criteria.select(customerAddress);
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(builder.equal(customerAddress.get("id"), customerAddressId));
+        predicates.add(builder.equal(customerAddress.get("customer").get("id"), customerId));
+
+        criteria.where(builder.and(predicates.toArray(new Predicate[predicates.size()])));
+        TypedQuery<CustomerAddress> query = em.createQuery(criteria);
+        query.setHint(QueryHints.HINT_CACHEABLE, true);
+        query.setHint(QueryHints.HINT_CACHE_REGION, "query.CustomerAddress");
+
+        return query.getSingleResult();
+    }
+
+    protected void clearDefaultAddressForCustomer(Long customerId) {
+        Query update = em.createNamedQuery("BC_CLEAR_DEFAULT_ADDRESS_BY_CUSTOMER_ID");
+        update.setParameter("customerId", customerId);
+        update.executeUpdate();
+    }
+
+    @Override
     public void deleteCustomerAddressById(Long customerAddressId) {
         CustomerAddress customerAddress = readCustomerAddressById(customerAddressId);
         if (customerAddress != null) {
@@ -105,6 +143,7 @@ public class CustomerAddressDaoImpl implements CustomerAddressDao {
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public CustomerAddress findDefaultCustomerAddress(Long customerId) {
         Query query = em.createNamedQuery("BC_FIND_DEFAULT_ADDRESS_BY_CUSTOMER_ID");
         query.setParameter("customerId", customerId);

--- a/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/CustomerAddress.orm.xml
+++ b/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/CustomerAddress.orm.xml
@@ -34,5 +34,15 @@
         WHERE ca.customer.id = :customerId
         AND ca.address.isDefault = TRUE</query>
     </named-query>
+
+    <named-query name="BC_CLEAR_DEFAULT_ADDRESS_BY_CUSTOMER_ID" >
+        <query>UPDATE org.broadleafcommerce.profile.core.domain.Address a
+            SET a.isDefault = false
+            WHERE a.id in (
+                SELECT ca.address.id FROM org.broadleafcommerce.profile.core.domain.CustomerAddress ca
+                WHERE ca.customer.id = :customerId AND ca.address.isDefault = TRUE
+            )
+        </query>
+    </named-query>
     
 </entity-mappings>

--- a/integration/src/test/java/org/broadleafcommerce/profile/web/core/service/CustomerAddressTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/profile/web/core/service/CustomerAddressTest.java
@@ -32,8 +32,9 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 import org.testng.annotations.Test;
 
-import javax.annotation.Resource;
 import java.util.List;
+
+import javax.annotation.Resource;
 
 public class CustomerAddressTest extends CommonSetupBaseTest {
 
@@ -54,9 +55,9 @@ public class CustomerAddressTest extends CommonSetupBaseTest {
     }
     
     @Test(groups = "testCustomerAddress")
-    @Transactional
     public void createNewDefaultAddress() {
         Customer customer = createCustomerWithAddresses();
+
         CustomerAddress ca = new CustomerAddressImpl();
         Address address = new AddressImpl();
         address.setAddressLine1("123 Main");
@@ -66,8 +67,8 @@ public class CustomerAddressTest extends CommonSetupBaseTest {
         ca.setAddress(address);
         ca.setCustomer(customer);
         ca.setAddressName("address3");
-        CustomerAddress savedAddress = saveCustomerAddress(ca);
-        
+        CustomerAddress savedAddress = customerAddressService.saveCustomerAddress(ca);
+
         List<CustomerAddress> customerAddressList = customerAddressService.readActiveCustomerAddressesByCustomerId(customer.getId());
         for (CustomerAddress customerAddress : customerAddressList) {
             if (customerAddress.getId().equals(savedAddress.getId())) {

--- a/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
@@ -121,6 +121,11 @@ public abstract class CommonSetupBaseTest extends TestNGSiteIntegrationSetup {
     public Customer createCustomerWithAddresses() {
         createCountry();
         createState();
+
+        Customer customer = createCustomer();
+        customer.setUsername(String.valueOf(customer.getId()));
+        customer = customerService.saveCustomer(customer);
+
         CustomerAddress ca1 = new CustomerAddressImpl();
         Address address1 = new AddressImpl();
         address1.setAddressLine1("1234 Merit Drive");
@@ -128,10 +133,9 @@ public abstract class CommonSetupBaseTest extends TestNGSiteIntegrationSetup {
         address1.setPostalCode("75251");
         ca1.setAddress(address1);
         ca1.setAddressName("address1");
-        CustomerAddress caResult = createCustomerWithAddress(ca1);
-        assert caResult != null;
-        assert caResult.getCustomer() != null;
-        Customer customer = caResult.getCustomer();
+        ca1.setCustomer(customer);
+        CustomerAddress addResult1 = customerAddressService.saveCustomerAddress(ca1);
+        assert addResult1 != null;
 
         CustomerAddress ca2 = new CustomerAddressImpl();
         Address address2 = new AddressImpl();
@@ -141,8 +145,9 @@ public abstract class CommonSetupBaseTest extends TestNGSiteIntegrationSetup {
         ca2.setAddress(address2);
         ca2.setAddressName("address2");
         ca2.setCustomer(customer);
-        CustomerAddress addResult = saveCustomerAddress(ca2);
-        assert addResult != null;
+        CustomerAddress addResult2 = customerAddressService.saveCustomerAddress(ca2);
+        assert addResult2 != null;
+
         return customer;
     }
     


### PR DESCRIPTION
**A Brief Overview**
- Refactor makeCustomerAddressDefault(...) to reduce the potentially large amount of update statements that could be executed due to the em.merge(...) calls
- Update CustomerAddressService#saveCustomerAddress(...) logic around the setting of a default address & remove unnecessary calls to CustomerAddressService#makeCustomerAddressDefault(...) after calling saveCustomerAddress(...)

https://github.com/BroadleafCommerce/QA/issues/3784