### PR TITLE
Fixes issue with bundled resource references having a hardcoded ID

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/AbstractResourceProcessor.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.common.web.processor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.resource.service.ResourceBundlingService;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.processor.attributes.ResourceTagAttributes;
 import org.broadleafcommerce.common.web.request.ResourcesRequest;
 import org.broadleafcommerce.common.web.request.ResourcesRequestBundle;
@@ -167,8 +168,14 @@ public abstract class AbstractResourceProcessor extends AbstractBroadleafTagRepl
         if (StringUtils.isNotEmpty(contextPath)) {
             bundleUrl = contextPath + bundleUrl;
         }
-
-        return bundleUrl + "?themeConfigId=-2";
+        BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
+        if (brc != null && brc.getTheme() != null) {
+            Long themeId = brc.getTheme().getId();
+            return bundleUrl + "?themeConfigId=" + themeId;
+        }
+        else {
+            return bundleUrl;
+        }
     }
 
     /**


### PR DESCRIPTION
Now using the BRC as the reference.  Fixes https://github.com/BroadleafCommerce/QA/issues/3867

