### PR TITLE
Added the ability to override the promotion calculation logic to allow an item percent off promotion to use more precise discounting

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/money/Money.java
+++ b/common/src/main/java/org/broadleafcommerce/common/money/Money.java
@@ -220,6 +220,14 @@ public class Money implements Serializable, Cloneable, Comparable<Money>, Extern
         return multiply(value);
     }
 
+    public Money multiplyWithRounding(int inInt, RoundingMode roundingMode) {
+        BigDecimal bd = getAmount();
+        BigDecimal in = new BigDecimal(inInt);
+        BigDecimal result = bd.multiply(in);
+        result = result.setScale(getCurrency().getDefaultFractionDigits(), roundingMode);
+        return new Money(result, getCurrency());
+    }
+
     public Money multiply(BigDecimal multiplier) {
         return new Money(amount.multiply(multiplier), currency, amount.scale() == 0 ? BankersRounding.getScaleForCurrency(currency) : amount.scale());
     }
@@ -470,6 +478,18 @@ public class Money implements Serializable, Cloneable, Comparable<Money>, Extern
         // Write out the client properties from the server representation.
         out.writeFloat(amount.floatValue());
         // out.writeObject(currency);
+    }
+
+    public static Money trimUnnecessaryScaleToCurrency(Money money) {
+        int currencyScale = 2;
+        if (money.getCurrency() != null) {
+            currencyScale = money.getCurrency().getDefaultFractionDigits();
+        }
+
+        BigDecimal amount = money.getAmount().stripTrailingZeros();
+
+        int scale = Math.max(currencyScale, amount.scale());
+        return new Money(amount, money.getCurrency(), scale);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.core.offer.domain;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
@@ -214,7 +215,18 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
 
     @Override
     public Money getValue() {
-        return value == null ? null : BroadleafCurrencyUtils.getMoney(value, getCurrency());
+        if (value == null) {
+            return null;
+        }
+
+        BroadleafCurrency currency = getCurrency();
+
+        // handle null currency by setting to system default
+        if (currency == null) {
+            currency = new BroadleafCurrencyImpl();
+            currency.setCurrencyCode(Money.defaultCurrency().getCurrencyCode());
+        }
+        return new Money(value, currency, value.scale());
     }
     
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/AbstractPromotionRounding.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/AbstractPromotionRounding.java
@@ -22,22 +22,14 @@ import java.math.RoundingMode;
 
 public abstract class AbstractPromotionRounding implements PromotionRounding {
 
-    protected boolean roundOfferValues = true;
-    protected int roundingScale = 2;
-    protected RoundingMode roundingMode = RoundingMode.HALF_EVEN;
+    protected Integer roundingScale;
+    protected RoundingMode roundingMode;
 
     /**
      * It is sometimes problematic to offer percentage-off offers with regards to rounding. For example,
      * consider an item that costs 9.99 and has a 50% promotion. To be precise, the offer value is 4.995,
      * but this may be a strange value to display to the user depending on the currency being used.
-     */
-    public boolean isRoundOfferValues() {
-        return roundOfferValues;
-    }
-
-    /**
-     * @see #isRoundOfferValues()
-     * 
+     *
      * @param roundingScale
      */
     public void setRoundingScale(int roundingScale) {
@@ -45,8 +37,10 @@ public abstract class AbstractPromotionRounding implements PromotionRounding {
     }
 
     /**
-     * @see #isRoundOfferValues()
-     * 
+     * It is sometimes problematic to offer percentage-off offers with regards to rounding. For example,
+     * consider an item that costs 9.99 and has a 50% promotion. To be precise, the offer value is 4.995,
+     * but this may be a strange value to display to the user depending on the currency being used.
+     *
      * @param roundingMode
      */
     public void setRoundingMode(RoundingMode roundingMode) {
@@ -55,11 +49,15 @@ public abstract class AbstractPromotionRounding implements PromotionRounding {
 
     @Override
     public RoundingMode getRoundingMode() {
-        return roundingMode;
+        if (roundingMode != null) {
+            return roundingMode;
+        } else {
+            return RoundingMode.HALF_EVEN;
+        }
     }
 
     @Override
-    public int getRoundingScale() {
+    public Integer getRoundingScale() {
         return roundingScale;
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableFulfillmentGroupAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableFulfillmentGroupAdjustmentImpl.java
@@ -65,12 +65,22 @@ public class PromotableFulfillmentGroupAdjustmentImpl extends AbstractPromotionR
         }
 
         if (OfferDiscountType.PERCENT_OFF.equals(discountType)) {
-            BigDecimal offerValue = currentPriceDetailValue.getAmount().multiply(offer.getValue().divide(new BigDecimal("100"), 5, RoundingMode.HALF_EVEN));
+            BigDecimal offerValue = currentPriceDetailValue.getAmount().multiply(
+                    offer.getValue().divide(new BigDecimal("100"), 5, RoundingMode.HALF_EVEN));
 
-            if (isRoundOfferValues()) {
-                offerValue = offerValue.setScale(roundingScale, roundingMode);
+            int scale = 2;
+            if (getCurrency() != null) {
+                // default scale to currency if currency is not null
+                scale = getCurrency().getJavaCurrency().getDefaultFractionDigits();
             }
-            adjustmentValue = new Money(offerValue, getCurrency(), 5);
+            if (roundingScale != null) {
+                // override scale from rounding settings if set
+                scale = roundingScale;
+            }
+            adjustmentValue = new Money(offerValue, getCurrency(), scale);
+            if (roundingScale != null) {
+                adjustmentValue = Money.trimUnnecessaryScaleToCurrency(adjustmentValue);
+            }
         }
 
         if (currentPriceDetailValue.lessThan(adjustmentValue)) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
@@ -124,7 +124,7 @@ public class PromotableItemFactoryImpl implements PromotableItemFactory {
                 promotableOrder, offer, useQtyOnlyTierCalculation);
 
         // Range enforcement
-        if (itemOfferPercentRoundingScale >= 0) {
+        if (itemOfferPercentRoundingScale != null && itemOfferPercentRoundingScale >= 0) {
             itemOfferPercentRoundingScale = Math.max(0,itemOfferPercentRoundingScale);
             itemOfferPercentRoundingScale = Math.min(itemOfferPercentRoundingScale, 5);
             pcio.setRoundingScale(itemOfferPercentRoundingScale);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableItemFactoryImpl.java
@@ -42,7 +42,7 @@ public class PromotableItemFactoryImpl implements PromotableItemFactory {
     @Value("${use.quantity.only.tier.calculation:false}")
     protected boolean useQtyOnlyTierCalculation = false;
 
-    @Value("${item.offer.percent.rounding.scale}")
+    @Value("${item.offer.percent.rounding.scale:-1}")
     protected Integer itemOfferPercentRoundingScale;
 
 
@@ -124,7 +124,7 @@ public class PromotableItemFactoryImpl implements PromotableItemFactory {
                 promotableOrder, offer, useQtyOnlyTierCalculation);
 
         // Range enforcement
-        if (itemOfferPercentRoundingScale != null) {
+        if (itemOfferPercentRoundingScale >= 0) {
             itemOfferPercentRoundingScale = Math.max(0,itemOfferPercentRoundingScale);
             itemOfferPercentRoundingScale = Math.min(itemOfferPercentRoundingScale, 5);
             pcio.setRoundingScale(itemOfferPercentRoundingScale);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
@@ -108,6 +108,8 @@ public class PromotableOrderItemPriceDetailImpl implements PromotableOrderItemPr
             returnPrice = promotableOrderItem.getRetailPriceBeforeAdjustments();
         }
         for (PromotableOrderItemPriceDetailAdjustment adjustment : promotableOrderItemPriceDetailAdjustments) {
+            returnPrice = buildPreciseMoneyFromAdjustment(returnPrice,
+                    adjustment.getSaleAdjustmentValue());
             returnPrice = returnPrice.subtract(adjustment.getSaleAdjustmentValue());
         }
         return returnPrice;
@@ -116,9 +118,17 @@ public class PromotableOrderItemPriceDetailImpl implements PromotableOrderItemPr
     public Money calculateRetailAdjustmentUnitPrice() {
         Money returnPrice = promotableOrderItem.getRetailPriceBeforeAdjustments();
         for (PromotableOrderItemPriceDetailAdjustment adjustment : promotableOrderItemPriceDetailAdjustments) {
+            returnPrice = buildPreciseMoneyFromAdjustment(returnPrice,
+                    adjustment.getRetailAdjustmentValue());
             returnPrice = returnPrice.subtract(adjustment.getRetailAdjustmentValue());
         }
         return returnPrice;
+    }
+
+    protected Money buildPreciseMoneyFromAdjustment(Money original,
+                                                    Money adjustment) {
+        return new Money(original.getAmount(), original.getCurrency(),
+                adjustment.getAmount().scale());
     }
 
     /**

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotionRounding.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotionRounding.java
@@ -25,24 +25,19 @@ import java.math.RoundingMode;
  *
  */
 public interface PromotionRounding {
-    
+
     /**
      * It is sometimes problematic to offer percentage-off offers with regards to rounding. For example,
      * consider an item that costs 9.99 and has a 50% promotion. To be precise, the offer value is 4.995,
      * but this may be a strange value to display to the user depending on the currency being used.
      */
-    boolean isRoundOfferValues();
-
-    /**
-     * Returns the rounding mode to use for rounding operations. 
-     * @return
-     */
     RoundingMode getRoundingMode();
 
     /**
-     * Returns the scale to use when rounding.
-     * @return
+     * It is sometimes problematic to offer percentage-off offers with regards to rounding. For example,
+     * consider an item that costs 9.99 and has a 50% promotion. To be precise, the offer value is 4.995,
+     * but this may be a strange value to display to the user depending on the currency being used.
      */
-    int getRoundingScale();
+    Integer getRoundingScale();
     
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -25,6 +26,7 @@ import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.money.BankersRounding;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -34,14 +36,19 @@ import org.broadleafcommerce.common.presentation.override.AdminPresentationMerge
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
 import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.broadleafcommerce.common.util.ApplicationContextHolder;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustment;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustmentImpl;
+import org.broadleafcommerce.core.payment.service.OrderPaymentStatusService;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+import org.springframework.context.ApplicationContext;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,6 +82,8 @@ import javax.persistence.Table;
 public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyCodeIdentifiable {
 
     private static final long serialVersionUID = 1L;
+
+    private static RoundingMode _roundingMode;
 
     @Id
     @GeneratedValue(generator = "OrderItemPriceDetailId")
@@ -168,8 +177,16 @@ public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyC
     public Money getAdjustmentValue() {
         Money adjustmentValue = BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getCurrency());
         for (OrderItemPriceDetailAdjustment adjustment : orderItemPriceDetailAdjustments) {
-            if (!adjustment.isFutureCredit()) {
-                adjustmentValue = adjustmentValue.add(adjustment.getValue());
+            if (! adjustment.isFutureCredit()) {
+                // preserve highest scale / allows adjustments to maintain more precision
+                // adjustments should only have more precision if the roundingScale was
+                // overridden
+                if (adjustment.getValue().getAmount().scale() >
+                        adjustmentValue.getAmount().scale()) {
+                    adjustmentValue = adjustment.getValue().add(adjustmentValue);
+                } else {
+                    adjustmentValue = adjustmentValue.add(adjustment.getValue());
+                }
             }
         }
         return adjustmentValue;
@@ -180,20 +197,51 @@ public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyC
         Money adjustmentValue = BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getCurrency());
         for (OrderItemPriceDetailAdjustment adjustment : orderItemPriceDetailAdjustments) {
             if (adjustment.isFutureCredit()) {
-                adjustmentValue = adjustmentValue.add(adjustment.getValue());
+                // preserve highest scale / allows adjustments to maintain more precision
+                // adjustments should only have more precision if the roundingScale was
+                // overridden
+                if (adjustment.getValue().getAmount().scale() >
+                        adjustmentValue.getAmount().scale()) {
+                    adjustmentValue = adjustment.getValue().add(adjustmentValue);
+                } else {
+                    adjustmentValue = adjustmentValue.add(adjustment.getValue());
+                }
             }
         }
         return adjustmentValue;
     }
 
+    public RoundingMode getRoundingModeForAdj() {
+        RoundingMode mode = RoundingMode.HALF_EVEN;
+        if (_roundingMode == null) {
+            ApplicationContext ctx = ApplicationContextHolder.getApplicationContext();
+            if (ctx != null) {
+                String modeStr = ctx.getEnvironment().getProperty(
+                        "item.offer.percent.rounding.mode");
+                if (StringUtils.isNotEmpty(modeStr)) {
+                    try {
+                        mode = RoundingMode.valueOf(modeStr);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            _roundingMode = mode;
+        }
+
+        return _roundingMode;
+    }
+
     @Override
     public Money getTotalAdjustmentValue() {
-        return getAdjustmentValue().multiply(quantity);
+        return getAdjustmentValue().multiplyWithRounding(quantity,
+                getRoundingModeForAdj());
     }
 
     @Override
     public Money getFutureCreditTotalAdjustmentValue() {
-        return getFutureCreditAdjustmentValue().multiply(quantity);
+        return getFutureCreditAdjustmentValue().multiplyWithRounding(quantity,
+                getRoundingModeForAdj());
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
@@ -18,6 +18,8 @@
 package org.broadleafcommerce.core.order.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -40,6 +42,7 @@ import org.broadleafcommerce.common.util.ApplicationContextHolder;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustment;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustmentImpl;
+import org.broadleafcommerce.core.offer.service.discount.domain.PromotableItemFactoryImpl;
 import org.broadleafcommerce.core.payment.service.OrderPaymentStatusService;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -84,6 +87,8 @@ public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyC
     private static final long serialVersionUID = 1L;
 
     private static RoundingMode _roundingMode;
+
+    protected static final Log LOG = LogFactory.getLog(OrderItemPriceDetailImpl.class);
 
     @Id
     @GeneratedValue(generator = "OrderItemPriceDetailId")
@@ -222,7 +227,8 @@ public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyC
                     try {
                         mode = RoundingMode.valueOf(modeStr);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LOG.error("Unable to initialize rounding mode, using default. Value set for " +
+                                "item.offer.percent.rounding.mode was " + modeStr, e);
                     }
                 }
             }


### PR DESCRIPTION
**Feature Description.**
This feature will allow clients to override the promotion calculation logic to allow an item percent off promotion to use more precise discounting.

For example, consider a product that is 77.85 and an offer that is 10% off.

By default, the system will use BankersRounding (HALF_EVEN) and round the adjustment amount.

So, for a quantity of 1 the out of box calculated price would be: 77.85 - 7.78 = $70.07 with a savings of 7.78
For a quantity of 3, the out of box calculated price would be: (77.85 * 3) - (7.78 * 3) = $210.21 with a savings of $23.34.

A more precise representation would be to store the adjustments and not round until after the multiplication.
So, (77.85 * .1) * 3 = 23.355 which would be rounded to 23.36 (using bankers rounding).

To support this use case, code has been added to support a client override of the default rounding mode.

Clients can control both the rounding mode and the precision.

**Steps to Implement**

Use the following properties to control the scale and rounding mode for percent off item offers.

// Integer value from java.lang.RoundingMode.  Leave blank/unset for default behavior
item.offer.percent.rounding.mode=DOWN

// Can be any value from 0 to 5, typical would be 3-5 (2 is the default for most currencies)
item.offer.percent.rounding.scale=5

**About the fix**
Changes the default behavior of PromotableItemFactoryImpl to impact the scale and rounding mode for the CandidateItemOffer. Other offer calculation functionality honors these scale settings.
Money utility updated to support multiply with explicit rounding.
OrderItemPriceDetail updated to read configured property when calculating total item adjustments.

Fixes https://github.com/BroadleafCommerce/QA/issues/4206