### PR TITLE
Xss protection encoding html entities looks wrong in admin

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -1471,7 +1471,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                             Class<MediaDto> type = entityConfiguration.lookupEntityClass(MediaDto.class.getName(), MediaDto.class);
                             mf.setMedia(mediaBuilderService.convertJsonToMedia(entityProp.getUnHtmlEncodedValue(), type));
                         } else if (!SupportedFieldType.PASSWORD_CONFIRM.equals(basicFM.getExplicitFieldType())) {
-                            field.setValue((basicFM.isLargeEntry()!=null && basicFM.isLargeEntry()) ? entityProp.getValue() : exploitProtectionService.htmlDecode(entityProp.getValue()));
+                            field.setValue((basicFM.isLargeEntry() != null && basicFM.isLargeEntry()) ? entityProp.getValue() : exploitProtectionService.htmlDecode(entityProp.getValue()));
                             field.setDisplayValue(entityProp.getDisplayValue());
                         }
                     }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -311,6 +311,12 @@ public class FormBuilderServiceImpl implements FormBuilderService {
             fieldDTO.setInput("select");
             fieldDTO.setType("string");
             String[][] enumerationValues = fmd.getEnumerationValues ();
+
+            //not sure if we need to decode here or not...
+            for(int i=0; i< enumerationValues.length;i++){
+                enumerationValues[i][1] = exploitProtectionService.htmlDecode(enumerationValues[i][1]);
+            }
+
             Map<String, String> enumMap = new HashMap<>();
             for (int i = 0; i < enumerationValues.length; i++) {
                 enumMap.put(enumerationValues[i][0], enumerationValues[i][1]);
@@ -342,7 +348,11 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                 fmd.getFieldType().equals(SupportedFieldType.DATA_DRIVEN_ENUMERATION) ||
                 fmd.getFieldType().equals(SupportedFieldType.EMPTY_ENUMERATION)) {
             hf = new ComboField();
-            ((ComboField) hf).setOptions(fmd.getEnumerationValues());
+            String[][] enumerationValues = fmd.getEnumerationValues();
+            for(int i=0; i< enumerationValues.length;i++){
+                enumerationValues[i][1] = exploitProtectionService.htmlDecode(enumerationValues[i][1]);
+            }
+            ((ComboField) hf).setOptions(enumerationValues);
         } else {
             hf = new Field();
         }
@@ -994,7 +1004,12 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                             || fieldType.equals(SupportedFieldType.EMPTY_ENUMERATION.toString())) {
                         // We're dealing with fields that should render as drop-downs, so set their possible values
                         f = new ComboField();
-                        ((ComboField) f).setOptions(fmd.getEnumerationValues());
+
+                        String[][] enumerationValues = fmd.getEnumerationValues();
+                        for(int i=0; i< enumerationValues.length;i++){
+                            enumerationValues[i][1] = exploitProtectionService.htmlDecode(enumerationValues[i][1]);
+                        }
+                        ((ComboField) f).setOptions(enumerationValues);
                         if (fmd.getHideEnumerationIfEmpty() != null && fmd.getHideEnumerationIfEmpty().booleanValue()
                                 && ((ComboField) f).getOptions().size() == 0) {
                             f.setIsVisible(false);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -1471,7 +1471,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                             Class<MediaDto> type = entityConfiguration.lookupEntityClass(MediaDto.class.getName(), MediaDto.class);
                             mf.setMedia(mediaBuilderService.convertJsonToMedia(entityProp.getUnHtmlEncodedValue(), type));
                         } else if (!SupportedFieldType.PASSWORD_CONFIRM.equals(basicFM.getExplicitFieldType())) {
-                            field.setValue(basicFM.isLargeEntry() ? entityProp.getValue() : exploitProtectionService.htmlDecode(entityProp.getValue()));
+                            field.setValue((basicFM.isLargeEntry()!=null && basicFM.isLargeEntry()) ? entityProp.getValue() : exploitProtectionService.htmlDecode(entityProp.getValue()));
                             field.setDisplayValue(entityProp.getDisplayValue());
                         }
                     }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -40,6 +40,7 @@ import org.broadleafcommerce.common.presentation.client.LookupType;
 import org.broadleafcommerce.common.presentation.client.PersistencePerspectiveItemType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.security.service.ExploitProtectionService;
 import org.broadleafcommerce.common.util.BLCMessageUtils;
 import org.broadleafcommerce.common.util.FormatUtil;
 import org.broadleafcommerce.common.util.StringUtil;
@@ -172,6 +173,9 @@ public class FormBuilderServiceImpl implements FormBuilderService {
 
     @Value("${use.translation.search:false}")
     protected boolean useTranslationSearch;
+
+    @Resource(name = "blExploitProtectionService")
+    ExploitProtectionService exploitProtectionService;
 
     protected static final VisibilityEnum[] FORM_HIDDEN_VISIBILITIES = new VisibilityEnum[] { 
             VisibilityEnum.HIDDEN_ALL, VisibilityEnum.FORM_HIDDEN
@@ -1382,7 +1386,7 @@ public class FormBuilderServiceImpl implements FormBuilderService {
 
         Property p = entity.findProperty(BasicPersistenceModule.MAIN_ENTITY_NAME_PROPERTY);
         if (p != null) {
-            ef.setMainEntityName(p.getValue());
+            ef.setMainEntityName(exploitProtectionService.htmlDecode(p.getValue()));
         }
         
         extensionManager.getProxy().modifyPopulatedEntityForm(ef, entity);
@@ -1461,13 +1465,13 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                             }
                         } 
                         if (basicFM.getFieldType() == SupportedFieldType.MEDIA) {
-                            field.setValue(entityProp.getValue());
+                            field.setValue(exploitProtectionService.htmlDecode(entityProp.getValue()));
                             field.setDisplayValue(entityProp.getDisplayValue());
                             MediaField mf = (MediaField) field;
                             Class<MediaDto> type = entityConfiguration.lookupEntityClass(MediaDto.class.getName(), MediaDto.class);
                             mf.setMedia(mediaBuilderService.convertJsonToMedia(entityProp.getUnHtmlEncodedValue(), type));
                         } else if (!SupportedFieldType.PASSWORD_CONFIRM.equals(basicFM.getExplicitFieldType())) {
-                            field.setValue(entityProp.getValue());
+                            field.setValue(basicFM.isLargeEntry() ? entityProp.getValue() : exploitProtectionService.htmlDecode(entityProp.getValue()));
                             field.setDisplayValue(entityProp.getDisplayValue());
                         }
                     }

--- a/common/src/main/java/org/broadleafcommerce/common/security/service/ExploitProtectionService.java
+++ b/common/src/main/java/org/broadleafcommerce/common/security/service/ExploitProtectionService.java
@@ -63,4 +63,5 @@ public interface ExploitProtectionService {
 
     public String getCsrfTokenParameter();
 
+    String htmlDecode(String value);
 }

--- a/common/src/main/java/org/broadleafcommerce/common/security/service/ExploitProtectionServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/security/service/ExploitProtectionServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.common.security.service;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -191,6 +192,15 @@ public class ExploitProtectionServiceImpl implements ExploitProtectionService {
     @Override
     public String getCsrfTokenParameter() {
         return CSRFTOKENPARAMETER;
+    }
+
+    @Override
+    public String htmlDecode(String value) {
+        if(xssProtectionEnabled) {
+            return StringEscapeUtils.unescapeHtml(value);
+        }else{
+            return value;
+        }
     }
 
     public void setXssProtectionEnabled(boolean xssProtectionEnabled) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -21,6 +21,7 @@ package org.broadleafcommerce.core.search.service.solr;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -74,7 +75,9 @@ import org.broadleafcommerce.core.search.domain.SearchFacetRange;
 import org.broadleafcommerce.core.search.domain.SearchFacetResultDTO;
 import org.broadleafcommerce.core.search.domain.solr.FieldType;
 import org.broadleafcommerce.core.search.service.solr.index.SolrIndexServiceExtensionManager;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -142,6 +145,10 @@ public class SolrHelperServiceImpl implements SolrHelperService {
 
     @Value(value = "${enable.solr.optimize:true}")
     private boolean optimizeEnabled;
+
+
+    @Autowired
+    protected Environment environment;
 
     /**
      * This should only ever be called when using the Solr reindex service to do a full reindex.
@@ -427,7 +434,14 @@ public class SolrHelperServiceImpl implements SolrHelperService {
     @Override
     public Object getPropertyValue(Object object, String propertyName) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         String[] components = propertyName.split("\\.");
-        return getPropertyValueInternal(object, components, 0);
+        Object propertyValueInternal = getPropertyValueInternal(object, components, 0);
+        if(propertyValueInternal instanceof String){
+            String enabled = environment.getProperty("exploitProtection.xssEnabled", "false");
+            if(Boolean.parseBoolean(enabled)){
+                return StringEscapeUtils.unescapeHtml((String) propertyValueInternal);
+            }
+        }
+        return propertyValueInternal;
     }
 
     @Override


### PR DESCRIPTION
Xss protection encoding html entities looks wrong in admin
fixes BroadleafCommerce/QA#4142

- if this is "string field" and not "large entry" and xss protection enabled content of the field will be unHtmlEscaped before rendering
- when data sent to solr if exploitProtection.xssEnabled is enabled on admin node exploitProtection.xssEnabled should be also enabled on the node that's responsible for solr indexing - it will unHtmlEscaped fields.
- "q" parameter is added to whitelist, so searching on site should be not encoded