### PR TITLE
Offer rules should allow between rules

### DIFF
--- a/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/MVELToDataWrapperTranslatorTest.java
+++ b/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/MVELToDataWrapperTranslatorTest.java
@@ -301,7 +301,22 @@ public class MVELToDataWrapperTranslatorTest extends TestCase {
         entities[0] = entity;
 
         DataWrapper dataWrapper = translator.createRuleData(entities, "matchRule", null, null, fulfillmentGroupFieldService);
-        assert(dataWrapper.getError().equals(MVELToDataWrapperTranslator.SUB_GROUP_MESSAGE));
+        assert(dataWrapper.getData().size() == 1);
+        assert(dataWrapper.getData().get(0).getQuantity() == null);
+        assert(dataWrapper.getData().get(0).getCondition().equals(BLCOperator.AND.name()));
+        assert(dataWrapper.getData().get(0).getRules().size()==2);
+
+        assert(dataWrapper.getData().get(0).getRules().get(0) instanceof ExpressionDTO);
+        ExpressionDTO e1 = (ExpressionDTO) dataWrapper.getData().get(0).getRules().get(0);
+        assert(e1.getId().equals("address.state.name"));
+        assert(e1.getOperator().equals(BLCOperator.EQUALS.name()));
+        assert(e1.getValue().equals("Texas"));
+
+        assert(dataWrapper.getData().get(0).getRules().get(1) instanceof ExpressionDTO);
+        ExpressionDTO e2 = (ExpressionDTO) dataWrapper.getData().get(0).getRules().get(1);
+        assert(e2.getId().equals("retailFulfillmentPrice"));
+        assert(e2.getOperator().equals(BLCOperator.BETWEEN_INCLUSIVE.name()));
+        assert(e2.getValue().equals("[99,199]"));
     }
 
     public void testItemQualificationCollectionDataWrapper() throws MVELTranslationException {
@@ -412,7 +427,7 @@ public class MVELToDataWrapperTranslatorTest extends TestCase {
         entities[1] = e2;
 
         DataWrapper dataWrapper = translator.createRuleData(entities, "orderItemMatchRule", "quantity", "id", orderItemFieldService);
-        assert(dataWrapper.getError().equals(MVELToDataWrapperTranslator.SUB_GROUP_MESSAGE));
+        assert(MVELToDataWrapperTranslator.SUB_GROUP_MESSAGE.equals(dataWrapper.getError()));
 
     }
 

--- a/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/MVELToDataWrapperTranslatorTest.java
+++ b/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/MVELToDataWrapperTranslatorTest.java
@@ -287,7 +287,7 @@ public class MVELToDataWrapperTranslatorTest extends TestCase {
         assert(e2.getValue().equals("[99,199]"));
     }
 
-    public void testNestedExpressionExceptionForFulfillmentGroupQualificationDataWrapper() throws MVELTranslationException {
+    public void testNestedExpressionForFulfillmentGroupQualificationDataWrapper() throws MVELTranslationException {
         MVELToDataWrapperTranslator translator = new MVELToDataWrapperTranslator();
 
         Property[] properties = new Property[1];

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/DataDTO.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/DataDTO.java
@@ -35,6 +35,7 @@ public class DataDTO implements Serializable {
     protected Long previousContainedPk;
     protected Integer quantity;
     protected String condition;
+    protected boolean createdFromSubGroup;
     protected ArrayList<DataDTO> rules = new ArrayList<DataDTO>();
 
     public Long getPk() {
@@ -91,6 +92,14 @@ public class DataDTO implements Serializable {
 
     public void setPreviousContainedPk(Long previousContainedPk) {
         this.previousContainedPk = previousContainedPk;
+    }
+
+    public boolean isCreatedFromSubGroup() {
+        return createdFromSubGroup;
+    }
+
+    public void setCreatedFromSubGroup(boolean createdFromSubGroup) {
+        this.createdFromSubGroup = createdFromSubGroup;
     }
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/DataDTO.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/dto/DataDTO.java
@@ -35,7 +35,7 @@ public class DataDTO implements Serializable {
     protected Long previousContainedPk;
     protected Integer quantity;
     protected String condition;
-    protected boolean createdFromSubGroup;
+    protected boolean createdFromSubGroup=false;
     protected ArrayList<DataDTO> rules = new ArrayList<DataDTO>();
 
     public Long getPk() {


### PR DESCRIPTION
BroadleafCommerce/QA#4061
Offer rules should allow between rules

Changed logic so checkForInvalidSubGroup will check only dtos created from subgroup

Changed test because it should be a valid case according to Brian & Daniel