### PR TITLE
New Credit Card types 

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/payment/PaymentType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/payment/PaymentType.java
@@ -37,7 +37,7 @@ public class PaymentType implements Serializable, BroadleafEnumerationType {
     private static final Map<String, PaymentType> TYPES = new LinkedHashMap<String, PaymentType>();
 
     public static final PaymentType GIFT_CARD = new PaymentType("GIFT_CARD", "Gift Card", false);
-    public static final PaymentType CREDIT_CARD = new PaymentType("CREDIT_CARD", "Credit Card", true);
+    public static final PaymentType CREDIT_CARD = new PaymentType("CREDIT_CARD", "Credit Card", true, true);
     public static final PaymentType BANK_ACCOUNT = new PaymentType("BANK_ACCOUNT", "Bank Account", false);
     public static final PaymentType CHECK = new PaymentType("CHECK", "Check", false);
     public static final PaymentType ELECTRONIC_CHECK = new PaymentType("ELECTRONIC_CHECK", "Electronic Check", false);
@@ -47,6 +47,8 @@ public class PaymentType implements Serializable, BroadleafEnumerationType {
     public static final PaymentType COD = new PaymentType("COD", "Collect On Delivery", false);
     public static final PaymentType CUSTOMER_PAYMENT = new PaymentType("CUSTOMER_PAYMENT", "Customer Payment", true);
     public static final PaymentType PURCHASE_ORDER = new PaymentType("PURCHASE_ORDER", "Purchase Order", false);
+    public static final PaymentType APPLE_PAY = new PaymentType("APPLE_PAY", "Apple Pay", true, true);
+    public static final PaymentType GOOGLE_PAY = new PaymentType("GOOGLE_PAY", "Google Pay", true, true);
     /**
      * Intended for modules like PayPal Express Checkout
      *
@@ -66,6 +68,7 @@ public class PaymentType implements Serializable, BroadleafEnumerationType {
     private String type;
     private String friendlyType;
     private boolean isFinalPayment;
+    private boolean isCreditCardType;
 
     public PaymentType() {
         //do nothing
@@ -75,18 +78,31 @@ public class PaymentType implements Serializable, BroadleafEnumerationType {
         this.friendlyType = friendlyType;
         setType(type);
         this.isFinalPayment = false;
+        this.isCreditCardType = false;
     }
     
     public PaymentType(final String type, final String friendlyType, final boolean isFinalPayment) {
         this.friendlyType = friendlyType;
         this.isFinalPayment = isFinalPayment;
+        this.isCreditCardType = false;
+        setType(type);
+    }
+
+    public PaymentType(final String type, final String friendlyType, final boolean isFinalPayment, final boolean isCreditCardType) {
+        this.friendlyType = friendlyType;
+        this.isFinalPayment = isFinalPayment;
+        this.isCreditCardType = isCreditCardType;
         setType(type);
     }
     
     public boolean getIsFinalPayment() {
         return isFinalPayment;
     }
-    
+
+    public boolean isCreditCardType() {
+        return isCreditCardType;
+    }
+
     @Override
     public String getType() {
         return type;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/strategy/OrderPaymentConfirmationStrategyImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/strategy/OrderPaymentConfirmationStrategyImpl.java
@@ -119,7 +119,7 @@ public class OrderPaymentConfirmationStrategyImpl implements OrderPaymentConfirm
         if (isCheckout && enablePendingPaymentsOnCheckoutConfirmation()) {
             responseDTO = constructPendingTransaction(payment.getType(), payment.getGatewayType(), confirmationRequest);
         } else {
-            if (PaymentType.CREDIT_CARD.equals(payment.getType())) {
+            if (payment.getType().isCreditCardType()) {
                 // Handles the PCI-Compliant Scenario where you have an UNCONFIRMED CREDIT_CARD payment on the order.
                 // This can happen if you send the Credit Card directly to Broadleaf or you use a Digital Wallet solution like MasterPass.
                 // The Actual Credit Card PAN is stored in blSecurePU and will need to be sent to the Payment Gateway for processing.


### PR DESCRIPTION
Fixes BroadleafCommerce/QA#4147
Adding a way to indicate a payment type as credit card.  Credit Card types need to have payment confirmation before the order can be submitted.  cherry-picked from https://github.com/BroadleafCommerce/QA/issues/4148
