### PR TITLE
Fixed an issue where Admin returns blank error page on error

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminBasicErrorController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminBasicErrorController.java
@@ -1,0 +1,39 @@
+package org.broadleafcommerce.openadmin.web.controller;
+
+import org.broadleafcommerce.common.exception.ExceptionHelper;
+import org.broadleafcommerce.common.web.BroadleafWebRequestProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AdminBasicErrorController extends BasicErrorController {
+
+    @Autowired
+    @Qualifier("blAdminRequestProcessor")
+    protected BroadleafWebRequestProcessor requestProcessor;
+
+    public AdminBasicErrorController(final ErrorAttributes errorAttributes, final ErrorProperties errorProperties) {
+        super(errorAttributes, errorProperties);
+    }
+
+    @RequestMapping(produces = "text/html")
+    public ModelAndView errorHtml(final HttpServletRequest request,
+                                  final HttpServletResponse response) {
+        try {
+            requestProcessor.process(new ServletWebRequest(request, response));
+        } catch (Exception e) {
+            throw ExceptionHelper.refineException(e);
+        }
+
+        return super.errorHtml(request, response);
+    }
+
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/config/AdminWebMvcConfiguration.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/config/AdminWebMvcConfiguration.java
@@ -21,9 +21,12 @@ import org.broadleafcommerce.common.admin.condition.ConditionalOnAdmin;
 import org.broadleafcommerce.common.config.PostAutoConfigurationImport;
 import org.broadleafcommerce.common.web.BroadleafCookieLocaleResolver;
 import org.broadleafcommerce.openadmin.web.compatibility.JSFieldNameCompatibilityInterceptor;
+import org.broadleafcommerce.openadmin.web.controller.AdminBasicErrorController;
 import org.broadleafcommerce.openadmin.web.controller.AdminRequestMappingHandlerMapping;
+import org.springframework.boot.autoconfigure.web.ErrorProperties;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -99,6 +102,11 @@ public class AdminWebMvcConfiguration {
                     return new AdminRequestMappingHandlerMapping();
                 }
             };
+        }
+
+        @Bean
+        public AdminBasicErrorController basicErrorController() {
+            return new AdminBasicErrorController(new DefaultErrorAttributes(), new ErrorProperties());
         }
     }
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4223

**A Brief Overview**
We need to override BasicErrorController and to create proper BroadleafRequestContext before we render Error page

