### PR TITLE
Add a property to disable solr optimize call

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -140,6 +140,9 @@ public class SolrHelperServiceImpl implements SolrHelperService {
     @Resource(name = "blGenericEntityDao")
     protected GenericEntityDao genericEntityDao;
 
+    @Value(value = "${enable.solr.optimize:true}")
+    private boolean optimizeEnabled;
+
     /**
      * This should only ever be called when using the Solr reindex service to do a full reindex.
      * @throws SecurityException
@@ -438,8 +441,11 @@ public class SolrHelperServiceImpl implements SolrHelperService {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Optimizing the index...");
             }
-            if (isSolrConfigured) {
+            if (isSolrConfigured && optimizeEnabled) {
                 server.optimize(collection);
+            }
+            if(!optimizeEnabled){
+                LOG.warn("property enable.solr.optimize is false so no optimize will happen, but SolrHelperServiceImpl.optimizeIndex was invoked, check if you need to call this method");
             }
         } catch (SolrServerException e) {
             throw new ServiceException("Could not optimize index", e);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -190,10 +190,10 @@ public class SolrIndexServiceImpl implements SolrIndexService {
         if(optimizeEnabled) {
             // this is required to be at the very very very end after rebuilding the whole index
             optimizeIndex(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
-            // Swap the active and the reindex cores
-            if (!solrConfiguration.isSingleCoreMode()) {
-                shs.swapActiveCores(solrConfiguration);
-            }
+        }
+        // Swap the active and the reindex cores
+        if (!solrConfiguration.isSingleCoreMode()) {
+            shs.swapActiveCores(solrConfiguration);
         }
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -148,6 +148,10 @@ public class SolrIndexServiceImpl implements SolrIndexService {
     @Resource(name = "blIndexFieldDao")
     protected IndexFieldDao indexFieldDao;
 
+    @Value(value = "${enable.solr.optimize:false}")
+    private boolean optimizeEnabled;
+
+
     @Override
     public void performCachedOperation(SolrIndexCachedOperation.CacheOperation cacheOperation) throws ServiceException {
         try {
@@ -183,11 +187,13 @@ public class SolrIndexServiceImpl implements SolrIndexService {
 
     @Override
     public void postBuildIndex() throws IOException, ServiceException {
-        // this is required to be at the very very very end after rebuilding the whole index
-        optimizeIndex(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
-        // Swap the active and the reindex cores
-        if (!solrConfiguration.isSingleCoreMode()) {
-            shs.swapActiveCores(solrConfiguration);
+        if(optimizeEnabled) {
+            // this is required to be at the very very very end after rebuilding the whole index
+            optimizeIndex(solrConfiguration.getReindexCollectionName(), solrConfiguration.getReindexServer());
+            // Swap the active and the reindex cores
+            if (!solrConfiguration.isSingleCoreMode()) {
+                shs.swapActiveCores(solrConfiguration);
+            }
         }
     }
 


### PR DESCRIPTION
BroadleafCommerce/QA#3831
Add a property to disable solr optimize call

Property 
enable.solr.optimize

don't forget to add this prop to the doc

enable.solr.optimize false by default, checks if solr optimize will happen after index is rebuild. If you don't set this prop and somewhere you invoke SolrHelperService.optimize it will continue to work. To disable completely set it to false