### PR TITLE
Cannot upload an image from the Product page on community edition

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/web/controller/AdminAssetUploadController.java
@@ -136,7 +136,6 @@ public class AdminAssetUploadController extends AdminAbstractController {
         }
 
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.add("Content-Type", "text/html; charset=utf-8");
         return new ResponseEntity<Map<String, Object>>(responseMap, responseHeaders, HttpStatus.OK);
     }
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/assetSelector.js
@@ -36,11 +36,11 @@
                 'class' : 'upload_target hidden'
             });
             $form.before($iframe);
-            
+
             if (currentRedactor == null) {
-                $iframe.load(this.iframeOnLoad);
+                $iframe.on('load', this.iframeOnLoad);
             } else {
-                $iframe.load(this.iframeOnLoadRedactor);
+                $iframe.on('load', this.iframeOnLoadRedactor);
             }
 
             $form.attr('target', 'upload_target');


### PR DESCRIPTION
BroadleafCommerce/QA#3814

- changed to .on('load', fn) event handler for iframe in assetSelector.js instead of .load(fn). Since jquery 3.0, load fn is used for fetching data.
- Removed 'text/html' content type header from `upload` mapping as it produces 'application/json'