### PR TITLE
fix(theme): Made theme change detection null-safe

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/ThemeDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/ThemeDTO.java
@@ -10,12 +10,15 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.site.domain;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Stores the path to the theme.
@@ -26,11 +29,11 @@ public class ThemeDTO implements Theme {
     public String path = "";
     public String name = "";
     public Long id;
-    
+
     public ThemeDTO() {
         // empty constructor
     }
-    
+
     public ThemeDTO(String name, String path) {
         this.name = name;
         this.path = path;
@@ -60,4 +63,27 @@ public class ThemeDTO implements Theme {
         this.id = id;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || !getClass().isAssignableFrom(o.getClass())) {
+            return false;
+        }
+
+        ThemeDTO themeDTO = (ThemeDTO) o;
+
+        return new EqualsBuilder()
+                .append(getId(), themeDTO.getId())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getId())
+                .toHashCode();
+    }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
@@ -51,7 +51,7 @@ public class BroadleafThemeProcessor extends AbstractBroadleafWebRequestProcesso
         Theme newTheme = themeResolver.resolveTheme(request);
 
         //Track if the theme changed
-        if (originalTheme != null && newTheme != null && !Objects.equals(originalTheme, newTheme)) {
+        if (!Objects.equals(originalTheme, newTheme)) {
             Map<String, Object> properties = brc.getAdditionalProperties();
             properties.put(BroadleafThemeResolver.BRC_THEME_CHANGE_STATUS, true);
         }

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
@@ -51,7 +51,7 @@ public class BroadleafThemeProcessor extends AbstractBroadleafWebRequestProcesso
         Theme newTheme = themeResolver.resolveTheme(request);
 
         //Track if the theme changed
-        if (!Objects.equals(originalTheme, newTheme)) {
+        if (originalTheme != null && newTheme != null && !Objects.equals(originalTheme, newTheme)) {
             Map<String, Object> properties = brc.getAdditionalProperties();
             properties.put(BroadleafThemeResolver.BRC_THEME_CHANGE_STATUS, true);
         }

--- a/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/BroadleafThemeProcessor.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -25,11 +25,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.WebRequest;
 
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Resource;
 
 /**
- *
  * @author Stanislav Fedorov
  * @see {@link BroadleafThemeResolverFilter}
  */
@@ -46,18 +46,16 @@ public class BroadleafThemeProcessor extends AbstractBroadleafWebRequestProcesso
 
         BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
         Theme originalTheme = brc.getTheme();
-        
+
         // Note that this must happen after the request context is set up as resolving a theme is dependent on site
         Theme newTheme = themeResolver.resolveTheme(request);
-        
+
         //Track if the theme changed
-        if (originalTheme != null && newTheme != null) {
-            if (!originalTheme.getId().equals(newTheme.getId())) {
-                Map<String, Object> properties = brc.getAdditionalProperties();
-                properties.put(BroadleafThemeResolver.BRC_THEME_CHANGE_STATUS, true);
-            }
+        if (originalTheme != null && newTheme != null && !Objects.equals(originalTheme, newTheme)) {
+            Map<String, Object> properties = brc.getAdditionalProperties();
+            properties.put(BroadleafThemeResolver.BRC_THEME_CHANGE_STATUS, true);
         }
-        
+
         brc.setTheme(newTheme);
 
     }


### PR DESCRIPTION
Resolves https://github.com/BroadleafCommerce/QA/issues/3793

**Issue**
Detecting a changed theme results in NPE if the original `ThemeDTO` was created by `NullBroadleafThemeResolver`.

**Fix**
Added null-safe comparison of 2 `ThemeDTOs` with the objects' `equals` and `hashcode` instead of checking the IDs since one of the DTOs may be empty (i.e., would have a `null` ID).