### PR TITLE
backporting section resolution logic

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/dao/AdminNavigationDaoImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/dao/AdminNavigationDaoImpl.java
@@ -108,23 +108,14 @@ public class AdminNavigationDaoImpl implements AdminNavigationDao {
         }
         
         if (!CollectionUtils.isEmpty(sections)) {
-            AdminSection returnSection = sections.get(0);
-            if (sectionId == null) {
-                // if no sectionId was passed, ensure we are returning the correct section based on the request's sectionkey
-                sectionId = getSectionKey(true);
-            }
-
-            if (!sectionId.startsWith("/")) {
-                sectionId = "/" + sectionId;
-            }
             for (AdminSection section : sections) {
-                if (sectionId.equals(section.getUrl())) {
-                    returnSection = section;
-                    break;
+                //When identifying the "base" section, multiple can be returned.  "Type" sections (e.g. product:addon) will have a ":".
+                //  Since we are looking for the base section, the "type" sections should be ignored
+                if(!section.getUrl().contains(":")){
+                    return section;
                 }
             }
-
-            return returnSection;
+            return sections.get(0);
         }
         
         return null;


### PR DESCRIPTION
Backporting changes from 5.2.x branch for section resolution logic. For now if section id not specified then first element from section collection for class will be returned. 