### PR TITLE
Add index on table BLC_ADMIN_SECTION column URL

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
@@ -82,6 +82,7 @@ public class AdminSectionImpl implements AdminSection {
     protected String sectionKey;
 
     @Column(name = "URL", nullable=true)
+    @Index(name="BLC_ADMIN_SECTION_URL", columnNames={"URL"})
     @AdminPresentation(friendlyName = "AdminSectionImpl_Url", order=3, group = "AdminSectionImpl_Section", prominent=true)
     protected String url;
 


### PR DESCRIPTION
Adding index on table **BLC_ADMIN_SECTION** column **url** might speed up the underlying query issued via AdminNavigationServiceImpl#findAdminSectionByURI.
See #2273.


