### PR TITLE
Fixes xform template ordering during class transformation

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyClassTransformer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyClassTransformer.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -113,7 +114,7 @@ public class DirectCopyClassTransformer extends AbstractClassTransformer impleme
             String convertedClassName = className.replace('/', '.');
             ClassPool classPool = null;
             String xformKey = convertedClassName;
-            Set<String> buildXFormVals = new HashSet<>();
+            Set<String> buildXFormVals = new LinkedHashSet<>();
             Boolean[] xformSkipOverlaps = null;
             Boolean[] xformRenameMethodOverlaps = null;
             if (!xformTemplates.isEmpty()) {


### PR DESCRIPTION
**A Brief Overview**
During class transformation xform template values collected in HashSet, which not guaranteed, that objects to be inserted in same order.
Keeping record order is very important, because we match skip overlaps values with these records by index.

**Additional context**
BroadleafCommerce/QA#3790
