### PR TITLE
Added getter to skip dynamic adjustments on ProductOptionValue

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValue.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValue.java
@@ -83,15 +83,31 @@ public interface ProductOptionValue extends Serializable, MultiTenantCloneable<P
      * Gets the price adjustment associated with this value. For instance,
      * if this ProductOptionValue represented an extra-large shirt, that
      * might be a $1 upcharge. This adjustments will be automatically
-     * added to the Sku retail price and sale price
-     * <br />
-     * <br />
-     * Note: This could also be a negative value if you wanted to offer
+     * added to the Sku retail price and sale price.
+     * <p>
+     * This may be a negative value if you wanted to offer
      * a particular ProductOptionValue at a discount
+     * <p>
+     * Depending on the implementation, this may perform dynamic pricing,
+     * which influences the value returned by examining price lists for
+     * the product option.
+     * <p>
+     * To retrieve the price adjustment without dynamic pricing applied,
+     * see {@link #getPriceAdjustmentSkipDynamicPricing()}.
      * 
-     * @return the price adjustment for this 
+     * @return The price adjustment for this product option, with dynamic
+     * pricing applied, if applicable.
      */
     public Money getPriceAdjustment();
+
+    /**
+     * Retrieve the Product Option's price adjustment without dynamic pricing
+     * applied.
+     *
+     * @return The price adjustment for this product option.
+     * @see #getPriceAdjustment()
+     */
+    public Money getPriceAdjustmentSkipDynamicPricing();
 
     /**
      * Gets the price adjustment associated with this value. For instance,

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.Objects;
 
 import javax.persistence.CascadeType;
@@ -133,21 +134,26 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
 
     @Override
     public Money getPriceAdjustment() {
-
         Money returnPrice = null;
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
-
-            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getSkuPricingService().getPriceAdjustment(this, priceAdjustment == null ? null : new Money(priceAdjustment), SkuPricingConsiderationContext.getSkuPricingConsiderationContext());
+            HashMap pricingConsiderationContext = SkuPricingConsiderationContext.getSkuPricingConsiderationContext();
+            Money adjustment = priceAdjustment == null ? null : new Money(priceAdjustment);
+            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext
+                                                     .getSkuPricingService()
+                                                     .getPriceAdjustment(this, adjustment, pricingConsiderationContext);
             returnPrice = dynamicPrices.getPriceAdjustment();
 
-        } else {
-            if (priceAdjustment != null) {
-                returnPrice = new Money(priceAdjustment, Money.defaultCurrency());
-            }
+        } else if (priceAdjustment != null) {
+            returnPrice = new Money(priceAdjustment, Money.defaultCurrency());
         }
 
         return returnPrice;
+    }
+
+    @Override
+    public Money getPriceAdjustmentSkipDynamicPricing() {
+        return priceAdjustment != null ? new Money(priceAdjustment, Money.defaultCurrency()) : null;
     }
 
     @Override


### PR DESCRIPTION
**Added getter to skip dynamic adjustments on ProductOptionValue**
- Adds getter to retrieve `priceAdjustment` on `ProductOptionValue` and skip dynamic pricing.

**A Brief Overview**
This supports fixing an issue with an infinite recursion bug related to the PriceList module.

Addresses https://github.com/BroadleafCommerce/QA/issues/3895

PR in Pricelist is dependent on this change.  https://github.com/BroadleafCommerce/PriceList/pull/197