### PR TITLE
Cannot add additional content data

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -66,7 +66,7 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Column(name = "FLD_GROUP_ID")
     protected Long id;
 
-    @Column (name = "NAME",unique = true)
+    @Column (name = "NAME", unique = true)
     protected String name;
 
     @Column (name = "INIT_COLLAPSED_FLAG")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -66,7 +66,7 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Column(name = "FLD_GROUP_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column (name = "NAME",unique = true)
     protected String name;
 
     @Column (name = "INIT_COLLAPSED_FLAG")


### PR DESCRIPTION

**A Brief Overview**
If got same names of field group with master field group and not master field group,
it will removed additional content data. Solution is make name unique to avoid unwanted remove

**Additional context**
BroadleafCommerce/QA#4035