### PR TITLE
Improve getting page size in the SeoDefaultPropertyServiceImpl

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/seo/SeoDefaultPropertyServiceImpl.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/seo/SeoDefaultPropertyServiceImpl.java
@@ -25,6 +25,7 @@ import org.broadleafcommerce.common.page.dto.PageDTO;
 import org.broadleafcommerce.common.web.BaseUrlResolver;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.util.BroadleafUrlParamUtils;
+import org.broadleafcommerce.core.catalog.dao.CategoryDao;
 import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.CategoryMediaXref;
 import org.broadleafcommerce.core.catalog.domain.Product;
@@ -62,6 +63,9 @@ public class SeoDefaultPropertyServiceImpl implements SeoDefaultPropertyService 
 
     @Resource(name = "blSearchService")
     protected SearchService searchService;
+
+    @Resource(name = "blCategoryDao")
+    protected CategoryDao categoryDao;
 
     @Override
     public String getProductTitlePattern(Product product) {
@@ -303,7 +307,7 @@ public class SeoDefaultPropertyServiceImpl implements SeoDefaultPropertyService 
     }
 
     protected Integer getPageCount(Category category) {
-        int activeCategoryCount = category.getActiveProductXrefs().size();
+        long activeCategoryCount = categoryDao.readCountAllActiveProductsByCategory(category);
 
         return (int) Math.ceil(activeCategoryCount * 1.0 / getPageSize());
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDao.java
@@ -224,4 +224,6 @@ public interface CategoryDao {
      */
     public void setCurrentDateResolution(Long currentDateResolution);
 
+    Long readCountAllActiveProductsByCategory(Category category);
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDaoImpl.java
@@ -27,7 +27,6 @@ import org.broadleafcommerce.common.util.dao.TypedQueryBuilder;
 import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.CategoryImpl;
 import org.broadleafcommerce.core.catalog.domain.Product;
-import org.broadleafcommerce.core.catalog.domain.ProductImpl;
 import org.hibernate.ejb.QueryHints;
 import org.springframework.stereotype.Repository;
 
@@ -299,4 +298,14 @@ public class CategoryDaoImpl implements CategoryDao {
         }
     }
 
+    @Override
+    public Long readCountAllActiveProductsByCategory(Category category) {
+        TypedQuery<Long> query = em.createNamedQuery("BC_READ_COUNT_ALL_ACTIVE_PRODUCTS_BY_CATEGORY", Long.class);
+        query.setParameter("categoryId", category.getId());
+        query.setParameter("currentDate", getCurrentDateAfterFactoringInDateResolution());
+        query.setHint(QueryHints.HINT_CACHEABLE, true);
+        query.setHint(QueryHints.HINT_CACHE_REGION, "query.Catalog");
+
+        return query.getSingleResult();
+    }
 }

--- a/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Category.orm.xml
+++ b/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Category.orm.xml
@@ -69,4 +69,15 @@
         </query>
     </named-query>
 
+    <named-query name="BC_READ_COUNT_ALL_ACTIVE_PRODUCTS_BY_CATEGORY" >
+        <query>SELECT COUNT(xref) FROM org.broadleafcommerce.core.catalog.domain.CategoryProductXref xref
+            LEFT JOIN xref.product AS product
+            LEFT JOIN product.defaultSku AS defaultSku
+            WHERE xref.category.id = :categoryId
+            AND (product.archiveStatus.archived IS NULL OR product.archiveStatus.archived = 'N')
+            AND (defaultSku.activeStartDate &lt; :currentDate)
+            AND (defaultSku.activeEndDate IS NULL OR defaultSku.activeEndDate &gt; :currentDate)
+        </query>
+    </named-query>
+
 </entity-mappings>


### PR DESCRIPTION
BroadleafCommerce/QA#3947

Adding new `readCountAllActiveProductsByCategory` method into `CategoryDao`, to use it instead of getting `category.getActiveProductXrefs().size()` which is overkill to get count from lazy collection.