### PR TITLE
add index on AdminSectionImpl::ceilingEntity to accelerate query

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
@@ -116,6 +116,7 @@ public class AdminSectionImpl implements AdminSection {
     protected Boolean useDefaultHandler = Boolean.TRUE;
 
     @Column(name = "CEILING_ENTITY", nullable = true)
+    @Index(name="ADMINSECTION_CEILING_ENTITY_INDEX", columnNames={"CEILING_ENTITY"})
     @AdminPresentation(friendlyName = "AdminSectionImpl_Ceiling_Entity", order = 6, group = "AdminSectionImpl_Section")
     protected String ceilingEntity;
 


### PR DESCRIPTION
Missing index on AdminSectionImpl::ceilingEntity may slow query down in `AdminNavigationDaoImpl::readAdminSectionForClassName`. See #2274 