### PR TITLE
Don't save mergeCartResponse to session

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/security/CartStateRequestProcessor.java
@@ -71,8 +71,6 @@ public class CartStateRequestProcessor extends AbstractBroadleafWebRequestProces
 
     public static final String BLC_RULE_MAP_PARAM = "blRuleMap";
 
-    private final String mergeCartResponseKey = "bl_merge_cart_response";
-
     @Resource(name = "blCartStateRequestProcessorExtensionManager")
     protected CartStateRequestProcessorExtensionManager extensionManager;
 
@@ -208,8 +206,6 @@ public class CartStateRequestProcessor extends AbstractBroadleafWebRequestProces
                     WebRequest.SCOPE_SESSION);
             request.removeAttribute(CustomerStateRequestProcessor.getAnonymousCustomerIdSessionAttributeName(),
                     WebRequest.SCOPE_SESSION);
-
-            request.setAttribute(mergeCartResponseKey, mergeCartResponse, WebRequest.SCOPE_SESSION);
         }
         return mergeCartResponse.getOrder();
     }


### PR DESCRIPTION
After merging carts on login, the CartStateRequestProcessor saves the new cart to the session. Some nested object of the order is not serializable. This causes a problem when using Redis for session sharing between nodes. When a user visits a new node, that node cannot de-serialize the session data and the user is shown an error page.

The solution proposed is to simply not save the cart to session. Code usage search reveals that this variable was not ever used.

Issue #2290 - Merged cart being saved to session
