### PR TITLE
For Ratings Summary, bypass readRating query if ratingSummary ID is not available

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
@@ -155,7 +155,8 @@ public class RatingServiceImpl implements RatingService {
             ratingSummary = ratingSummaryDao.createSummary(itemId, type);
         }
 
-        RatingDetail ratingDetail = ratingSummaryDao.readRating(customer.getId(), ratingSummary.getId());
+        RatingDetail ratingDetail = ratingSummary.getId() == null ?
+            null : ratingSummaryDao.readRating(customer.getId(), ratingSummary.getId());
 
         if (ratingDetail == null) {
             ratingDetail = ratingSummaryDao.createDetail(ratingSummary, rating, SystemTime.asDate(), customer);


### PR DESCRIPTION
**Bypass redundant readRating query**
When `ratingSummary.getId` returns null, by pass the `readRating` query

**Additional context**
Related to https://github.com/BroadleafCommerce/BroadleafCommerce/issues/2220