### PR TITLE
Remove unused mergeCartResponseKey

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
@@ -71,8 +71,6 @@ public class CartStateRequestProcessor extends AbstractBroadleafWebRequestProces
 
     public static final String BLC_RULE_MAP_PARAM = "blRuleMap";
 
-    private final String mergeCartResponseKey = "bl_merge_cart_response";
-
     @Resource(name = "blCartStateRequestProcessorExtensionManager")
     protected CartStateRequestProcessorExtensionManager extensionManager;
 


### PR DESCRIPTION
This removes constant `mergeCartResponseKey`. The code that used it was removed previously. This relates to Issue #2290, Merged cart being saved to session.