### PR TITLE
With cache off actuator mbean for cache is failing on startup

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/NoOpCache.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/NoOpCache.java
@@ -32,6 +32,15 @@ import javax.cache.processor.EntryProcessorException;
 
 public class NoOpCache implements Cache {
 
+    private NoOpCacheManager noOpCacheManager;
+
+    public NoOpCache(){
+    }
+
+    public NoOpCache(NoOpCacheManager noOpCacheManager) {
+        this.noOpCacheManager = noOpCacheManager;
+    }
+
     @Override
     public Object get(Object o) {
         return null;
@@ -124,7 +133,7 @@ public class NoOpCache implements Cache {
 
     @Override
     public CacheManager getCacheManager() {
-        return null;
+        return noOpCacheManager;
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/NoOpCacheManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/cache/ehcache/NoOpCacheManager.java
@@ -29,7 +29,7 @@ import javax.cache.spi.CachingProvider;
 
 public class NoOpCacheManager implements CacheManager {
 
-    private NoOpCache noOpCache = new NoOpCache();
+    private NoOpCache noOpCache = new NoOpCache(this);
 
     @Override
     public CachingProvider getCachingProvider() {
@@ -38,7 +38,7 @@ public class NoOpCacheManager implements CacheManager {
 
     @Override
     public URI getURI() {
-        return null;
+        return URI.create("noop:cachemanager");
     }
 
     @Override


### PR DESCRIPTION
Fixes BroadleafCommerce/QA#4145
With cache off actuator mbean for cache is failing on startup