### PR TITLE
Fixed an issue where Error when filtering role permissions tab

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -1274,7 +1274,14 @@ $(document).ready(function() {
         $modalContainer.attr('id', $modalContainer.attr('id') + '-modal');
         $modalContainer.empty();
 
-        var filterBuilder = BLCAdmin.filterBuilders.getFilterBuilder($modalContainer.attr('id'));
+        var filterBuilder;
+
+        if (hiddenId) {
+            filterBuilder = BLCAdmin.filterBuilders.getFilterBuilderByHiddenId(hiddenId);
+        } else {
+            filterBuilder = BLCAdmin.filterBuilders.getFilterBuilder($modalContainer.attr('id'));
+        }
+
         if (filterBuilder) {
             var jsonVal = $.parseJSON($('#'+hiddenId).val());
             if (jsonVal.data.length > 0) {


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4277

**A Brief Overview**
The issue appears when on one page (include modals) we have several filters.
The fix is to get filter by unique HiddenId instead of containerId that was before.
