### PR TITLE
Fix issue where a customer can't add addresses when using MySQL

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDaoImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerAddressDaoImpl.java
@@ -129,9 +129,14 @@ public class CustomerAddressDaoImpl implements CustomerAddressDao {
         return query.getSingleResult();
     }
 
+    @SuppressWarnings("unchecked")
     protected void clearDefaultAddressForCustomer(Long customerId) {
-        Query update = em.createNamedQuery("BC_CLEAR_DEFAULT_ADDRESS_BY_CUSTOMER_ID");
-        update.setParameter("customerId", customerId);
+        // This has to be done in two queries because MySQL doesn't support updates on a table with a subquery on the same table
+        Query query = em.createNamedQuery("BC_READ_DEFAULT_ADDRESS_IDS_BY_CUSTOMER_ID");
+        query.setParameter("customerId", customerId);
+        List<Long> addressIds = query.getResultList();
+        Query update = em.createNamedQuery("BC_CLEAR_DEFAULT_ADDRESS_BY_IDS");
+        update.setParameter("addressIds", addressIds);
         update.executeUpdate();
     }
 

--- a/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/CustomerAddress.orm.xml
+++ b/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/CustomerAddress.orm.xml
@@ -35,14 +35,19 @@
         AND ca.address.isDefault = TRUE</query>
     </named-query>
 
-    <named-query name="BC_CLEAR_DEFAULT_ADDRESS_BY_CUSTOMER_ID" >
-        <query>UPDATE org.broadleafcommerce.profile.core.domain.Address a
+    <named-query name="BC_READ_DEFAULT_ADDRESS_IDS_BY_CUSTOMER_ID">
+    	<query>
+    		SELECT ca.address.id FROM org.broadleafcommerce.profile.core.domain.CustomerAddress ca
+    		WHERE ca.customer.id = :customerId AND ca.address.isDefault = TRUE
+    	</query>
+    </named-query>
+    
+    <named-query name="BC_CLEAR_DEFAULT_ADDRESS_BY_IDS">
+    	<query>
+    		UPDATE org.broadleafcommerce.profile.core.domain.Address a
             SET a.isDefault = false
-            WHERE a.id in (
-                SELECT ca.address.id FROM org.broadleafcommerce.profile.core.domain.CustomerAddress ca
-                WHERE ca.customer.id = :customerId AND ca.address.isDefault = TRUE
-            )
-        </query>
+            WHERE a.id in :addressIds
+    	</query>
     </named-query>
     
 </entity-mappings>


### PR DESCRIPTION
Break up update query to clear a customer's default address into a select and update query since the existing update query used a subquery that targeted the same table as the update query which is not allowed in MySQL.

Original error
`You can't specify target table 'BLC_ADDRESS' for update in FROM clause`

BroadleafCommerce/QA#3822