### PR TITLE
Remove Offer Code with API

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/AbstractOfferServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/AbstractOfferServiceExtensionHandler.java
@@ -92,6 +92,10 @@ public class AbstractOfferServiceExtensionHandler extends AbstractExtensionHandl
         return ExtensionResultStatusType.NOT_HANDLED;
     }
 
+    @Override
+    public ExtensionResultStatusType removeOfferCodeFromOrder(OfferCode offerCode, Order order) {
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
 
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceExtensionHandler.java
@@ -132,5 +132,7 @@ public interface OfferServiceExtensionHandler extends ExtensionHandler {
      */
     ExtensionResultStatusType addAdditionalOffersForCode(List<Offer> offers, OfferCode offerCode);
 
+    ExtensionResultStatusType removeOfferCodeFromOrder(OfferCode offerCode, Order order);
+
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceExtensionManager.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceExtensionManager.java
@@ -115,6 +115,13 @@ public class OfferServiceExtensionManager extends ExtensionManager<OfferServiceE
         }
     };
 
+    public static final ExtensionManagerOperation removeOfferCodeFromOrder = new ExtensionManagerOperation() {
+        @Override
+        public ExtensionResultStatusType execute(ExtensionHandler handler, Object... params) {
+            return ((OfferServiceExtensionHandler) handler).removeOfferCodeFromOrder((OfferCode) params[0], (Order) params[1]);
+        }
+    };
+
 
     public OfferServiceExtensionManager() {
         super(OfferServiceExtensionHandler.class);
@@ -168,6 +175,11 @@ public class OfferServiceExtensionManager extends ExtensionManager<OfferServiceE
     @Override
     public ExtensionResultStatusType addAdditionalOffersForCode(List<Offer> offers, OfferCode offerCode) {
         return execute(addAdditionalOffersForCode, offers, offerCode);
+    }
+
+    @Override
+    public ExtensionResultStatusType removeOfferCodeFromOrder(OfferCode offerCode, Order order) {
+        return execute(removeOfferCodeFromOrder, offerCode, order);
     }
 
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -34,6 +34,8 @@ import org.broadleafcommerce.core.offer.dao.OfferDao;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferCode;
 import org.broadleafcommerce.core.offer.service.OfferService;
+import org.broadleafcommerce.core.offer.service.OfferServiceExtensionHandler;
+import org.broadleafcommerce.core.offer.service.OfferServiceExtensionManager;
 import org.broadleafcommerce.core.offer.service.exception.OfferAlreadyAddedException;
 import org.broadleafcommerce.core.offer.service.exception.OfferException;
 import org.broadleafcommerce.core.offer.service.exception.OfferExpiredException;
@@ -200,6 +202,10 @@ public class OrderServiceImpl implements OrderService {
 
     @Resource(name = "blOrderMultishipOptionService")
     protected OrderMultishipOptionService orderMultishipOptionService;
+
+    @Resource(name = "blOfferServiceExtensionManager")
+    protected OfferServiceExtensionManager offerServiceExtensionManager;
+
 
     @Override
     @Transactional("blTransactionManager")
@@ -480,6 +486,7 @@ public class OrderServiceImpl implements OrderService {
     @Transactional("blTransactionManager")
     public Order removeOfferCode(Order order, OfferCode offerCode, boolean priceOrder) throws PricingException {
         order.getAddedOfferCodes().remove(offerCode);
+        offerServiceExtensionManager.removeOfferCodeFromOrder(offerCode, order);
         order = save(order, priceOrder);
         return order;   
     }


### PR DESCRIPTION
BroadleafCommerce/QA#4137
Remove Offer Code with API
Introduce new remove method in extension handler so in advanced offer we will remove customer-offercode relationship
