### PR TITLE
Added compression mode for PNG compression to improve performance

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/artifact/image/ImageArtifactProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/artifact/image/ImageArtifactProcessor.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.zip.Deflater;
 
 import javax.annotation.Resource;
 import javax.imageio.IIOImage;
@@ -204,7 +205,7 @@ public class ImageArtifactProcessor implements ArtifactProcessor {
     protected InputStream compressPNG(InputStream artifactStream) throws Exception {
         PngImage pngImage = new PngImage(artifactStream);
         PngOptimizer optimizer = new PngOptimizer();
-        PngImage response = optimizer.optimize(pngImage, true, null);
+        PngImage response = optimizer.optimize(pngImage, true, Deflater.DEFLATED);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         response.writeDataOutputStream(baos);
         return new ByteArrayInputStream(baos.toByteArray());

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         </repository>
         <repository>
             <id>spring-milestones</id>
-            <url>http://repo.spring.io/milestone</url>
+            <url>https://repo.spring.io/milestone</url>
         </repository>
     </repositories>
     <properties>


### PR DESCRIPTION
**Added compression mode for PNG compression to improve performance** 
- Specifies a compression mode for PNG compression. Previously, this defaulted to "Best" compression, which compressed the image 5-6 times to find the smallest size. 

**A Brief Overview**
This addresses an issue with PNG images that caused poor performance when uploading PNG assets. Compression would take ~6 seconds for a 400KB file. This reduces it to ~500-1000ms depending on the image. This does result in a slightly larger file size, but 6 seconds was unacceptable. 

Addresses https://github.com/BroadleafCommerce/QA/issues/3903