### PR TITLE
Excluding archived payment transactions from query result

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
@@ -53,6 +53,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.context.ApplicationContext;
 
 import java.math.BigDecimal;
@@ -155,9 +156,9 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
             broadleafEnumeration="org.broadleafcommerce.common.payment.PaymentGatewayType")
     protected String gatewayType;
-    
-    //TODO: add a filter for archived transactions
+
     @OneToMany(mappedBy = "orderPayment", targetEntity = PaymentTransactionImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
+    @Where(clause = "archived != 'Y'")
     @AdminPresentationCollection(friendlyName="OrderPaymentImpl_Details",
             tab = Presentation.Tab.Name.Log, tabOrder = Presentation.Tab.Order.Log)
     protected List<PaymentTransaction> transactions = new ArrayList<PaymentTransaction>();


### PR DESCRIPTION
**A Brief Overview**
When querying for Payment Transactions all transactions are returned - including archived transactions

**Link to HelpScout**
https://secure.helpscout.net/conversation/1105424196/40203?folderId=387708

**Link to QA issue**
BroadleafCommerce/QA#3967
