### PR TITLE
Disable translations by property

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/filter/TranslationFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/filter/TranslationFilter.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.common.web.filter;
 
 import org.broadleafcommerce.common.admin.condition.ConditionalOnNotAdmin;
 import org.broadleafcommerce.common.i18n.service.TranslationConsiderationContext;
+import org.broadleafcommerce.common.util.BLCSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -46,14 +47,22 @@ public class TranslationFilter extends AbstractIgnorableFilter {
     @Qualifier("blTranslationRequestProcessor")
     protected TranslationRequestProcessor translationRequestProcessor;
 
+    protected boolean getTranslationEnabled() {
+        return BLCSystemProperty.resolveBooleanSystemProperty("i18n.translation.enabled");
+    }
+
     @Override
     public void doFilterUnlessIgnored(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        try {
-            translationRequestProcessor.process(new ServletWebRequest((HttpServletRequest) request, (HttpServletResponse) response));
-            filterChain.doFilter(request, response);
-        } finally {
-            translationRequestProcessor.postProcess(new ServletWebRequest((HttpServletRequest) request, (HttpServletResponse) response));
+        if (getTranslationEnabled()) {
+            try {
+                translationRequestProcessor.process(new ServletWebRequest((HttpServletRequest) request, (HttpServletResponse) response));
+                filterChain.doFilter(request, response);
+            } finally {
+                translationRequestProcessor.postProcess(new ServletWebRequest((HttpServletRequest) request, (HttpServletResponse) response));
+            }
         }
+
+        filterChain.doFilter(request, response);
     }
 
     @Override

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/i18nUpdateCartServiceExtensionHandler.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/service/i18nUpdateCartServiceExtensionHandler.java
@@ -64,6 +64,10 @@ public class i18nUpdateCartServiceExtensionHandler extends AbstractUpdateCartSer
         }
     }
 
+    protected boolean getTranslationEnabled() {
+        return BLCSystemProperty.resolveBooleanSystemProperty("i18n.translation.enabled");
+    }
+
     /**
      * If the locale of the cart does not match the current locale, then this extension handler will
      * attempt to translate the order items.  
@@ -76,7 +80,7 @@ public class i18nUpdateCartServiceExtensionHandler extends AbstractUpdateCartSer
      * @return
      */
     public ExtensionResultStatusType updateAndValidateCart(Order cart, ExtensionResultHolder resultHolder) {
-        if (BroadleafRequestContext.hasLocale()) {
+        if (BroadleafRequestContext.hasLocale() && getTranslationEnabled()) {
             BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
             if (!brc.getLocale().getLocaleCode().matches(cart.getLocale().getLocaleCode())) {
                 if (LOG.isDebugEnabled()) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/I18nSolrSearchServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/I18nSolrSearchServiceExtensionHandler.java
@@ -77,7 +77,6 @@ public class I18nSolrSearchServiceExtensionHandler extends AbstractSolrSearchSer
         return getLocalePrefix(field.getField(), prefixList);
     }
 
-
     /**
      * If the field is translatable, take the current locale and add that as a prefix.
      * @param context
@@ -85,7 +84,7 @@ public class I18nSolrSearchServiceExtensionHandler extends AbstractSolrSearchSer
      * @return
      */
     protected ExtensionResultStatusType getLocalePrefix(Field field, List<String> prefixList) {
-        if (field.getTranslatable()) {
+        if (field.getTranslatable() && getTranslationEnabled()) {
             if (BroadleafRequestContext.getBroadleafRequestContext() != null) {
                 Locale locale = BroadleafRequestContext.getBroadleafRequestContext().getLocale();
                 if (locale != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/I18nSolrIndexServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/I18nSolrIndexServiceExtensionHandler.java
@@ -86,7 +86,7 @@ public class I18nSolrIndexServiceExtensionHandler extends AbstractSolrIndexServi
         Set<String> processedLocaleCodes = new HashSet<String>();
 
         ExtensionResultStatusType result = ExtensionResultStatusType.NOT_HANDLED;
-        if (field.getTranslatable()) {
+        if (field.getTranslatable() && getTranslationEnabled()) {
             result = ExtensionResultStatusType.HANDLED;
 
             TranslationConsiderationContext.setTranslationConsiderationContext(getTranslationEnabled());
@@ -136,7 +136,7 @@ public class I18nSolrIndexServiceExtensionHandler extends AbstractSolrIndexServi
      * @return
      */
     protected ExtensionResultStatusType getLocalePrefix(Field field, List<String> prefixList) {
-        if (field.getTranslatable()) {
+        if (field.getTranslatable() && getTranslationEnabled()) {
             if (BroadleafRequestContext.getBroadleafRequestContext() != null) {
                 Locale locale = BroadleafRequestContext.getBroadleafRequestContext().getLocale();
                 if (locale != null) {
@@ -183,11 +183,13 @@ public class I18nSolrIndexServiceExtensionHandler extends AbstractSolrIndexServi
             }
         }
 
-        addEntitiesToTranslationCache(skuIds, TranslatedEntity.SKU);
-        addEntitiesToTranslationCache(productIds, TranslatedEntity.PRODUCT);
-        addEntitiesToTranslationCache(skuAttributeIds, TranslatedEntity.SKU_ATTRIBUTE);
-        addEntitiesToTranslationCache(productAttributeIds, TranslatedEntity.PRODUCT_ATTRIBUTE);
-        
+        if (getTranslationEnabled()) {
+            addEntitiesToTranslationCache(skuIds, TranslatedEntity.SKU);
+            addEntitiesToTranslationCache(productIds, TranslatedEntity.PRODUCT);
+            addEntitiesToTranslationCache(skuAttributeIds, TranslatedEntity.SKU_ATTRIBUTE);
+            addEntitiesToTranslationCache(productAttributeIds, TranslatedEntity.PRODUCT_ATTRIBUTE);
+        }
+
         return ExtensionResultStatusType.HANDLED_CONTINUE;
     }
 


### PR DESCRIPTION
- Add property check on solr index
- Add property check on solr search
- Add property check on update cart after locale change
- Add property check to translation filter (powers Dynamic Translations)
- Add property check to admin product extension handler

**A Brief Overview**
There is an `i18n.translation.enabled` property that is not used, and the framework will always translate if the data is there. This is causing a performance problem both during the solr index as well as normal site browsing.

**Additional context**
Issue found in FOL - FTD.