### PR TITLE
For Ratings Summary, bypass readReview query if ratingSummary ID is not available

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
@@ -164,7 +164,8 @@ public class RatingServiceImpl implements RatingService {
             ratingDetail.setRating(rating);         
         }
 
-        ReviewDetail reviewDetail = ratingSummaryDao.readReview(customer.getId(), ratingSummary.getId());
+        ReviewDetail reviewDetail = ratingSummary.getId() == null ?
+            null : ratingSummaryDao.readReview(customer.getId(), ratingSummary.getId());
 
         if (reviewDetail == null) {
             reviewDetail = new ReviewDetailImpl(customer, SystemTime.asDate(), ratingDetail, reviewText, ratingSummary);


### PR DESCRIPTION
**Bypass redundant readRating query**
When `ratingSummary.getId` returns null, by pass the unnecessary `readReview` query

**Additional context**
Related to https://github.com/BroadleafCommerce/BroadleafCommerce/issues/2221