### PR TITLE
Fix Totalitarian offer calculations

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/service/GenericEntityServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/service/GenericEntityServiceImpl.java
@@ -19,7 +19,9 @@
 package org.broadleafcommerce.common.service;
 
 import org.broadleafcommerce.common.dao.GenericEntityDao;
+import org.broadleafcommerce.common.util.TransactionUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.Serializable;
 import java.util.List;
@@ -50,6 +52,7 @@ public class GenericEntityServiceImpl implements GenericEntityService {
         return genericEntityDao.save(object);
     }
 
+    @Override
     public void persist(Object object) {
         genericEntityDao.persist(object);
     }
@@ -115,6 +118,7 @@ public class GenericEntityServiceImpl implements GenericEntityService {
     }
 
     @Override
+    @Transactional(TransactionUtils.DEFAULT_TRANSACTION_MANAGER)
     public void remove(Object object) {
         genericEntityDao.remove(object);
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -498,6 +498,8 @@ public class OfferServiceImpl implements OfferService {
                 fulfillmentGroupOfferProcessor.applyAllFulfillmentGroupOffers(qualifiedFGOffers, promotableOrder);
                 fulfillmentGroupOfferProcessor.calculateFulfillmentGroupTotal(promotableOrder);
                 orderOfferProcessor.synchronizeAdjustmentsAndPrices(promotableOrder);
+                order.setSubTotal(order.calculateSubTotal());
+                order.finalizeItemPrices();
             }
 
             return orderService.save(order, false);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.service.GenericEntityService;
 import org.broadleafcommerce.core.offer.dao.OfferDao;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferItemCriteria;
@@ -71,6 +72,9 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
 
     @Resource(name = "blOfferServiceExtensionManager")
     protected OfferServiceExtensionManager extensionManager;
+
+    @Resource(name = "blGenericEntityService")
+    protected GenericEntityService entityService;
 
     @Override
     public void sortTargetItemDetails(List<PromotableOrderItemPriceDetail> itemPriceDetails, boolean applyToSalePrice) {
@@ -431,6 +435,7 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
                 OrderItemPriceDetailAdjustment adj = iterator.next();
                 if (adjustmentIdsToRemove.contains(adj.getOffer().getId())) {
                     iterator.remove();
+                    entityService.remove(adj);
                 }
             }
         }
@@ -451,6 +456,7 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
             OrderItemPriceDetail currentDetail = pdIterator.next();
             if (unmatchedDetailsMap.containsKey(currentDetail.getId())) {
                 pdIterator.remove();
+                entityService.remove(currentDetail);
             }
         }
     }
@@ -462,6 +468,7 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
             OrderItemQualifier currentQualifier = qIterator.next();
             if (unmatchedQualifiersMap.containsKey(currentQualifier.getId())) {
                 qIterator.remove();
+                entityService.remove(currentQualifier);
             }
         }
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceUtilitiesImpl.java
@@ -537,4 +537,11 @@ public class OfferServiceUtilitiesImpl implements OfferServiceUtilities {
         this.offerDao = offerDao;
     }
 
+    public GenericEntityService getGenericEntityService() {
+        return entityService;
+    }
+
+    public void setGenericEntityService(GenericEntityService entityService) {
+        this.entityService = entityService;
+    }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
@@ -272,7 +272,7 @@ public class FulfillmentGroupOfferProcessorImpl extends OrderOfferProcessorImpl 
             discountOrderRegularShippingTotal = discountOrderRegularShippingTotal.add(fg.calculatePriceWithoutAdjustments());
         }
 
-        if (discountOrderRegularShippingTotal.lessThan(regularOrderDiscountShippingTotal)) {
+        if (discountOrderRegularShippingTotal.lessThanOrEqual(regularOrderDiscountShippingTotal)) {
             // order/item offer is better; remove totalitarian fulfillment group offer and process other fg offers
             order.removeAllCandidateFulfillmentOfferAdjustments();
             fgOfferApplied = false;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
@@ -20,17 +20,16 @@ package org.broadleafcommerce.core.offer.service.processor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.service.GenericEntityService;
 import org.broadleafcommerce.core.offer.dao.OfferDao;
 import org.broadleafcommerce.core.offer.domain.FulfillmentGroupAdjustment;
 import org.broadleafcommerce.core.offer.domain.Offer;
-import org.broadleafcommerce.core.offer.domain.OfferItemCriteria;
 import org.broadleafcommerce.core.offer.domain.OfferOfferRuleXref;
 import org.broadleafcommerce.core.offer.domain.OrderAdjustment;
 import org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustment;
 import org.broadleafcommerce.core.offer.service.OfferServiceUtilities;
 import org.broadleafcommerce.core.offer.service.discount.CandidatePromotionItems;
 import org.broadleafcommerce.core.offer.service.discount.PromotionQualifier;
-import org.broadleafcommerce.core.offer.service.discount.domain.PromotableCandidateItemOffer;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableCandidateOrderOffer;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfillmentGroup;
 import org.broadleafcommerce.core.offer.service.discount.domain.PromotableFulfillmentGroupAdjustment;
@@ -66,7 +65,7 @@ import javax.annotation.Resource;
 public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements OrderOfferProcessor {
 
     private static final Log LOG = LogFactory.getLog(OrderOfferProcessorImpl.class);
-
+    
     @Resource(name = "blPromotableItemFactory")
     protected PromotableItemFactory promotableItemFactory;
 
@@ -78,6 +77,9 @@ public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements Or
 
     @Resource(name = "blOfferServiceUtilities")
     protected OfferServiceUtilities offerServiceUtilities;
+
+    @Resource(name = "blGenericEntityService")
+    protected GenericEntityService entityService;
 
     @Override
     public void filterOrderLevelOffer(PromotableOrder promotableOrder, List<PromotableCandidateOrderOffer> qualifiedOrderOffers, Offer offer) {
@@ -324,6 +326,7 @@ public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements Or
                 } else {
                     // No longer using this order adjustment, remove it.
                     orderAdjIterator.remove();
+                    entityService.remove(adjustment);
                 }
             }
         }
@@ -529,6 +532,7 @@ public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements Or
             } else {
                 // Removing no longer valid adjustment
                 adjustmentIterator.remove();
+                entityService.remove(currentAdj);
             }
         }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/CountTotalOffersActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/CountTotalOffersActivity.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.pricing.service.workflow;
+
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.broadleafcommerce.core.offer.domain.Offer;
+import org.broadleafcommerce.core.offer.service.OfferService;
+import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.workflow.BaseActivity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Resource;
+
+/**
+ * This class is used in conjunction with the {@link DetermineOfferChangeActivity} to determine if the number
+ * of offers changed on the order during the pricing workflow. This is important in determining if an offer
+ * expired between the last time the order was priced and when the order was about to be sent through checkout.
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Component("blCountTotalOffersActivity")
+public class CountTotalOffersActivity extends BaseActivity<ProcessContext<Order>> {
+
+    public static final int ORDER = Integer.MIN_VALUE + 100;
+
+    @Resource(name = "blOfferService")
+    protected OfferService offerService;
+
+    public CountTotalOffersActivity() {
+        setOrder(ORDER);
+    }
+
+    @Override
+    public ProcessContext<Order> execute(ProcessContext<Order> context) throws Exception {
+        Order order = context.getSeedData();
+        Boolean isCheckout = (Boolean) BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().get(OfferActivity.FINALIZE_CHECKOUT);
+        if (isCheckout != null && isCheckout) {
+            Set<Long> offers = convertOffersToIds(offerService.getUniqueOffersFromOrder(order));
+            BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().put(OfferActivity.ORIG_OFFERS, offers);
+        }
+        return context;
+    }
+
+    protected Set<Long> convertOffersToIds(Set<Offer> offers) {
+        Set<Long> ids = new HashSet<>();
+        for (Offer offer : offers) {
+            ids.add(offer.getId());
+        }
+        return ids;
+    }
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/DetermineOfferChangeActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/DetermineOfferChangeActivity.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2020 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.pricing.service.workflow;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.broadleafcommerce.common.web.BroadleafRequestContext;
+import org.broadleafcommerce.core.offer.domain.Offer;
+import org.broadleafcommerce.core.offer.service.OfferService;
+import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.workflow.BaseActivity;
+import org.broadleafcommerce.core.workflow.ProcessContext;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Resource;
+
+/**
+ * This class is used in conjunction with the {@link CountTotalOffersActivity} to determine if the number
+ * of offers changed on the order during the pricing workflow. This is important in determining if an offer
+ * expired between the last time the order was priced and when the order was about to be sent through checkout.
+ * 
+ * @author Jay Aisenbrey (cja769)
+ *
+ */
+@Component("blDetermineOfferChangeActivity")
+public class DetermineOfferChangeActivity extends BaseActivity<ProcessContext<Order>> {
+
+    public static final int ORDER = Integer.MAX_VALUE - 100;
+
+    @Resource(name = "blOfferService")
+    protected OfferService offerService;
+
+    public DetermineOfferChangeActivity() {
+        setOrder(ORDER);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ProcessContext<Order> execute(ProcessContext<Order> context) throws Exception {
+        Order order = context.getSeedData();
+        Boolean isCheckout = (Boolean) BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().get(OfferActivity.FINALIZE_CHECKOUT);
+        if (isCheckout != null && isCheckout) {
+            Set<Long> currentOffers = convertOffersToIds(offerService.getUniqueOffersFromOrder(order));
+            Set<Long> oldOffers = (Set<Long>) BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().get(OfferActivity.ORIG_OFFERS);
+            if (!CollectionUtils.isEqualCollection(currentOffers, oldOffers)) {
+                BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().put(OfferActivity.OFFERS_EXPIRED, Boolean.TRUE);
+            }
+        }
+        return context;
+    }
+
+    protected Set<Long> convertOffersToIds(Set<Offer> offers) {
+        Set<Long> ids = new HashSet<>();
+        for (Offer offer : offers) {
+            ids.add(offer.getId());
+        }
+        return ids;
+    }
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/OfferActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/OfferActivity.java
@@ -18,10 +18,8 @@
 package org.broadleafcommerce.core.pricing.service.workflow;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferCode;
-import org.broadleafcommerce.core.offer.domain.OrderAdjustment;
 import org.broadleafcommerce.core.offer.service.OfferService;
 import org.broadleafcommerce.core.offer.service.OfferValueModifierExtensionManager;
 import org.broadleafcommerce.core.order.domain.Order;
@@ -40,6 +38,7 @@ public class OfferActivity extends BaseActivity<ProcessContext<Order>> {
     public static final int ORDER = 1000;
     public static final String FINALIZE_CHECKOUT = "FINALIZE_CHECKOUT";
     public static final String OFFERS_EXPIRED = "OFFERS_EXPIRED";
+    public static final String ORIG_OFFERS = "ORIG_OFFERS";
     
     @Resource(name="blOfferService")
     protected OfferService offerService;
@@ -68,35 +67,12 @@ public class OfferActivity extends BaseActivity<ProcessContext<Order>> {
         if (CollectionUtils.isNotEmpty(offers) && offerModifierExtensionManager != null) {
             offerModifierExtensionManager.getProxy().modifyOfferValues(offers, order);
         }
-        Boolean isCheckout = (Boolean)BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().get(FINALIZE_CHECKOUT);
-        int offerCount = 0;
-        if (isCheckout != null && isCheckout) {
-            offerCount = getOfferCount(order);
-        }
 
         order = offerService.applyAndSaveOffersToOrder(offers, order);
 
-        if (isCheckout != null && isCheckout) {
-            int offerCountAfter = getOfferCount(order);
-            if (offerCountAfter != offerCount) {
-                BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties().put(OFFERS_EXPIRED, Boolean.TRUE);
-            }
-        }
         context.setSeedData(order);
 
         return context;
-    }
-
-    private int getOfferCount(Order order) {
-        int offerCount = 0;
-        if (CollectionUtils.isNotEmpty(order.getOrderAdjustments())) {
-            for (OrderAdjustment orderAdjustment : order.getOrderAdjustments()) {
-                if (orderAdjustment.getOffer() != null) {
-                    offerCount++;
-                }
-            }
-        }
-        return offerCount;
     }
 
     protected List<OfferCode> getNewOfferCodesFromCustomer(Order order) {

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-workflow.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext-workflow.xml
@@ -77,6 +77,8 @@
                 <ref bean="blTaxActivity" />
                 <ref bean="blTotalActivity"/>
                 <ref bean="blAdjustOrderPaymentsActivity"/>
+                <ref bean="blCountTotalOffersActivity" />
+                <ref bean="blDetermineOfferChangeActivity" />
             </list>
         </property>
     </bean>

--- a/core/broadleaf-framework/src/test/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorTest.java
+++ b/core/broadleaf-framework/src/test/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorTest.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.processor;
 
+import org.broadleafcommerce.common.service.GenericEntityService;
 import org.broadleafcommerce.core.offer.dao.CustomerOfferDao;
 import org.broadleafcommerce.core.offer.dao.OfferCodeDao;
 import org.broadleafcommerce.core.offer.dao.OfferDao;
@@ -86,6 +87,7 @@ public class FulfillmentGroupOfferProcessorTest extends TestCase {
     protected OrderMultishipOptionService multishipOptionServiceMock;
     protected OfferTimeZoneProcessor offerTimeZoneProcessorMock;
     protected OfferServiceUtilities offerServiceUtilitiesMock;
+    protected GenericEntityService genericEntityServiceMock;
 
     protected FulfillmentGroupOfferProcessorImpl fgProcessor;
 
@@ -117,6 +119,7 @@ public class FulfillmentGroupOfferProcessorTest extends TestCase {
         multishipOptionServiceMock = EasyMock.createMock(OrderMultishipOptionService.class);
         offerServiceUtilitiesMock = EasyMock.createMock(OfferServiceUtilities.class);
         offerTimeZoneProcessorMock = EasyMock.createMock(OfferTimeZoneProcessor.class);
+        genericEntityServiceMock = EasyMock.createMock(GenericEntityService.class);
 
         fgProcessor = new TestableFulfillmentGroupOfferProcessor();
         fgProcessor.setOfferDao(offerDaoMock);
@@ -127,6 +130,7 @@ public class FulfillmentGroupOfferProcessorTest extends TestCase {
         OfferServiceUtilitiesImpl offerServiceUtilities = new OfferServiceUtilitiesImpl();
         offerServiceUtilities.setOfferDao(offerDaoMock);
         offerServiceUtilities.setPromotableItemFactory(new PromotableItemFactoryImpl());
+        offerServiceUtilities.setGenericEntityService(genericEntityServiceMock);
 
         OrderOfferProcessorImpl orderProcessor = new OrderOfferProcessorImpl();
         orderProcessor.setOfferDao(offerDaoMock);

--- a/core/broadleaf-framework/src/test/java/org/broadleafcommerce/core/offer/service/processor/ItemOfferProcessorTest.java
+++ b/core/broadleaf-framework/src/test/java/org/broadleafcommerce/core/offer/service/processor/ItemOfferProcessorTest.java
@@ -18,6 +18,7 @@
 package org.broadleafcommerce.core.offer.service.processor;
 
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.service.GenericEntityService;
 import org.broadleafcommerce.core.offer.dao.CustomerOfferDao;
 import org.broadleafcommerce.core.offer.dao.OfferCodeDao;
 import org.broadleafcommerce.core.offer.dao.OfferDao;
@@ -79,6 +80,7 @@ public class ItemOfferProcessorTest extends TestCase {
     protected FulfillmentGroupService fgServiceMock;
     protected OrderMultishipOptionService multishipOptionServiceMock;
     protected OfferTimeZoneProcessor offerTimeZoneProcessorMock;
+    protected GenericEntityService genericEntityServiceMock;
 
     protected ItemOfferProcessorImpl itemProcessor;
 
@@ -95,10 +97,12 @@ public class ItemOfferProcessorTest extends TestCase {
         fgServiceMock = EasyMock.createMock(FulfillmentGroupService.class);
         multishipOptionServiceMock = EasyMock.createMock(OrderMultishipOptionService.class);
         offerTimeZoneProcessorMock = EasyMock.createMock(OfferTimeZoneProcessor.class);
+        genericEntityServiceMock = EasyMock.createMock(GenericEntityService.class);
 
         OfferServiceUtilitiesImpl offerServiceUtilities = new OfferServiceUtilitiesImpl();
         offerServiceUtilities.setOfferDao(offerDaoMock);
         offerServiceUtilities.setPromotableItemFactory(new PromotableItemFactoryImpl());
+        offerServiceUtilities.setGenericEntityService(genericEntityServiceMock);
 
         itemProcessor = new ItemOfferProcessorImpl();
         itemProcessor.setOfferDao(offerDaoMock);


### PR DESCRIPTION
These changes accomplish a few things

1. Change lessThan to lessThanOrEqual so the correct offers are applied when dealing with totalitarian offers
2. Manually remove adjustments to the order via the `GenericEntityService` since there's cases where an order or order item level offer is applicable but is discarded in favor of a fulfillment group offer. This originally caused an issue because the order/order item adjustment was added to the Hibernate session but since the collection looked the same after the transaction as before the transaction Hibernate's cascade logic didn't clean up correctly which resulted in the order/order item adjustment still being persisted and added to the order
3. Move and improve the logic around determining if the offers changed on an order during pricing by moving code for the `OfferActivity` to an activity at the beginning and end of the pricing workflow that looks at all of the offers applied to an order to see if they changed. This was needed as the situation in the 2nd bullet would create an adjustment in the `OfferActivity` which would be removed later by the `ShippingOfferActivity` which was picked up by the offer expiration logic as a change in offers when in fact no change was actually made when comparing the order before and after the pricing workflow went through. Additionally this new logic correctly identifies expired item and shipping offers instead of only order offers.

This PR was created to fix https://secure.helpscout.net/conversation/1327186720/43558/