### PR TITLE
 Revert Hibernate 5.3 sequence generator strategy back to the old strategy

### DIFF
--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -23,6 +23,9 @@ detect.sequence.generator.inconsistencies=true
 #turn on auto correction of corrupt primary key generation configuration
 auto.correct.sequence.generator.inconsistencies=false
 
+#revert Hibernate 5.3 id sequencing back to pre Hibernate 5.3 functionality where the next id is stored and not the last
+hibernate.id.generator.stored_last_used=false
+
 #qualify unqualified table name with this schema name when performing sequence generator inconsistency detection
 default.schema.sequence.generator=
 


### PR DESCRIPTION
Add property that reverts Hibernate's strategy for sequence generators back to where it stores the next id instead of storing the last used id for better backwards compatibility support for upgrades

BroadleafCommerce/QA#3586