### PR TITLE
Add back support of allowNoValueEnumOption

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -604,7 +604,7 @@ public class BasicFieldMetadata extends FieldMetadata {
     }
 
     public Boolean getAllowNoValueEnumOption() {
-        if (allowNoValueEnumOption == null) {
+        if (allowNoValueEnumOption==null || !allowNoValueEnumOption) {
             return StringUtils.isEmpty(getDefaultValue())
                     && (!getRequired() && !(getRequiredOverride() != null && getRequiredOverride()));
         }else{

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/BasicFieldMetadata.java
@@ -105,6 +105,8 @@ public class BasicFieldMetadata extends FieldMetadata {
     protected String toOneParentProperty;
     protected String mapKeyValueProperty;
 
+    protected Boolean allowNoValueEnumOption;
+
     public SupportedFieldType getFieldType() {
         return fieldType;
     }
@@ -602,8 +604,12 @@ public class BasicFieldMetadata extends FieldMetadata {
     }
 
     public Boolean getAllowNoValueEnumOption() {
-        return StringUtils.isEmpty(getDefaultValue())
-            && (!getRequired() && !(getRequiredOverride() != null && getRequiredOverride()));
+        if (allowNoValueEnumOption == null) {
+            return StringUtils.isEmpty(getDefaultValue())
+                    && (!getRequired() && !(getRequiredOverride() != null && getRequiredOverride()));
+        }else{
+            return allowNoValueEnumOption;
+        }
     }
 
     public void setCanLinkToExternalEntity(Boolean canLinkToExternalEntity) {
@@ -612,6 +618,10 @@ public class BasicFieldMetadata extends FieldMetadata {
 
     public Boolean getCanLinkToExternalEntity() {
         return canLinkToExternalEntity;
+    }
+
+    public void setAllowNoValueEnumOption(Boolean allowNoValueEnumOption) {
+        this.allowNoValueEnumOption = allowNoValueEnumOption;
     }
 
     @Override
@@ -702,6 +712,7 @@ public class BasicFieldMetadata extends FieldMetadata {
         metadata.defaultValue = defaultValue;
         metadata.associatedFieldName = associatedFieldName;
         metadata.canLinkToExternalEntity = canLinkToExternalEntity;
+        metadata.allowNoValueEnumOption = allowNoValueEnumOption;
 
         metadata = (BasicFieldMetadata) populate(metadata);
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/BasicFieldMetadataProvider.java
@@ -860,6 +860,9 @@ public class BasicFieldMetadataProvider extends FieldMetadataProviderAdapter {
         if (basicFieldMetadata.getCanLinkToExternalEntity() != null) {
             metadata.setCanLinkToExternalEntity(basicFieldMetadata.getCanLinkToExternalEntity());
         }
+        if (basicFieldMetadata.getAllowNoValueEnumOption() != null) {
+            metadata.setAllowNoValueEnumOption(basicFieldMetadata.getAllowNoValueEnumOption());
+        }
 
         attributes.put(field.getName(), metadata);
     }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1234,6 +1234,11 @@ $.fn.blSelectize = function (settings_user) {
         settings_user['placeholder'] = settings_user['placeholder'] || 'Click here to select ...';
         settings_user['positionDropdown'] = settings_user['positionDropdown'] || 'auto';
         settings_user['onInitialize'] = settings_user['onInitialize'] || function() {
+            if (Object.keys(this.options).length <= 1) {
+                // Remove the dropdown css
+                this.$control.addClass('remove-caret');
+            }
+        };
         settings_user['allowEmptyOption'] = settings_user['allowEmptyOption'] || $(el).hasClass("selectAllowNoValueEnumOption");
         var $select = $(el).selectize(settings_user);
         var selectize = $select[0].selectize;

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1225,6 +1225,7 @@ $.fn.blSelectize = function (settings_user) {
         if (settings_user === undefined) {
             settings_user = {};
         }
+
         // add default settings here
         settings_user['dropdownParent'] = settings_user['dropdownParent'] || 'body';
         settings_user['hideSelected'] = settings_user['hideSelected'] !== undefined ? settings_user['hideSelected'] : true;
@@ -1233,12 +1234,7 @@ $.fn.blSelectize = function (settings_user) {
         settings_user['placeholder'] = settings_user['placeholder'] || 'Click here to select ...';
         settings_user['positionDropdown'] = settings_user['positionDropdown'] || 'auto';
         settings_user['onInitialize'] = settings_user['onInitialize'] || function() {
-            if (Object.keys(this.options).length <= 1) {
-                // Remove the dropdown css
-                this.$control.addClass('remove-caret');
-            }
-        };
-
+        settings_user['allowEmptyOption'] = settings_user['allowEmptyOption'] || $(el).hasClass("selectAllowNoValueEnumOption");
         var $select = $(el).selectize(settings_user);
         var selectize = $select[0].selectize;
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/vendor/selectize.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/vendor/selectize.js
@@ -2254,7 +2254,7 @@
 		 */
 		registerOption: function(data) {
 			var key = hash_key(data[this.settings.valueField]);
-			if (!key || this.options.hasOwnProperty(key)) return false;
+			if (typeof key === 'undefined' || key === null || this.options.hasOwnProperty(key)) return false;
 			data.$order = data.$order || ++this.order;
 			this.options[key] = data;
 			return key;

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/broadleaf_enumeration.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/broadleaf_enumeration.html
@@ -4,7 +4,7 @@
 </label>
 
 <th:block th:if="${!#maps.isEmpty(field.options) and #maps.size(field.options) ge #props.getAsInt('admin.enum.minCountForDropDown')}">
-    <select class="six" th:field="*{fields['__${field.name}__'].value}" th:disabled="${field.readOnly}">
+    <select class="six" th:field="*{fields['__${field.name}__'].value}" th:disabled="${field.readOnly}" th:classappend="${field.allowNoValueEnumOption} ? selectAllowNoValueEnumOption : notAllowNoValueEnumOption">
         <option th:if="${field.allowNoValueEnumOption}" value="" th:utext="#{No_Value_Selected}"></option>
         <option th:each="entry : *{fields['__${field.name}__'].options}"
                 th:value="${entry.key}"

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/data_driven_enumeration.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/fields/data_driven_enumeration.html
@@ -4,7 +4,7 @@
 </label>
 
 <th:block th:if="${!#maps.isEmpty(field.options) and #maps.size(field.options) ge #props.getAsInt('admin.enum.minCountForDropDown')}">
-    <select class="six" th:field="*{fields['__${field.name}__'].value}" th:disabled="${field.readOnly}">
+    <select class="six" th:field="*{fields['__${field.name}__'].value}" th:disabled="${field.readOnly}" th:classappend="${field.allowNoValueEnumOption} ? selectAllowNoValueEnumOption : notAllowNoValueEnumOption">
         <option th:if="${field.allowNoValueEnumOption}" value="" th:utext="#{No_Value_Selected}"></option>
         <option th:each="entry : *{fields['__${field.name}__'].options}"
                 th:value="${entry.key}"


### PR DESCRIPTION
Fixes: BroadleafCommerce/QA#4154
Add back support of allowNoValueEnumOption

tested with when you have enough items in enum to become drop-down

            <mo:field name="dimension.dimensionUnitOfMeasure">
                <mo:property name="allowNoValueEnumOption" value="true"/>
            </mo:field>