### PR TITLE
Fixes the issue where a ThemeDTO returns an uninitialized Object and crashes the site application #2180 uninitialized Long object causes NullPointerException

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/ThemeDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/ThemeDTO.java
@@ -25,7 +25,7 @@ public class ThemeDTO implements Theme {
 
     public String path = "";
     public String name = "";
-    public Long id;
+    public Long id=0;
     
     public ThemeDTO() {
         // empty constructor


### PR DESCRIPTION
**BUG**

NullPointerException due to a comparison on a null value in BroadleafThemeProcessor when running the site module (Issue: #2180).

The crash is due to [a comparison on the ID of a Null Object](https://github.com/BroadleafCommerce/BroadleafCommerce/blame/f2361835349b9ef2426d9c258b540f5613031d2e/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java#L55) introduced as part of some optimization task.

This comes from the [uninitialized Long object in ThemeDTO](https://github.com/BroadleafCommerce/BroadleafCommerce/blame/f2361835349b9ef2426d9c258b540f5613031d2e/common/src/main/java/org/broadleafcommerce/common/site/domain/ThemeDTO.java#L28).

I guess this happens when running the project without any custom configuration of the Theme.