### PR TITLE
Fix for not deleting blc_qual_crit_offer_xref when saving after promote

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
@@ -704,7 +704,8 @@ public class RuleFieldPersistenceProvider extends FieldPersistenceProviderAdapte
                         QuantityBasedRule original = itr.next();
                         for (QuantityBasedRule quantityBasedRule : updatedRules) {
                             Long id = sandBoxHelper.getOriginalId(quantityBasedRule);
-                            boolean isMatch = original.getId().equals(id) || original.getId().equals(quantityBasedRule.getId());
+                            Long origId = sandBoxHelper.getOriginalId(original);
+                            boolean isMatch = original.getId().equals(id) || original.getId().equals(quantityBasedRule.getId()) || id.equals(origId);
                             if (isMatch) {
                                 break checkForRemove;
                             }


### PR DESCRIPTION
Fix for not deleting blc_qual_crit_offer_xref when saving after promote
BroadleafCommerce/QA#3952
