### PR TITLE
Improve jcache support so that other cache providers other than ehcache can easily be used

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/config/CmsCacheConfiguration.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/config/CmsCacheConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * BroadleafCommerce CMS Module
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.cms.config;
+
+import org.broadleafcommerce.common.extensibility.cache.JCacheRegionConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for defining cache regions via Java config when either not using ehcache or when jcache.create.cache.forceJavaConfig is true
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Configuration
+public class CmsCacheConfiguration {
+
+    @Bean
+    public JCacheRegionConfiguration blCMSElements() {
+        return new JCacheRegionConfiguration("blCMSElements", 3600, 10000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration cmsPageCache() {
+        return new JCacheRegionConfiguration("cmsPageCache", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration cmsPageMapCache() {
+        return new JCacheRegionConfiguration("cmsPageMapCache", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration uriCachedDateCache() {
+        return new JCacheRegionConfiguration("uriCachedDateCache", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration cmsStructuredContentCache() {
+        return new JCacheRegionConfiguration("cmsStructuredContentCache", 3600, 5000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration cmsUrlHandlerCache() {
+        return new JCacheRegionConfiguration("cmsUrlHandlerCache", 3600, 5000);
+    }
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/config/OpenAdminCacheConfig.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/config/OpenAdminCacheConfig.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.config;
+
+import org.broadleafcommerce.common.extensibility.cache.JCacheRegionConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for defining cache regions via Java config when either not using ehcache or when jcache.create.cache.forceJavaConfig is true
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Configuration
+public class OpenAdminCacheConfig {
+
+    @Bean
+    public JCacheRegionConfiguration blAdminSecurityQuery() {
+        return new JCacheRegionConfiguration("blAdminSecurityQuery", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blAdminSecurityQueryVolatile() {
+        return new JCacheRegionConfiguration("blAdminSecurityQueryVolatile", 60, 200);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blAdminSecurity() {
+        return new JCacheRegionConfiguration("blAdminSecurity", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blAdminSecurityVolatile() {
+        return new JCacheRegionConfiguration("blAdminSecurityVolatile", 60, 200);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/config/CommonCacheConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/CommonCacheConfiguration.java
@@ -1,0 +1,202 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.config;
+
+import org.broadleafcommerce.common.extensibility.cache.JCacheRegionConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for defining cache regions via Java config when either not using ehcache or when jcache.create.cache.forceJavaConfig is true
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Configuration
+public class CommonCacheConfiguration {
+
+    @Bean
+    public JCacheRegionConfiguration defaultUpdateTimestampsRegion() {
+        return new JCacheRegionConfiguration("default-update-timestamps-region", -1, 5000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration defaultQueryResultsRegion() {
+        return new JCacheRegionConfiguration("default-query-results-region", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blStandardElements() {
+        return new JCacheRegionConfiguration("blStandardElements", 86400, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProducts() {
+        return new JCacheRegionConfiguration("blProducts", 86400, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProductUrlCache() {
+        return new JCacheRegionConfiguration("blProductUrlCache", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blCategories() {
+        return new JCacheRegionConfiguration("blCategories", 86400, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blCategoryUrlCache() {
+        return new JCacheRegionConfiguration("blCategoryUrlCache", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blOffers() {
+        return new JCacheRegionConfiguration("blOffers", 86400, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blInventoryElements() {
+        return new JCacheRegionConfiguration("blInventoryElements", 60, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryCatalog() {
+        return new JCacheRegionConfiguration("query.Catalog", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryPriceList() {
+        return new JCacheRegionConfiguration("query.PriceList", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryCms() {
+        return new JCacheRegionConfiguration("query.Cms", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryOffer() {
+        return new JCacheRegionConfiguration("query.Offer", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blOrderElements() {
+        return new JCacheRegionConfiguration("blOrderElements", 600, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blCustomerElements() {
+        return new JCacheRegionConfiguration("blCustomerElements", 600, 100000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryOrder() {
+        return new JCacheRegionConfiguration("query.Order", 60, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration querySearch() {
+        return new JCacheRegionConfiguration("query.Search", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration generatedResourceCache() {
+        return new JCacheRegionConfiguration("generatedResourceCache", 600, 100);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blTemplateElements() {
+        return new JCacheRegionConfiguration("blTemplateElements", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blTranslationElements() {
+        return new JCacheRegionConfiguration("blTranslationElements", 3600, 10000000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blBatchTranslationCache() {
+        return new JCacheRegionConfiguration("blBatchTranslationCache", -1, 10000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blConfigurationModuleElements() {
+        return new JCacheRegionConfiguration("blConfigurationModuleElements", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryConfigurationModuleElements() {
+        return new JCacheRegionConfiguration("query.ConfigurationModuleElements", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSystemPropertyElements() {
+        return new JCacheRegionConfiguration("blSystemPropertyElements", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSystemPropertyNullCheckCache() {
+        return new JCacheRegionConfiguration("blSystemPropertyNullCheckCache", 600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blBundleElements() {
+        return new JCacheRegionConfiguration("blBundleElements", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blResourceCacheElements() {
+        return new JCacheRegionConfiguration("blResourceCacheElements", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blResourceTransformerCacheElements() {
+        return new JCacheRegionConfiguration("blResourceTransformerCacheElements", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSandBoxElements() {
+        return new JCacheRegionConfiguration("blSandBoxElements", 3, 2000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration queryblSandBoxElements() {
+        return new JCacheRegionConfiguration("query.blSandBoxElements", 3, 500);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSecurityElements() {
+        return new JCacheRegionConfiguration("blSecurityElements", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSiteElements() {
+        return new JCacheRegionConfiguration("blSiteElements", 3600, 5000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSiteElementsQuery() {
+        return new JCacheRegionConfiguration("blSiteElementsQuery", 3600, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProductOverrideCache() {
+        return new JCacheRegionConfiguration("blProductOverrideCache", -1, 100);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/config/dao/SystemPropertiesDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/dao/SystemPropertiesDaoImpl.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.cache.AbstractCacheMissAware;
 import org.broadleafcommerce.common.cache.PersistentRetrieval;
+import org.broadleafcommerce.common.config.domain.NullSystemProperty;
 import org.broadleafcommerce.common.config.domain.SystemProperty;
 import org.broadleafcommerce.common.config.domain.SystemPropertyImpl;
 import org.broadleafcommerce.common.extensibility.jpa.SiteDiscriminator;
@@ -64,6 +65,8 @@ public class SystemPropertiesDaoImpl extends AbstractCacheMissAware<SystemProper
 
     @Resource(name = "blSystemPropertyDaoQueryExtensionManager")
     protected SystemPropertyDaoQueryExtensionManager queryExtensionManager;
+
+    private SystemProperty nullObject;
 
     @Override
     public SystemProperty readById(Long id) {
@@ -188,4 +191,13 @@ public class SystemPropertiesDaoImpl extends AbstractCacheMissAware<SystemProper
         }
         return site;
     }
+
+    @Override
+    protected synchronized SystemProperty getNullObject(final Class<SystemProperty> responseClass) {
+        if (nullObject == null) {
+            nullObject = new NullSystemProperty();
+        }
+        return nullObject;
+    }
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/config/domain/NullSystemProperty.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/domain/NullSystemProperty.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.config.domain;
+
+import org.broadleafcommerce.common.cache.AbstractCacheMissAware;
+import org.broadleafcommerce.common.config.dao.SystemPropertiesDaoImpl;
+import org.broadleafcommerce.common.config.service.type.SystemPropertyFieldType;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+
+/**
+ * Class created for caching misses as some cache implementations, such as Redis, are unable to serialize a proxy (see {@link AbstractCacheMissAware} and {@link SystemPropertiesDaoImpl})
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public class NullSystemProperty implements SystemProperty {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public <G extends SystemProperty> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+        return null;
+    }
+
+    @Override
+    public Long getId() {
+        return null;
+    }
+
+    @Override
+    public void setId(Long id) {
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public void setName(String name) {
+    }
+
+    @Override
+    public Boolean getOverrideGeneratedPropertyName() {
+        return null;
+    }
+
+    @Override
+    public void setOverrideGeneratedPropertyName(Boolean overrideGeneratedPropertyName) {
+    }
+
+    @Override
+    public String getValue() {
+        return null;
+    }
+
+    @Override
+    public void setValue(String value) {
+
+    }
+
+    @Override
+    public SystemPropertyFieldType getPropertyType() {
+        return null;
+    }
+
+    @Override
+    public void setPropertyType(SystemPropertyFieldType type) {
+    }
+
+    @Override
+    public String getFriendlyName() {
+        return null;
+    }
+
+    @Override
+    public void setFriendlyName(String friendlyName) {
+    }
+
+    @Override
+    public String getFriendlyGroup() {
+        return null;
+    }
+
+    @Override
+    public void setFriendlyGroup(String friendlyGroup) {
+    }
+
+    @Override
+    public String getFriendlyTab() {
+        return null;
+    }
+
+    @Override
+    public void setFriendlyTab(String friendlyTab) {
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof NullSystemProperty;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ConditionalOnEhCacheMissing.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ConditionalOnEhCacheMissing.java
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to indicate that a class should be instantiated as a bean if ehcache is missing fromm the classpath
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnEhCacheMissingCondition.class)
+public @interface ConditionalOnEhCacheMissing {
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/DefaultJCacheConfigurationBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/DefaultJCacheConfigurationBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.cache.configuration.Configuration;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.EternalExpiryPolicy;
+import javax.cache.expiry.ExpiryPolicy;
+
+@Service("blJCacheConfigurationBuilder")
+@ConditionalOnEhCacheMissing
+public class DefaultJCacheConfigurationBuilder implements JCacheConfigurationBuilder {
+
+    @Override
+    public Configuration buildConfiguration(JCacheRegionConfiguration regionInformation) {
+        return buildConfiguration(regionInformation.getTtlSeconds(), regionInformation.getMaxElementsInMemory(), regionInformation.getKey(), regionInformation.getValue());
+    }
+
+    @Override
+    public <K, V> Configuration<K, V> buildConfiguration(int ttlSeconds, int maxElementsInMemory, Class<K> keyClass, Class<V> valueClass) {
+        final Factory<ExpiryPolicy> expiryPolicy;
+        if (ttlSeconds < 0) {
+            //Eternal
+            expiryPolicy = EternalExpiryPolicy.factoryOf();
+        } else {
+            //Number of seconds since created in cache
+            expiryPolicy = CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, ttlSeconds));
+        }
+
+        final MutableConfiguration<K, V> config = new MutableConfiguration<>();
+        config.setTypes(keyClass, valueClass);
+        config.setExpiryPolicyFactory(expiryPolicy);
+        return config;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/DefaultJCacheUriProvider.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/DefaultJCacheUriProvider.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.extensibility.cache.jcache.JCacheUriProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+@Component("blJCacheUriProvider")
+@ConditionalOnEhCacheMissing
+public class DefaultJCacheUriProvider implements JCacheUriProvider {
+
+    private static final Log LOG = LogFactory.getLog(DefaultJCacheUriProvider.class);
+
+    @Value("${hibernate.javax.cache.uri:#{null}}")
+    protected String configLocation;
+
+    @Value("${hibernate.javax.cache.uri.relative:true}")
+    protected boolean isLocationRelative;
+
+    @Override
+    public URI getJCacheUri() {
+        if (StringUtils.isEmpty(configLocation)) {
+            return null;
+        }
+        try {
+            if (isLocationRelative) {
+                URL url = getClass().getClassLoader().getResource(configLocation);
+                if (url != null) {
+                    return url.toURI();
+                }
+                LOG.warn("The property hibernate.javax.cache.uri.relative was set to true however there was no resource found for " + configLocation + ". Falling back on creating a URI from the provided config location set by the property hibernate.javax.cache.uri");
+            }
+            return new URI(configLocation);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Incorrect URI syntax set for property hibernate.javax.cache.uri", e);
+        }
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/JCacheConfigurationBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/JCacheConfigurationBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import javax.cache.configuration.Configuration;
+
+/**
+ * Helper class for building {@link Configuration} classes
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public interface JCacheConfigurationBuilder {
+
+    /**
+     * Given a {@link JCacheRegionConfiguration} build the appropriate {@link Configuration} class
+     * 
+     * The purpose of this method is to allow for extensibility and customization when using specific JCache implementations since most
+     * support more configuration than the JSR-107 spec allows
+     * 
+     * @param regionInformation The {@link JCacheRegionConfiguration} to use to build the {@link Configuration}
+     * @return The {@link Configuration}
+     */
+    public Configuration buildConfiguration(JCacheRegionConfiguration regionInformation);
+
+    /**
+     * Similar to {@link #buildConfiguration(JCacheRegionConfiguration)} however it requires more specifc arguments.
+     * 
+     * The purpose of this method was for internal Broadleaf usages where we're sending the exact arguments
+     * 
+     * @deprecated use {@link #buildConfiguration(JCacheRegionConfiguration)} as this will be removed in the future
+     * @param <K> The key class of the {@link Configuration}
+     * @param <V> The value class of the {@link Configuration}
+     * @param ttlSeconds The time to live for cache items in seconds
+     * @param maxElementsInMemory The maximum number of elments allowed in the cache. Note that in some JCache implementations this is not used
+     * @param keyClass The key class of the {@link Configuration}
+     * @param valueClass The value class of the {@link Configuration}
+     * @return
+     */
+    @Deprecated
+    public <K, V> Configuration<K, V> buildConfiguration(int ttlSeconds, int maxElementsInMemory, Class<K> keyClass, Class<V> valueClass);
+    
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/JCacheRegionConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/JCacheRegionConfiguration.java
@@ -1,0 +1,137 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import javax.cache.configuration.Configuration;
+
+/**
+ * DTO object to represent the configuration of a cache region
+ * 
+ * If {@link #configuration} is set then it will be used to create the region otherwise the other properties will be used.
+ * If this class is subclassed then {@link JCacheConfigurationBuilder} will likely also need to be overridden in order to utilize any new properties.
+ * 
+ * By default instances of this class are defined in Broadleaf to set the default configuration for known cache regions. If you would like to override
+ * cache regions using this DTO when targeting ehcache then set the property jcache.create.cache.forceJavaConfig to true. When targeting any other jcache
+ * implementation simply create an instance of this DTO for each new region or region override as a bean.
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public class JCacheRegionConfiguration {
+
+    protected String cacheName;
+    protected int ttlSeconds;
+    protected int maxElementsInMemory;
+    protected Class<?> key;
+    protected Class<?> value;
+    protected Boolean enableManagement;
+    protected Boolean enableStatistics;
+    protected Configuration<?, ?> configuration;
+
+    public JCacheRegionConfiguration(String cacheName, int ttlSeconds, int maxElementsInMemory, Class<?> key, Class<?> value, Boolean enableManagement, Boolean enableStatistics) {
+        this.cacheName = cacheName;
+        this.ttlSeconds = ttlSeconds;
+        this.maxElementsInMemory = maxElementsInMemory;
+        this.key = key;
+        this.value = value;
+        this.enableManagement = enableManagement;
+        this.enableStatistics = enableStatistics;
+    }
+
+    public JCacheRegionConfiguration(String cacheName, int ttlSeconds, int maxElementsInMemory, Class<?> key, Class<?> value) {
+        this(cacheName, ttlSeconds, maxElementsInMemory, key, value, true, true);
+    }
+
+    public JCacheRegionConfiguration(String cacheName, int ttlSeconds, int maxElementsInMemory) {
+        this(cacheName, ttlSeconds, maxElementsInMemory, Object.class, Object.class);
+    }
+
+    public JCacheRegionConfiguration(String cacheName) {
+        this(cacheName, -1, 1000, Object.class, Object.class);
+    }
+
+    public JCacheRegionConfiguration(String cacheName, Configuration<?, ?> configuration) {
+        this.cacheName = cacheName;
+        this.configuration = configuration;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCacheName(String cacheName) {
+        this.cacheName = cacheName;
+    }
+
+    public int getTtlSeconds() {
+        return ttlSeconds;
+    }
+
+    public void setTtlSeconds(int ttlSeconds) {
+        this.ttlSeconds = ttlSeconds;
+    }
+
+    public int getMaxElementsInMemory() {
+        return maxElementsInMemory;
+    }
+
+    public void setMaxElementsInMemory(int maxElementsInMemory) {
+        this.maxElementsInMemory = maxElementsInMemory;
+    }
+
+    public Class<?> getKey() {
+        return key;
+    }
+
+    public void setKey(Class<?> key) {
+        this.key = key;
+    }
+
+    public Class<?> getValue() {
+        return value;
+    }
+
+    public void setValue(Class<?> value) {
+        this.value = value;
+    }
+
+    public Boolean getEnableManagement() {
+        return enableManagement;
+    }
+
+    public void setEnableManagement(Boolean enableManagement) {
+        this.enableManagement = enableManagement;
+    }
+
+    public Boolean getEnableStatistics() {
+        return enableStatistics;
+    }
+
+    public void setEnableStatistics(Boolean enableStatistics) {
+        this.enableStatistics = enableStatistics;
+    }
+
+    public Configuration<?, ?> getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(Configuration<?, ?> configuration) {
+        this.configuration = configuration;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/OnEhCacheMissingCondition.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/OnEhCacheMissingCondition.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache;
+
+import org.broadleafcommerce.common.extensibility.cache.ehcache.OnEhCacheCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition specifying that ehcache is not on the classpath
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public class OnEhCacheMissingCondition extends OnEhCacheCondition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return !super.matches(context, metadata);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/ConditionalOnEhCache.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/ConditionalOnEhCache.java
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache.ehcache;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to indicate that a class should be instantiated as a bean if ehcache is on the classpath
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnEhCacheCondition.class)
+public @interface ConditionalOnEhCache {
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/DefaultEhCacheConfigurationBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/DefaultEhCacheConfigurationBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache.ehcache;
+
+import org.broadleafcommerce.common.extensibility.cache.DefaultJCacheConfigurationBuilder;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.expiry.ExpiryPolicy;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.stereotype.Service;
+
+import javax.cache.configuration.Configuration;
+
+@Service("blJCacheConfigurationBuilder")
+@ConditionalOnEhCache
+public class DefaultEhCacheConfigurationBuilder extends DefaultJCacheConfigurationBuilder {
+
+    @Override
+    public <K, V> Configuration<K, V> buildConfiguration(int ttlSeconds, int maxElementsInMemory, Class<K> keyClass, Class<V> valueClass) {
+        ExpiryPolicy<Object, Object> expiryPolicy = new DefaultExpiryPolicy(ttlSeconds);
+        
+        CacheConfiguration config = CacheConfigurationBuilder.
+                newCacheConfigurationBuilder(valueClass, keyClass, ResourcePoolsBuilder.heap(maxElementsInMemory))
+                .withExpiry(expiryPolicy)
+                .build();
+
+        return Eh107Configuration.fromEhcacheCacheConfiguration(config);
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/DefaultEhCacheUriProvider.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/DefaultEhCacheUriProvider.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache.ehcache;
+
+import org.apache.commons.io.IOUtils;
+import org.broadleafcommerce.common.extensibility.cache.DefaultJCacheUriProvider;
+import org.broadleafcommerce.common.extensibility.context.merge.MergeXmlConfigResource;
+import org.broadleafcommerce.common.extensibility.context.merge.ResourceInputStream;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component("blJCacheUriProvider")
+@ConditionalOnEhCache
+public class DefaultEhCacheUriProvider extends DefaultJCacheUriProvider implements ApplicationContextAware, InitializingBean {
+
+    @javax.annotation.Resource(name = "blMergedCacheConfigLocations")
+    protected Set<String> mergedCacheConfigLocations;
+
+    protected URI cacheManagerUri = new File(System.getProperty("java.io.tmpdir"), "broadleaf-merged-jcache.xml").toURI();
+
+    protected List<Resource> configLocations;
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        mergeCacheLocations();
+    }
+
+    @Override
+    public URI getJCacheUri() {
+        return cacheManagerUri;
+    }
+
+    protected void mergeCacheLocations() throws IOException {
+        List<Resource> resources = new ArrayList<>();
+        if (mergedCacheConfigLocations != null && !mergedCacheConfigLocations.isEmpty()) {
+            for (String location : mergedCacheConfigLocations) {
+                resources.add(applicationContext.getResource(location));
+            }
+        }
+        if (configLocations != null && !configLocations.isEmpty()) {
+            resources.addAll(configLocations);
+        }
+        MergeXmlConfigResource merge = new MergeXmlConfigResource();
+        ResourceInputStream[] sources = new ResourceInputStream[resources.size()];
+        int j = 0;
+        for (Resource resource : resources) {
+            sources[j] = new ResourceInputStream(resource.getInputStream(), resource.getURL().toString());
+            j++;
+        }
+
+        Resource mergeResource = merge.getMergedConfigResource(sources);
+        createTemporaryMergeXml(mergeResource);
+    }
+    
+    protected File createTemporaryMergeXml(Resource mergedJcacheResource) throws FileNotFoundException, IOException {
+        File file = new File(getJCacheUri());
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+        }
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+            IOUtils.copy(mergedJcacheResource.getInputStream(), outputStream);
+        }
+        return file;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    public void setConfigLocations(List<Resource> configLocations) throws BeansException {
+        this.configLocations = configLocations;
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/OnEhCacheCondition.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/OnEhCacheCondition.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache.ehcache;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition for checking if ehcache is on the classpath
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public class OnEhCacheCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        try {
+            Class.forName("org.ehcache.jsr107.EhcacheCachingProvider");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/jcache/JCacheUriProvider.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/jcache/JCacheUriProvider.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.extensibility.cache.jcache;
+
+import java.net.URI;
+
+/**
+ * Provides the URI to be used for JCache configuration
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+public interface JCacheUriProvider {
+
+    /**
+     * Returns the URI that should be used for JCache configuration
+     * 
+     * @return the URI to use
+     */
+    public URI getJCacheUri();
+}

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/jcache/MergeJCacheManagerFactoryBean.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/jcache/MergeJCacheManagerFactoryBean.java
@@ -17,38 +17,24 @@
  */
 package org.broadleafcommerce.common.extensibility.cache.jcache;
 
-import org.apache.commons.io.IOUtils;
-import org.broadleafcommerce.common.extensibility.cache.ehcache.DefaultEhCacheUtil;
+import org.apache.commons.collections4.CollectionUtils;
+import org.broadleafcommerce.common.extensibility.cache.JCacheConfigurationBuilder;
+import org.broadleafcommerce.common.extensibility.cache.JCacheRegionConfiguration;
 import org.broadleafcommerce.common.extensibility.cache.ehcache.NoOpCacheManager;
-import org.broadleafcommerce.common.extensibility.context.merge.MergeXmlConfigResource;
-import org.broadleafcommerce.common.extensibility.context.merge.ResourceInputStream;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.io.Resource;
-import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import javax.cache.CacheManager;
 import javax.cache.Caching;
+import javax.cache.configuration.Configuration;
 import javax.cache.spi.CachingProvider;
 
 /**
@@ -59,7 +45,7 @@ import javax.cache.spi.CachingProvider;
  * @author Kelly Tisdell
  *
  */
-public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>, BeanClassLoaderAware, InitializingBean, DisposableBean, ApplicationContextAware {
+public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>, BeanClassLoaderAware, InitializingBean, DisposableBean {
     
     @Nullable
     private Properties cacheManagerProperties;
@@ -70,23 +56,23 @@ public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>,
     @Nullable
     private CacheManager cacheManager;
 
-    private ApplicationContext applicationContext;
-    
-    @javax.annotation.Resource(name="blMergedCacheConfigLocations")
-    protected Set<String> mergedCacheConfigLocations;
-    
-    protected List<Resource> configLocations;
-
     @Value("${jcache.disable.cache:false}")
     protected boolean disableCache;
     
-    //We use EhCache as the default.  Provide the URI that referrs to a merged JCache (typically EhCache) XML file that will be created
-    protected URI cacheManagerUri = DefaultEhCacheUtil.JCACHE_MERGED_XML_RESOUCE_URI;
-    
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
-    }
+    @Autowired
+    protected JCacheUriProvider uriProvider;
+
+    @Autowired
+    protected JCacheConfigurationBuilder configBuilder;
+
+    @Autowired(required = false)
+    protected List<JCacheRegionConfiguration> cacheConfiguration;
+
+    @Value("${jcache.create.cache.ifMissing:true}")
+    protected boolean createIfMissing;
+
+    @Value("${jcache.create.cache.forceJavaConfig:false}")
+    protected boolean overrideWithJavaConfig;
 
     @Override
     public void afterPropertiesSet() {
@@ -95,47 +81,25 @@ public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>,
             return;
         }
 
-        if (getObject() != null && !getObject().isClosed() && getObject().getURI().equals(cacheManagerUri)) {
+        if (getObject() != null && !getObject().isClosed() && getObject().getURI().equals(uriProvider.getJCacheUri())) {
             return;
         }
         
         Caching.setDefaultClassLoader(getDefaultClassLoaderForProvider());
         CachingProvider provider = Caching.getCachingProvider();
         
-        List<Resource> resources = new ArrayList<>();
-        if (mergedCacheConfigLocations != null && !mergedCacheConfigLocations.isEmpty()) {
-            for (String location : mergedCacheConfigLocations) {
-                resources.add(applicationContext.getResource(location));
+        //The ClassLoader needs to be the same as what Hibernate expects (see org.hibernate.cache.jcache.internal.JCacheRegionFactory).
+        this.cacheManager = provider.getCacheManager(uriProvider.getJCacheUri(), 
+                provider.getDefaultClassLoader(), cacheManagerProperties);
+
+        if (createIfMissing) {
+            for (JCacheRegionConfiguration config : CollectionUtils.emptyIfNull(cacheConfiguration)) {
+                createCacheIfNotExists(config);
             }
         }
-        if (configLocations != null && !configLocations.isEmpty()) {
-            resources.addAll(configLocations);
-        }
-        try {
-            MergeXmlConfigResource merge = new MergeXmlConfigResource();
-            ResourceInputStream[] sources = new ResourceInputStream[resources.size()];
-            int j = 0;
-            for (Resource resource : resources) {
-                sources[j] = new ResourceInputStream(resource.getInputStream(), resource.getURL().toString());
-                j++;
-            }
 
-            Resource mergeResource = merge.getMergedConfigResource(sources);
-            createTemporaryMergeXml(mergeResource);
-            
-            //The ClassLoader needs to be the same as what Hibernate expects (see org.hibernate.cache.jcache.internal.JCacheRegionFactory).
-            this.cacheManager = provider.getCacheManager(cacheManagerUri,  
-                    provider.getDefaultClassLoader(), cacheManagerProperties);
-
-        } catch (Exception e) {
-            throw new FatalBeanException("Unable to merge cache locations", e);
-        }
     }
 
-    public void setConfigLocations(List<Resource> configLocations) throws BeansException {
-        this.configLocations = configLocations;
-    }
-    
     @Override
     @Nullable
     public CacheManager getObject() {
@@ -168,11 +132,6 @@ public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>,
         this.cacheManagerProperties = cacheManagerProperties;
     }
     
-    public void setCacheManagerUri(@NonNull URI cacheManagerUri) {
-        Assert.notNull(cacheManagerUri, "The CacheManager URI cannot be null.");
-        this.cacheManagerUri = cacheManagerUri;
-    }
-    
     protected ClassLoader getDefaultClassLoaderForProvider() {
         if (beanClassLoader != null) {
             return beanClassLoader;
@@ -180,16 +139,22 @@ public class MergeJCacheManagerFactoryBean implements FactoryBean<CacheManager>,
         return getClass().getClassLoader();
     }
     
-    protected File createTemporaryMergeXml(Resource mergedJcacheResource) throws FileNotFoundException, IOException {
-        File file = new File(cacheManagerUri);
-        if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.createNewFile();
+    protected void createCacheIfNotExists(JCacheRegionConfiguration config) {
+        boolean cacheMissing = cacheManager.getCache(config.getCacheName()) == null;
+        if (cacheMissing || overrideWithJavaConfig) {
+            if (!cacheMissing) {
+                cacheManager.destroyCache(config.getCacheName());
+            }
+            Configuration configuration = config.getConfiguration() != null ? config.getConfiguration() : configBuilder.buildConfiguration(config);
+            cacheManager.createCache(config.getCacheName(), configuration);
+            if (config.getEnableManagement() != null) {
+                cacheManager.enableManagement(config.getCacheName(), config.getEnableManagement());
+            }
+            if (config.getEnableStatistics() != null) {
+                cacheManager.enableStatistics(config.getCacheName(), config.getEnableStatistics());
+            }
         }
-        try (OutputStream outputStream = new FileOutputStream(file)) {
-            IOUtils.copy(mergedJcacheResource.getInputStream(), outputStream);
-        }
-        return file;
     }
+
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JCachePersistenceUnitPostProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/JCachePersistenceUnitPostProcessor.java
@@ -17,17 +17,48 @@
  */
 package org.broadleafcommerce.common.extensibility.jpa;
 
-import org.broadleafcommerce.common.extensibility.cache.DefaultJCacheUtil;
+import org.broadleafcommerce.common.extensibility.cache.jcache.JCacheUriProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitPostProcessor;
 
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Persistence unit post processor for dynamically modifying the persistence unit. 
+ * 
+ * jcache.disable.cache - default: false, disables hibernate L2 and query cache if true
+ * hibernate.javax.cache.provider - default: null, overrides the cache provider defined in the persistence.xml
+ * hibernate.cache.region.factory_class - default: null, overrides the cache region factory defined in the persistence.xml
+ * 
+ * uriProvider - A configurable provider class that returns the URI to be used for caching
+ * overrideCacheProperties - A map used to set any additional properties on the persistence unit, presumeably related to caching
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
 public class JCachePersistenceUnitPostProcessor implements PersistenceUnitPostProcessor {
 
     @Value("${jcache.disable.cache:false}")
     protected Boolean disableCache;
+
+    @Value("${hibernate.javax.cache.provider:#{null}}")
+    protected String cacheProvider;
+
+    @Value("${hibernate.cache.region.factory_class:#{null}}")
+    protected String cacheRegionFactory;
+
+    @Autowired
+    protected JCacheUriProvider uriProvider;
+
+    @Autowired(required = false)
+    @Qualifier("blJCachePUPostProcessorOverrideProperties")
+    protected Map<String, String> overrideCacheProperties = new HashMap<>();
 
     @Override
     public void postProcessPersistenceUnitInfo(MutablePersistenceUnitInfo pui) {
@@ -36,7 +67,19 @@ public class JCachePersistenceUnitPostProcessor implements PersistenceUnitPostPr
             properties.setProperty("hibernate.cache.use_second_level_cache", "false");
             properties.setProperty("hibernate.cache.use_query_cache", "false");
         }
-        properties.setProperty("hibernate.javax.cache.uri", DefaultJCacheUtil.JCACHE_MERGED_XML_RESOUCE_URI.toString());
+
+        URI cacheUri = uriProvider.getJCacheUri();
+        properties.setProperty("hibernate.javax.cache.uri", cacheUri != null ? uriProvider.getJCacheUri().toString() : "");
+
+        if (cacheRegionFactory != null) {
+            properties.setProperty("hibernate.cache.region.factory_class", cacheRegionFactory);
+        }
+
+        if (cacheProvider != null) {
+            properties.setProperty("hibernate.javax.cache.provider", cacheProvider);
+        }
+
+        properties.putAll(overrideCacheProperties);
     }
 
 }

--- a/common/src/main/resources/bl-common-applicationContext-persistence.xml
+++ b/common/src/main/resources/bl-common-applicationContext-persistence.xml
@@ -89,10 +89,6 @@
     
     <bean id="blCacheManager" class="org.broadleafcommerce.common.extensibility.cache.jcache.MergeJCacheManagerFactoryBean"/>
     
-    <bean id="blJCacheUtil" class="org.broadleafcommerce.common.extensibility.cache.ehcache.DefaultEhCacheUtil">
-        <constructor-arg ref="blCacheManager"/>
-    </bean>
-
     <bean id="blMergedCacheConfigLocations" class="org.springframework.beans.factory.config.ListFactoryBean">
         <property name="sourceList">
             <list>


### PR DESCRIPTION
**A Brief Overview**
Currently it's difficult to switch cache providers from ehcache to anything else since changing Hibernate's cache provider requires a persistence unit post processor, the cache URI is hard coded, and there's some ehcache specific beans instantiated by default that would need to be overridden. These changes aim to fix these issues along with some issues found when testing against Redis 

**Summary of Changes**
- Refactor ehcache xml merge into a uri provider class so that if ehcache is available we do the xml merging however if it's not available then we just return a configurable property as a URI
- Refactor the JCacheUtil into a configuration builder class so that JCache Configuration objects can be created without a depenency on the cache manager in order for its use in MergeJCacheManagerFactory
- Implement the ability to define cache regions with Java config so that Broadleaf can provide cache defaults for other cache implementations other than just ehcache
    - Supports automatically generating cache regions from java config if ehcache xml doesn't define them but they're defined in java
    - Supports overriding the ehcache xml cache regions with java config
- Added default JCache java config for known cache regions
- Added conditional annotations to automatically hook up the correct uri provider and configuration builder based on if ehcache is available on the claspath or not
- Improved the JCachePersistenceUnitPostProcessor to have the ability to override some known hibernate cache properties along with allowing for additional jcache implementation specific properties via an injected map
- Create NullSystemProperty class to use for cache missing since by default we were using a proxied implementation of SystemProperty that was serializable and would cause exception when using Redis

Resolves https://github.com/BroadleafCommerce/QA/issues/3848