### PR TITLE
Fix incorrect map initialization

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/dao/HibernateMappingProvider.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/dao/HibernateMappingProvider.java
@@ -58,7 +58,7 @@ public class HibernateMappingProvider implements SessionFactoryBuilderFactory {
      * @param metadataMap seed data
      */
     public HibernateMappingProvider(Map<String, PersistentClass> metadataMap) {
-        metadataMap.putAll(metadataMap);
+        HibernateMappingProvider.metadataMap.putAll(metadataMap);
     }
 
     @Override


### PR DESCRIPTION
**A Brief Overview**
The original logic incorrectly put the content of incoming **metadataMap** to itself, rather than the static **metadataMap**.