### PR TITLE
fixes blocked threads on mvehelper calls

### DIFF
--- a/admin/broadleaf-admin-functional-tests/pom.xml
+++ b/admin/broadleaf-admin-functional-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>admin</artifactId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>broadleaf-admin-functional-tests</artifactId>
     <name>BroadleafCommerce Admin Functional Tests</name>

--- a/admin/broadleaf-admin-module/pom.xml
+++ b/admin/broadleaf-admin-module/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>admin</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>broadleaf-admin-module</artifactId>
     <packaging>jar</packaging>

--- a/admin/broadleaf-contentmanagement-module/pom.xml
+++ b/admin/broadleaf-contentmanagement-module/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>admin</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>broadleaf-contentmanagement-module</artifactId>
     <packaging>jar</packaging>

--- a/admin/broadleaf-open-admin-platform/pom.xml
+++ b/admin/broadleaf-open-admin-platform/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>admin</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>broadleaf-open-admin-platform</artifactId>
     <packaging>jar</packaging>

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>broadleaf</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>admin</artifactId>
     <packaging>pom</packaging>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>broadleaf</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broadleaf-common</artifactId>

--- a/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
@@ -182,7 +182,7 @@ public class MvelHelper {
 
     private static Serializable getExpression(String rule, Map<String, Object> ruleParameters, Map<String, Serializable> expressionCache, Map<String, Class<?>> additionalContextImports, Serializable exp) {
         ParserContext context = new ParserContext();
-        if (expressionCache instanceof ConcurrentHashMap) {
+        if (expressionCache instanceof ConcurrentHashMap || expressionCache instanceof EfficientLRUMap) {
             exp = processConcurrentMap(rule, ruleParameters, expressionCache, additionalContextImports, exp, context);
         } else {
             String modifiedRule = setupContext(rule, ruleParameters, additionalContextImports, context);

--- a/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
@@ -209,14 +209,17 @@ public class MvelHelper {
                 exp = MVEL.compileExpression(modifiedRule, context);
                 concurrentExpressionCache.put(rule, exp);
             } finally {
+                LOG.debug("Releasing thread for rule:" + rule);
                 ((RuleCountDownLatch)latch).countDown();
             }
         }
-        //if a concurrent thread happena to get the RuleCountDownLatch, we have the thread wait
+        //if a concurrent thread happens to get the RuleCountDownLatch, we have the thread wait
         if (exp instanceof RuleCountDownLatch) {
             try {
                 //have thread wait until Latch is released
-                ((RuleCountDownLatch)exp).await();
+                RuleCountDownLatch latch = ((RuleCountDownLatch)exp);
+                LOG.debug("Locking thread until MVEL is done processing rule: " + rule +". Threads waiting: " + latch.count());
+                latch.await();
             } catch (InterruptedException e) {
                 //no action can be taken
             }

--- a/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
@@ -36,6 +36,7 @@ import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -149,22 +150,7 @@ public class MvelHelper {
                 exp = expressionCache.get(rule);
             }
             if (exp == null) {
-                ParserContext context = new ParserContext();
-                context.addImport("MVEL", MVEL.class);
-                context.addImport("MvelHelper", MvelHelper.class);
-                context.addImport("CollectionUtils", SelectizeCollectionUtils.class);
-                if (MapUtils.isNotEmpty(additionalContextImports)) {
-                    for (Entry<String, Class<?>> entry : additionalContextImports.entrySet()) {
-                        context.addImport(entry.getKey(), entry.getValue());
-                    }
-                }
-                
-                String modifiedRule = modifyExpression(rule, ruleParameters, context);
-
-                synchronized (expressionCache) {
-                    exp = MVEL.compileExpression(modifiedRule, context);
-                    expressionCache.put(rule, exp);
-                }
+                exp = getExpression(rule, ruleParameters, expressionCache, additionalContextImports, exp);
             }
 
             Map<String, Object> mvelParameters = new HashMap<String, Object>();
@@ -193,7 +179,65 @@ public class MvelHelper {
             }
         }
     }
-    
+
+    private static Serializable getExpression(String rule, Map<String, Object> ruleParameters, Map<String, Serializable> expressionCache, Map<String, Class<?>> additionalContextImports, Serializable exp) {
+        ParserContext context = new ParserContext();
+        if (expressionCache instanceof ConcurrentHashMap) {
+            exp = processConcurrentMap(rule, ruleParameters, expressionCache, additionalContextImports, exp, context);
+        } else {
+            String modifiedRule = setupContext(rule, ruleParameters, additionalContextImports, context);
+
+            synchronized (expressionCache) {
+                exp = MVEL.compileExpression(modifiedRule, context);
+                expressionCache.put(rule, exp);
+            }
+        }
+        return exp;
+    }
+
+    private static Serializable processConcurrentMap(String rule, Map<String, Object> ruleParameters, Map<String, Serializable> expressionCache,
+                                                     Map<String, Class<?>> additionalContextImports, Serializable exp, ParserContext context) {
+        ConcurrentHashMap<String, Serializable> concurrentExpressionCache = (ConcurrentHashMap<String, Serializable>) expressionCache;
+        exp = concurrentExpressionCache.putIfAbsent(rule, new RuleCountDownLatch());
+
+        //if null, there was no rule defined yet so we have a latch on it
+        if (exp == null ) {
+            //get the latch so we can do a count down later
+            Serializable latch = concurrentExpressionCache.get(rule);
+            try {
+                String modifiedRule = setupContext(rule, ruleParameters, additionalContextImports, context);
+                exp = MVEL.compileExpression(modifiedRule, context);
+                concurrentExpressionCache.put(rule, exp);
+            } finally {
+                ((RuleCountDownLatch)latch).countDown();
+            }
+        }
+        //if a concurrent thread happena to get the RuleCountDownLatch, we have the thread wait
+        if (exp instanceof RuleCountDownLatch) {
+            try {
+                //have thread wait until Latch is released
+                ((RuleCountDownLatch)exp).await();
+            } catch (InterruptedException e) {
+                //no action can be taken
+            }
+            //once the thread is released, we should be able to get the compiled rule
+            exp = expressionCache.get(rule);
+        }
+        return exp;
+    }
+
+    private static String setupContext(String rule, Map<String, Object> ruleParameters, Map<String, Class<?>> additionalContextImports, ParserContext context) {
+        context.addImport("MVEL", MVEL.class);
+        context.addImport("MvelHelper", MvelHelper.class);
+        context.addImport("CollectionUtils", SelectizeCollectionUtils.class);
+        if (MapUtils.isNotEmpty(additionalContextImports)) {
+            for (Entry<String, Class<?>> entry : additionalContextImports.entrySet()) {
+                context.addImport(entry.getKey(), entry.getValue());
+            }
+        }
+        return modifyExpression(rule, ruleParameters, context);
+    }
+
     /**
      * <p>
      * Provides a hook point to modify the final expression before it's built. By default, this looks for attribute

--- a/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/MvelHelper.java
@@ -30,14 +30,14 @@ import org.broadleafcommerce.common.util.StringUtil;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
+
+import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Helper class for some common rule functions that can be called from mvel as well as utility functions
@@ -182,7 +182,7 @@ public class MvelHelper {
 
     private static Serializable getExpression(String rule, Map<String, Object> ruleParameters, Map<String, Serializable> expressionCache, Map<String, Class<?>> additionalContextImports, Serializable exp) {
         ParserContext context = new ParserContext();
-        if (expressionCache instanceof ConcurrentHashMap || expressionCache instanceof EfficientLRUMap) {
+        if (expressionCache instanceof EfficientLRUMap) {
             exp = processConcurrentMap(rule, ruleParameters, expressionCache, additionalContextImports, exp, context);
         } else {
             String modifiedRule = setupContext(rule, ruleParameters, additionalContextImports, context);
@@ -197,7 +197,7 @@ public class MvelHelper {
 
     private static Serializable processConcurrentMap(String rule, Map<String, Object> ruleParameters, Map<String, Serializable> expressionCache,
                                                      Map<String, Class<?>> additionalContextImports, Serializable exp, ParserContext context) {
-        ConcurrentHashMap<String, Serializable> concurrentExpressionCache = (ConcurrentHashMap<String, Serializable>) expressionCache;
+        EfficientLRUMap<String, Serializable> concurrentExpressionCache = (EfficientLRUMap<String, Serializable>) expressionCache;
         exp = concurrentExpressionCache.putIfAbsent(rule, new RuleCountDownLatch());
 
         //if null, there was no rule defined yet so we have a latch on it

--- a/common/src/main/java/org/broadleafcommerce/common/rule/RuleCountDownLatch.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/RuleCountDownLatch.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.rule;
+
+import java.io.Serializable;
+import java.util.concurrent.CountDownLatch;
+
+class RuleCountDownLatch implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    public void await() throws InterruptedException {
+        latch.await();
+    }
+
+    public void countDown() {
+        latch.countDown();
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/rule/RuleCountDownLatch.java
+++ b/common/src/main/java/org/broadleafcommerce/common/rule/RuleCountDownLatch.java
@@ -32,4 +32,8 @@ class RuleCountDownLatch implements Serializable {
     public void countDown() {
         latch.countDown();
     }
+
+    public long count() {
+        return latch.getCount();
+    }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/util/EfficientLRUMap.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/EfficientLRUMap.java
@@ -203,4 +203,19 @@ public class EfficientLRUMap<K, V> implements Map<K, V> {
             return concurrentMap.getClass();
         }
     }
+
+    public V putIfAbsent(K key, V value) {
+        if (usingLRUMap) {
+            return lruMap.put(key, value);
+        } else {
+            V returnVal = ((ConcurrentHashMap<K, V>) concurrentMap).putIfAbsent(key, value);
+            if (switchToLRUMap()) {
+                // The switch could have happened on another thread.
+                if (!lruMap.containsKey(key)) {
+                    lruMap.put(key, value);
+                }
+            }
+            return returnVal;
+        }
+    }
 }

--- a/core/broadleaf-framework-web/pom.xml
+++ b/core/broadleaf-framework-web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broadleaf-framework-web</artifactId>

--- a/core/broadleaf-framework/pom.xml
+++ b/core/broadleaf-framework/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broadleaf-framework</artifactId>

--- a/core/broadleaf-profile-web/pom.xml
+++ b/core/broadleaf-profile-web/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broadleaf-profile-web</artifactId>

--- a/core/broadleaf-profile/pom.xml
+++ b/core/broadleaf-profile/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broadleaf-profile</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>broadleaf</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <artifactId>core</artifactId>
     <packaging>pom</packaging>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>broadleaf</artifactId>
         <groupId>org.broadleafcommerce</groupId>
-        <version>5.2.15-GA</version>
+        <version>5.2.15.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>broadleaf</artifactId>
     <packaging>pom</packaging>
     <name>BroadleafCommerce</name>
-    <version>5.2.15-GA</version>
+    <version>5.2.15.2-SNAPSHOT</version>
     <description>BroadleafCommerce Top Level Project</description>
     <url>http://www.broadleafcommerce.org</url>
     <licenses>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:BroadleafCommerce/BroadleafCommerce.git</connection>
         <developerConnection>scm:git:git@github.com:BroadleafCommerce/BroadleafCommerce.git</developerConnection>
         <url>https://github.com/BroadleafCommerce/BroadleafCommerce</url>
-        <tag>broadleaf-5.2.15-GA</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <pluginManagement>


### PR DESCRIPTION
Fixes blocked threads on MVEHelper evaluateRule method

On gopher, calls for MVEHelper.evaluateRule were getting blocked and eventually we run out of db connections.