### PR TITLE
Fix to admin Schedule Jobs UI when fetching long parameters

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -1615,7 +1615,8 @@ public class AdminBasicEntityController extends AdminAbstractController {
             } catch (Exception e) {
                 LOG.error(e);
             }
-            entityForm.setTranslationId(entity.getPMap().get(fmd.getToOneTargetProperty()+".id").getValue());
+            String entityId = (fmd.getToOneTargetProperty().equals("") ? "id" : fmd.getToOneTargetProperty() + ".id");
+            entityForm.setTranslationId(entity.getPMap().get(entityId).getValue());
             formService.populateEntityFormFields(entityForm, entity, populateTypeAndId, populateTypeAndId);
             formService.populateMapEntityFormFields(entityForm, entity);
             addAuditableDisplayFields(entityForm);


### PR DESCRIPTION
There is an edge case in this flow where the "getToOneTargetProperty" is blank and the pmap value to look up is just "id" (not property + ".id"). Fixes https://github.com/BroadleafCommerce/QA/issues/4058