### PR TITLE
Add default value to Content Items

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/DynamicFieldPersistenceHandlerHelper.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/DynamicFieldPersistenceHandlerHelper.java
@@ -54,6 +54,7 @@ public class DynamicFieldPersistenceHandlerHelper {
         property.setName(definition.getName());
         BasicFieldMetadata fieldMetadata = new BasicFieldMetadata();
         property.setMetadata(fieldMetadata);
+        property.setValue(definition.getDefaultValue());
         fieldMetadata.setFieldType(definition.getFieldType());
 
         fieldMetadata.setMutable(true);
@@ -194,6 +195,7 @@ public class DynamicFieldPersistenceHandlerHelper {
             fieldMetadata.setGroup(group.getName());
             fieldMetadata.setGroupCollapsed(group.getInitCollapsedFlag());
             fieldMetadata.setGroupOrder(groupOrder.intValue());
+
             propertiesList.add(property);
         }
     }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinition.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinition.java
@@ -23,6 +23,8 @@ import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 
 import java.io.Serializable;
 
+import javax.annotation.Nonnull;
+
 /**
  * Created by bpolster.
  */
@@ -112,4 +114,17 @@ public interface FieldDefinition extends Serializable, MultiTenantCloneable<Fiel
 
     public void setAdditionalForeignKeyClass(String className);
 
+    /**
+     * Sets the default value of this custom field.
+     * @return
+     */
+    @Nonnull
+    public String getDefaultValue();
+
+    /**
+     * Sets the default value of this custom field.
+     * @return
+     */
+    @Nonnull
+    public void setDefaultValue(@Nonnull String value);
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -126,6 +126,7 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     @JoinColumn(name = "FLD_GROUP_ID")
     protected FieldGroup fieldGroup;
 
+
     @Column(name="FLD_ORDER")
     @AdminPresentation(friendlyName = "FieldDefinitionImpl_fieldOrder", order = 3000)
     protected Integer fieldOrder = 0;
@@ -138,6 +139,10 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
 
     @Column (name = "HINT")
     protected String hint;
+
+    @AdminPresentation
+    @Column (name = "DEFAULT_VALUE")
+    protected String defaultValue;
 
     @Override
     public Long getId() {
@@ -193,6 +198,17 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
         }
         
         this.fieldType = SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|' + className;
+    }
+
+    @Override
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+
+    @Override
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -1076,7 +1076,10 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                      .withTypeaheadEnabled(fmd.getEnableTypeaheadLookup())
                      .withCanLinkToExternalEntity(fmd.getCanLinkToExternalEntity())
                      .withAssociatedFieldName(fmd.getAssociatedFieldName());
-
+                    if (f.getValue() == null || f.getValue().isEmpty()) {
+                        f.setValue(property.getValue());
+                        f.setDisplayValue(property.getValue());
+                    }
                     String defaultValue = fmd.getDefaultValue();
                     if (defaultValue != null) {
                         defaultValue = extractDefaultValueFromFieldData(fieldType, fmd);


### PR DESCRIPTION
**A Brief Overview**
Broadleaf does not have support for default values for Content Items.
Added a new colum defaultValue to table BLC_FLD_DEF
and if we add new field it will set to defaultValue if it have such.

BroadleafCommerce/QA#4031