### PR TITLE
Populated entity type and field name for edit on admin translations controller.

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminTranslationController.java
@@ -171,27 +171,9 @@ public class AdminTranslationController extends AdminAbstractController {
         entityForm.setCeilingEntityClassname(Translation.class.getName());
         entityForm.setEntityType(TranslationImpl.class.getName());
 
-        Field entityType = new Field();
-        entityType.setName("entityType");
+        populateTranslationFields(entityForm, form);
 
-        String ceilingEntity = form.getCeilingEntity();
-
-        TranslatedEntity translatedEntity = translationService.getAssignableEntityType(ceilingEntity);
-        if (translatedEntity == null && ceilingEntity.endsWith("Impl")) {
-            int pos = ceilingEntity.lastIndexOf("Impl");
-            ceilingEntity = ceilingEntity.substring(0, pos);
-            translatedEntity = TranslatedEntity.getInstance(ceilingEntity);
-        }
-        entityType.setValue(translatedEntity.getFriendlyType());
-
-        Field fieldName = new Field();
-        fieldName.setName("fieldName");
-        fieldName.setValue(form.getPropertyName());
-
-        entityForm.getFields().put("entityType", entityType);
-        entityForm.getFields().put("fieldName", fieldName);
-
-        String[] sectionCriteria = customCriteriaService.mergeSectionCustomCriteria(ceilingEntity, getSectionCustomCriteria());
+        String[] sectionCriteria = customCriteriaService.mergeSectionCustomCriteria(form.getCeilingEntity(), getSectionCustomCriteria());
         Entity entity = service.addEntity(entityForm, sectionCriteria, sectionCrumbs).getEntity();
 
         entityFormValidator.validate(entityForm, entity, result);
@@ -296,7 +278,9 @@ public class AdminTranslationController extends AdminAbstractController {
         entityForm.getFields().put("id", id);
         entityForm.setId(String.valueOf(form.getTranslationId()));
 
-        String[] sectionCriteria = customCriteriaService.mergeSectionCustomCriteria(Translation.class.getName(), getSectionCustomCriteria());
+        populateTranslationFields(entityForm, form);
+
+        String[] sectionCriteria = customCriteriaService.mergeSectionCustomCriteria(form.getCeilingEntity(), getSectionCustomCriteria());
         service.updateEntity(entityForm, sectionCriteria, sectionCrumbs).getEntity();
         return viewTranslation(request, response, model, form, result);
     }
@@ -377,6 +361,28 @@ public class AdminTranslationController extends AdminAbstractController {
         if (action != null) {
             action.setButtonClass("translation-revert-button");
         }
+    }
+
+    protected void populateTranslationFields(EntityForm entityForm, TranslationForm translationForm) {
+        Field entityType = new Field();
+        entityType.setName("entityType");
+
+        String ceilingEntity = translationForm.getCeilingEntity();
+
+        TranslatedEntity translatedEntity = translationService.getAssignableEntityType(ceilingEntity);
+        if (translatedEntity == null && ceilingEntity.endsWith("Impl")) {
+            int pos = ceilingEntity.lastIndexOf("Impl");
+            ceilingEntity = ceilingEntity.substring(0, pos);
+            translatedEntity = TranslatedEntity.getInstance(ceilingEntity);
+        }
+        entityType.setValue(translatedEntity.getFriendlyType());
+
+        Field fieldName = new Field();
+        fieldName.setName("fieldName");
+        fieldName.setValue(translationForm.getPropertyName());
+
+        entityForm.getFields().put("entityType", entityType);
+        entityForm.getFields().put("fieldName", fieldName);
     }
 
 }


### PR DESCRIPTION
**A Brief Overview**
A NPE exception was being thrown in `TranslationCustomPersistenceHandler#update()` on line 114. This is because the admin instance did not have the entity type populated. Traced the issue back to the controller where we were populating those fields for add but not for edit. This PR extracts those updates into a method that is called for both add and edit.
 
