### PR TITLE
ProductOption hashcode issues

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -406,7 +406,6 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
                 .append(this.errorCode, rhs.errorCode)
                 .append(this.errorMessage, rhs.errorMessage)
                 .append(this.allowedValues, rhs.allowedValues)
-                .append(this.products, rhs.products)
                 .isEquals();
     }
 
@@ -427,7 +426,6 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
                 .append(errorCode)
                 .append(errorMessage)
                 .append(allowedValues)
-                .append(products)
                 .toHashCode();
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -186,11 +186,11 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
             return id.equals(other.id);
         }
 
-        if (getAttributeValue() == null) {
-            if (other.getAttributeValue() != null) {
+        if (attributeValue == null) {
+            if (other.attributeValue != null) {
                 return false;
             }
-        } else if (!getAttributeValue().equals(other.getAttributeValue())) {
+        } else if (!attributeValue.equals(other.attributeValue)) {
             return false;
         }
         return true;
@@ -199,7 +199,7 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
     @Override
     public int hashCode() {
 
-        return Objects.hash(id, getAttributeValue());
+        return Objects.hash(id, attributeValue);
     }
 
     @Override


### PR DESCRIPTION
Hashcode uses wrong args and so results in circular dependency
Hashcode should not use translation of fields
Fixes BroadleafCommerce/QA#4150