### PR TITLE
Prevent leading 0s from being removed for text-list rule-builder

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -562,6 +562,7 @@
 
                                 $selectize.addOption({id: item, label: label});
                             }
+                            // leading 0s get stripped when converted to number
                             if (!isNaN(item) && !String(item).startsWith('0')) {
                                 $selectize.addItem(Number(item), false);
                             } else {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -562,7 +562,7 @@
 
                                 $selectize.addOption({id: item, label: label});
                             }
-                            if (!isNaN(item)) {
+                            if (!isNaN(item) && !String(item).startsWith('0')) {
                                 $selectize.addItem(Number(item), false);
                             } else {
                                 $selectize.addItem(item, false);


### PR DESCRIPTION
**A Brief Overview**

>The end result is the correct values are loaded in the database on the first time, but then on subsequent viewing of that segment, any value that started with a zero, is not shown on the list, and if that segment is changed (the main use case for viewing a segment after it's been created), the values that started with a zero are not displayed and if they are not "added back" with the changes, the items with the leading zero are removed from the segment. This is unexpected behavior for a TextList of FieldType String as we understand it and thus why I'm reaching out to you now.

**Problem that was fixed**

The problem is that when we convert value to Number it removes leading zero.

**Additional context**

[Link to HelpScout](https://secure.helpscout.net/conversation/990062758/38371?folderId=767981)

**Link to QA**
BroadleafCommerce/QA#3804
