### PR TITLE
Fixed issue where IndexFieldTypes and SearchFacetRanges were being returned in collections after they were archived

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Where;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -101,6 +102,7 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
     @OneToMany(mappedBy = "indexField", targetEntity = IndexFieldTypeImpl.class, cascade = CascadeType.ALL)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
     @BatchSize(size = 50)
+    @Where(clause = "(ARCHIVED != 'Y' OR ARCHIVED IS NULL)")
     @AdminPresentationCollection(friendlyName = "IndexFieldImpl_fieldTypes", order = 1000)
     protected List<IndexFieldType> fieldTypes = new ArrayList<>();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -17,7 +17,6 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
-import com.google.common.base.Strings;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -27,7 +26,11 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.*;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationAdornedTargetCollection;
+import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.broadleafcommerce.common.presentation.client.AddMethodType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
@@ -35,16 +38,29 @@ import org.broadleafcommerce.common.presentation.override.AdminPresentationMerge
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
 import org.broadleafcommerce.common.presentation.override.PropertyType;
 import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Where;
 
-import javax.persistence.CascadeType;
-import javax.persistence.*;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import com.google.common.base.Strings;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 
 @Entity
@@ -141,6 +157,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable, AdminMainEnti
     @OneToMany(mappedBy = "searchFacet", targetEntity = SearchFacetRangeImpl.class, cascade = {CascadeType.ALL})
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Where(clause = "(ARCHIVED != 'Y' OR ARCHIVED IS NULL)")
     @AdminPresentationCollection(addType = AddMethodType.PERSIST,
             friendlyName = "newRangeTitle",
             group = GroupName.Ranges)


### PR DESCRIPTION
These changes fixes an issue where archived IndexFieldTypes and SearchFacetRanges were being returned in their collections on IndexFieldImpl and SearchFacetImpl respectively. This was happening because there's nothing filtering them when they're lazy loaded as collections. To fix this an `@Where` annotation was added which is used by Hibernate to filter out the results. This particular behavior happens for any collection where the entity is archive only and isn't sandboxable as any entities that are sandboxable are subject to `SandBoxInitializeCollectionEventListener` which will filter out the results that shouldn't be returned (i.e. archived, sandbox records while in production, etc). This change has limited impact to implementations as this is now working as one would expect as currently records deleted in the admin are still used in indexing and searching when they shouldn't be.

This was in response to https://secure.helpscout.net/conversation/1111001947/40266?folderId=1185670