### PR TITLE
Disabled asset bulk removal on search and filter views

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -699,6 +699,8 @@
                     var assetGrid = $filterButton.closest('.content-yield').find('.asset-grid').html($assetGrid.html());
                     var $assetListGrid = data.find('.asset-listgrid');
                     var assetListgrid = $filterButton.closest('.content-yield').find('.asset-listgrid').html($assetListGrid.html());
+                    var $assetFunctions = data.find('.asset-functions');
+                    var assetFunctions = $filterButton.closest('.content-yield').find('.asset-functions').html($assetFunctions.html());
 
                     var container = assetGrid.closest('.asset-listgrid-container');
 


### PR DESCRIPTION
Updated asset remove from folder verbiage.
Fixed UI bug where asset functions did not display on listgrid select all.
Removed delete asset function from search and filter views.

https://github.com/BroadleafCommerce/Enterprise/pull/1293