### PR TITLE
Fix for page empty url

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/PageSiteMapGenerator.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/PageSiteMapGenerator.java
@@ -65,7 +65,7 @@ public class PageSiteMapGenerator implements SiteMapGenerator {
             rowOffset += pages.size();
             for (Page page : pages) {
 
-                if (page.getExcludeFromSiteMap()) {
+                if (page.getExcludeFromSiteMap() || page.getFullUrl()==null || page.getFullUrl().trim().length()==0) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes: BroadleafCommerce/QA#4199
Fix for page empty url

