### PR TITLE
Offer code max use fix

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -509,7 +509,7 @@ public class OfferServiceImpl implements OfferService {
     public boolean verifyMaxCustomerUsageThreshold(Order order, Offer offer) {
         Customer customer = order.getCustomer();
         
-        if (offer.isLimitedUsePerCustomer()) {
+        if (customer != null && customer.isRegistered() && offer.isLimitedUsePerCustomer()) {
             Long currentUses = offerAuditService.countUsesByCustomer(order, customer.getId(), offer.getId());
             
             if (currentUses >= offer.getMaxUsesPerCustomer()) {


### PR DESCRIPTION
Offer code max use fix
Fixes: BroadleafCommerce/QA#4158

Moved condition from advanced offer module to core, to check customer max usage