### PR TITLE
add index on BLC_CUSTOMER.USER_NAME

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
@@ -109,6 +109,7 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
     protected PreviewStatus previewable = new PreviewStatus();
 
     @Column(name = "USER_NAME")
+    @Index(name = "CUSTOMER_USER_NAME_INDEX", columnNames = { "USER_NAME" })
     @AdminPresentation(friendlyName = "CustomerImpl_UserName",
             group = GroupName.Customer, order = FieldOrder.USERNAME,
             requiredOverride = RequiredOverride.REQUIRED)


### PR DESCRIPTION
## Problem
Missing index on table **BLC_CUSTOMER** column **USER_NAME** might make  named query `BC_READ_CUSTOMER_BY_USER_NAME` slow. Since table BLC_CUSTOMER is mostly read and sometimes inserted or updated,  the performance impact for write operations is acceptable under common cases.
## Possible Solution
Add Index on BLC_CUSTOMER.USER_NAME

See # #2276 