### PR TITLE
Fixed issue where translations could not be added to fields when the entity was part of a MappedCollection

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -1600,6 +1600,11 @@ public class AdminBasicEntityController extends AdminAbstractController {
                 populateTypeAndId = false;
             }
 
+            //For MappedCollections, we need to be specific on what translation ceilingEntity and Id is used.
+            //It should be the entity and referenced Id of the value entity (not the target entity and Id).
+            entityForm.setTranslationCeilingEntity(fmd.getValueClassName());
+            entityForm.setTranslationId(collectionItemId);
+            
             formService.populateEntityFormFields(entityForm, entity, populateTypeAndId, populateTypeAndId);
             formService.populateMapEntityFormFields(entityForm, entity);
             addAuditableDisplayFields(entityForm);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -1600,9 +1600,11 @@ public class AdminBasicEntityController extends AdminAbstractController {
                 populateTypeAndId = false;
             }
 
-            //For MappedCollections, we need to be specific on what translation ceilingEntity and Id is used.
+            //For MappedCollections, we need to be specific on what ceilingEntity and translationId is used.
             //It should be the entity and referenced Id of the value entity (not the target entity and Id).
-            entityForm.setTranslationCeilingEntity(fmd.getValueClassName());
+            if (entityForm.getCeilingEntityClassname() == null) {
+                entityForm.setCeilingEntityClassname(fmd.getValueClassName());
+            }
             entityForm.setTranslationId(collectionItemId);
             
             formService.populateEntityFormFields(entityForm, entity, populateTypeAndId, populateTypeAndId);


### PR DESCRIPTION
Adding the translationCeilingEntity for entity fields in a MappedCollection.  
Fixes https://github.com/BroadleafCommerce/QA/issues/3935