### PR TITLE
Fixes CustomField INTEGER type validation

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BasicFieldTypeValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/BasicFieldTypeValidator.java
@@ -58,6 +58,8 @@ public class BasicFieldTypeValidator implements PopulateValueRequestValidator {
                         Short.parseShort(populateValueRequest.getRequestedValue());
                     } else if (long.class.isAssignableFrom(populateValueRequest.getReturnType()) || Long.class.isAssignableFrom(populateValueRequest.getReturnType())) {
                         Long.parseLong(populateValueRequest.getRequestedValue());
+                    } else {
+                        Integer.parseInt(populateValueRequest.getRequestedValue());
                     }
                 } catch (NumberFormatException e) {
                     return new PropertyValidationResult(false, "Field must be an valid number");


### PR DESCRIPTION
**A Brief Overview**
When adding a CustomField to Product of type INTEGER, no validation is occurring when the entity is saved.  This PR adds a "default" validation check against Integers in the case that the `populateValueRequest.getReturnType()` is not an int, short, long, etc.
