### PR TITLE
Upgrade lib quartz-scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.2</version>
                 <type>jar</type>
                 <scope>compile</scope>
             </dependency>


### PR DESCRIPTION
**A Brief Overview**
CVE-2019-13990
initDocumentParser in xml/XMLSchedulingDataProcessor.java in Terracotta Quartz Scheduler through 2.3.0 allows XXE attacks via a job description.
Patched version: 2.3.2

**Additional context**
BroadleafCommerce/QA#4098