### PR TITLE
Adds missing functionality back to `entityForm-status` logic

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -189,8 +189,7 @@
                             if (ruleType !== BLCAdmin.RuleTypeEnum.RULE_WITH_QUANTITY) {
                                 jsonVal.data[i].quantity = null;
                             }
-                            BLCAdmin.ruleBuilders.constructQueryBuilder($ruleBuilderContainer, jsonVal.data[i],
-                                ruleBuilder.fields, ruleBuilder);
+                            BLCAdmin.ruleBuilders.constructQueryBuilder($ruleBuilderContainer, jsonVal.data[i], ruleBuilder.fields, ruleBuilder);
                         }
                     } else {
                         var qty = null;
@@ -198,8 +197,7 @@
                             qty = 1;
                         }
 
-                        BLCAdmin.ruleBuilders.constructQueryBuilder($ruleBuilderContainer, BLCAdmin.ruleBuilders.getEmptyRuleData(qty),
-                            ruleBuilder.fields, ruleBuilder);
+                        BLCAdmin.ruleBuilders.constructQueryBuilder($ruleBuilderContainer, BLCAdmin.ruleBuilders.getEmptyRuleData(qty), ruleBuilder.fields, ruleBuilder);
                     }
 
                     continue;
@@ -305,7 +303,7 @@
                 // in community, modal submit gets disabled when there is a validation error
                 $('.submit-button', $addEntityFormModal).prop('disabled', !this.getEntityFormChangesCount());
             }
-            
+
             // Grab all buttons we might want to enable/disable
             var $saveBtn = $('.sticky-container').find('.entity-form-actions').find('button.submit-button');
             var $promoteBtn = $('.sandbox-actions').find('.button a:contains("Promote")').parent();
@@ -533,11 +531,11 @@
             if (BLCAdmin.entityForm.status.getEntityFormChangesCount()) {
                 var message;
                 // If this is a `Promote` show the promote message
-                if ($(el).text() == 'Promote') {
+                if ($(el).text() === 'Promote') {
                     message = BLCAdmin.messages.promoteUnsavedChanges;
                 }
                 // Else, if this is an `Approve` show the approve message
-                else if ($(el).text() == 'Approve') {
+                else if ($(el).text() === 'Approve') {
                     message = BLCAdmin.messages.approveUnsavedChanges;
                 }
                 // Otherwise, this is another button on the ribbon, continue as normal
@@ -566,8 +564,13 @@
          * @returns {boolean}
          */
         checkIfShouldTrackChanges : function(el) {
-            if(el) {
+            if (el) {
                 var $element = $(el);
+
+                // if changes are explcitly tracked on this input, track it
+                if ($element.data('track-changes')) {
+                    return true;
+                }
 
                 // if this element is in an OMS tab, we don't want to track
                 if ($element.closest('.oms-tab').length) {
@@ -575,15 +578,12 @@
                 }
 
                 // Don't track if we are on an OMS page, in a modal, or not on a page with an entity form
-                if ($('.oms').length ||
-                    this.isParentModal(el) ||
-                    !$('.entity-form').length) {
+                if ($('.oms').length || this.isParentModal(el) || !$('.entity-form').length) {
                     return false;
                 }
 
                 // If this is a Selectize Adder or Collection input, we don't want to track as changes are auto-saved
-                if ($element.closest('.selectize-adder').length ||
-                    $element.closest('.selectize-collection').length) {
+                if ($element.closest('.selectize-adder').length ||  $element.closest('.selectize-collection').length) {
                     return false;
                 }
 
@@ -591,10 +591,12 @@
                 if ($element.closest('.field-group').find('.boolean-link').length) {
                     return false;
                 }
+
+                // Otherwise, track the changes
+                return true;
             }
 
-
-            return true;
+            return false;
         },
 
         /**
@@ -602,8 +604,8 @@
          * @param el
          * @returns {boolean}
          */
-        isParentModal : function(el){
-          return el && $(el).parents('.modal').length >= 1;
+        isParentModal : function(el) {
+            return el && $(el).parents('.modal').length >= 1;
         }
 
     };
@@ -683,7 +685,7 @@ $(document).ready(function() {
      * and presents a dialog asking if they are sure they want to leave.
      */
     $body.on('click', 'a.back-button, ul.nav-links a', function(event) {
-       BLCAdmin.entityForm.status.confirmLeaveEntityForm(this, event);
+        BLCAdmin.entityForm.status.confirmLeaveEntityForm(this, event);
     });
 
     /**


### PR DESCRIPTION
**A Brief Overview**
In a merge, functionality was removed from the `entityForm-status.js` file.  This PR adds that back in.

BroadleafCommerce/QA/issues/3863
