### PR TITLE
Fix spelling error in column name for OfferImpls marketing message

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -133,8 +133,8 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
         largeEntry = true, fieldType = SupportedFieldType.DESCRIPTION, defaultValue = "")
     protected String description;
 
-    @Column(name = "MARKETING_MESSASGE")
-    @Index(name = "OFFER_MARKETING_MESSAGE_INDEX", columnNames = { "MARKETING_MESSASGE" })
+    @Column(name = "MARKETING_MESSAGE")
+    @Index(name = "OFFER_MARKETING_MESSAGE_INDEX", columnNames = { "MARKETING_MESSAGE" })
     @AdminPresentation(friendlyName = "OfferImpl_marketingMessage",
         group = GroupName.Marketing, order = FieldOrder.Message,
         translatable = true, defaultValue = "")


### PR DESCRIPTION
This change fixes a spelling error where the marketing message property on OfferImpl was spelled `MARKETING_MESSASGE` and should have been spelled `MARKETING_MESSAGE`. Since this requires a schema change it's going in the 6.1.x line.

Fixes BroadleafCommerce/QA#3768 
Fixes BroadleafCommerce/BroadleafCommerce#2016