### PR TITLE
Cannot see translations for profile entities in child site, that were added in parent

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
@@ -180,15 +180,16 @@ public class TranslationDaoImpl implements TranslationDao {
         List<Predicate> restrictions = new ArrayList<Predicate>();
         restrictions.add(builder.equal(root.get("entityType"), entityType.getFriendlyType()));
         try {
+            Class<?> aClass = entityConfiguration.createEntityInstance(entityType.getType()).getClass();
             if (extensionManager != null) {
-                extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().setup(aClass, stage);
+                extensionManager.getProxy().refineParameterRetrieve(aClass, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Long> query = em.createQuery(criteria);
             if (extensionManager != null) {
-                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+                extensionManager.getProxy().refineQuery(aClass, stage, query);
             }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             return query.getSingleResult();
@@ -215,15 +216,16 @@ public class TranslationDaoImpl implements TranslationDao {
             restrictions.add(root.get("entityId").in(entityIds));
         }
         try {
+            Class<?> aClass = entityConfiguration.createEntityInstance(entityType.getType()).getClass();
             if (extensionManager != null) {
-                extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().setup(aClass, stage);
+                extensionManager.getProxy().refineParameterRetrieve(aClass, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Translation> query = em.createQuery(criteria);
             if (extensionManager != null) {
-                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+                extensionManager.getProxy().refineQuery(aClass, stage, query);
             }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             return query.getResultList();
@@ -257,15 +259,16 @@ public class TranslationDaoImpl implements TranslationDao {
         restrictions.add(builder.equal(root.get("fieldName"), fieldName));
         restrictions.add(builder.like(root.get("localeCode").as(String.class), localeCode + "%"));
         try {
+            Class<?> aClass = entityConfiguration.createEntityInstance(entityType.getType()).getClass();
             if (extensionManager != null) {
-                extensionManager.getProxy().setup(TranslationImpl.class, stage);
-                extensionManager.getProxy().refineParameterRetrieve(TranslationImpl.class, stage, builder, criteria, root, restrictions);
+                extensionManager.getProxy().setup(aClass, stage);
+                extensionManager.getProxy().refineParameterRetrieve(aClass, stage, builder, criteria, root, restrictions);
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
 
             TypedQuery<Translation> query = em.createQuery(criteria);
             if (extensionManager != null) {
-                extensionManager.getProxy().refineQuery(TranslationImpl.class, stage, query);
+                extensionManager.getProxy().refineQuery(aClass, stage, query);
             }
             query.setHint(QueryHints.HINT_CACHEABLE, true);
             List<Translation> translations = query.getResultList();


### PR DESCRIPTION
BroadleafCommerce/QA#1237
fix for showing correct translations for profile entities(pages etc) on site
