### PR TITLE
Update versions to recommended patches.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.0.8.RELEASE</spring.version>
+        <spring.version>5.0.16.RELEASE</spring.version>
         <spring.security.version>5.0.12.RELEASE</spring.security.version>
         <spring.boot.version>2.0.4.RELEASE</spring.boot.version>
         <spring.mobile.version>2.0.0.M3</spring.mobile.version>
@@ -1275,7 +1275,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>6.0.9.Final</version>
+                <version>6.0.18.Final</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>


### PR DESCRIPTION
**Description:**
Security vulnerabilities detected for spring-webmvc and hibernate-validator.

**Versions to upgrade**

spring-webmvc - from 5.0.8.RELEASE to 5.0.16.RELEASE
hibernate-validator- from 6.0.9.Final to 6.0.18.Final

https://github.com/BroadleafCommerce/QA/issues/3912