### PR TITLE
Create a new list for email attachments on clone

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
@@ -152,7 +152,7 @@ public class EmailInfo implements Serializable {
 
     public synchronized EmailInfo clone() {
         EmailInfo info = new EmailInfo();
-        info.setAttachments(new ArrayList<Attachment>());
+        info.setAttachments(new ArrayList<Attachment>(attachments));
         info.setEmailTemplate(emailTemplate);
         info.setEmailType(emailType);
         info.setFromAddress(fromAddress);

--- a/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/info/EmailInfo.java
@@ -152,7 +152,7 @@ public class EmailInfo implements Serializable {
 
     public synchronized EmailInfo clone() {
         EmailInfo info = new EmailInfo();
-        info.setAttachments(attachments);
+        info.setAttachments(new ArrayList<Attachment>());
         info.setEmailTemplate(emailTemplate);
         info.setEmailType(emailType);
         info.setFromAddress(fromAddress);


### PR DESCRIPTION
**A Brief Overview**
Adding email attachments caused other email info objects created via the clone() method to receive those attachments incorrectly.

https://github.com/BroadleafCommerce/QA/issues/3908