### PR TITLE
Skus added to products are propagated to sandbox but cannot be approved.

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -700,6 +700,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
                 return entity;
             }
 
+            dynamicEntityDao.persist(adminInstance.getProduct());
             //persist the newly-created Sku
             adminInstance = dynamicEntityDao.persist(adminInstance);
 


### PR DESCRIPTION
BroadleafCommerce/QA#3900
Collection propagation is doesn't create change details for alt sanbox flow

The problem that if we add only sku there is only change detail for sku. 
So, when propagation logic comes into play it unable to find change detail that corresponds to workflow item, and so workflow item is not clonned.

When I change default sku field it presists product and not sku and in this way it create change details for product & sku and so workflow item is clonned during propagation.

So I save product before saving additional sku, in this way I have all workflow/change details and it goes smooth. 
Probably there should be another way to create change details, but I didin't find the place where I can hook and create additional change details for product when change details for sku are created and handle only the case when it happens during collection.add.
Guess this issue happens to other collections as well, so maybe @jefffischer can suggest a way where change details for product/"collection holder entity" should be created ? Maybe use somehow related_to_table information ?
Maybe add in controller direct call to add change details for "collection holder entity" and link to workflow item ?