### PR TITLE
Prevent leading 0s from being removed for text-list rule-builder

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -562,7 +562,8 @@
 
                                 $selectize.addOption({id: item, label: label});
                             }
-                            if (!isNaN(item)) {
+                            // leading 0s get stripped when converted to number
+                            if (!isNaN(item) && !String(item).startsWith('0')) {
                                 $selectize.addItem(Number(item), false);
                             } else {
                                 $selectize.addItem(item, false);


### PR DESCRIPTION
Cherry-picked from #2186 (5.3)

The problem is that when we convert value to Number it removes leading zero.

Resolves https://github.com/BroadleafCommerce/QA/issues/3804