### PR TITLE
Fixed an issue where viewing audit details the UI table can overflow and become unresponsive

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/css/admin/blc-admin.css
@@ -4747,59 +4747,56 @@ table th[class*="col-"] {
     border-color: #fbeed5
 }
 
-@media (max-width: 767px) {
-    .table-responsive {
-        width: 100%;
-        margin-bottom: 15px;
-        overflow-y: hidden;
-        overflow-x: scroll;
-        -ms-overflow-style: -ms-autohiding-scrollbar;
-        border: 1px solid #D4D2CF;
-        -webkit-overflow-scrolling: touch
-    }
+.table-responsive {
+    width: 100%;
+    margin-bottom: 15px;
+    overflow-y: hidden;
+    overflow-x: scroll;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    border: 1px solid #D4D2CF;
+    -webkit-overflow-scrolling: touch
+}
 
-    .table-responsive>.table {
-        margin-bottom: 0
-    }
+.table-responsive>.table {
+    margin-bottom: 0
+}
 
-    .table-responsive>.table>thead>tr>th,
-    .table-responsive>.table>tbody>tr>th,
-    .table-responsive>.table>tfoot>tr>th,
-    .table-responsive>.table>thead>tr>td,
-    .table-responsive>.table>tbody>tr>td,
-    .table-responsive>.table>tfoot>tr>td {
-        white-space: nowrap
-    }
+.table-responsive>.table>thead>tr>th,
+.table-responsive>.table>tbody>tr>th,
+.table-responsive>.table>tfoot>tr>th,
+.table-responsive>.table>thead>tr>td,
+.table-responsive>.table>tbody>tr>td,
+.table-responsive>.table>tfoot>tr>td {
+    white-space: nowrap
+}
 
-    .table-responsive>.table-bordered {
-        border: 0
-    }
+.table-responsive>.table-bordered {
+    border: 0
+}
 
-    .table-responsive>.table-bordered>thead>tr>th:first-child,
-    .table-responsive>.table-bordered>tbody>tr>th:first-child,
-    .table-responsive>.table-bordered>tfoot>tr>th:first-child,
-    .table-responsive>.table-bordered>thead>tr>td:first-child,
-    .table-responsive>.table-bordered>tbody>tr>td:first-child,
-    .table-responsive>.table-bordered>tfoot>tr>td:first-child {
-        border-left: 0
-    }
+.table-responsive>.table-bordered>thead>tr>th:first-child,
+.table-responsive>.table-bordered>tbody>tr>th:first-child,
+.table-responsive>.table-bordered>tfoot>tr>th:first-child,
+.table-responsive>.table-bordered>thead>tr>td:first-child,
+.table-responsive>.table-bordered>tbody>tr>td:first-child,
+.table-responsive>.table-bordered>tfoot>tr>td:first-child {
+    border-left: 0
+}
 
-    .table-responsive>.table-bordered>thead>tr>th:last-child,
-    .table-responsive>.table-bordered>tbody>tr>th:last-child,
-    .table-responsive>.table-bordered>tfoot>tr>th:last-child,
-    .table-responsive>.table-bordered>thead>tr>td:last-child,
-    .table-responsive>.table-bordered>tbody>tr>td:last-child,
-    .table-responsive>.table-bordered>tfoot>tr>td:last-child {
-        border-right: 0
-    }
+.table-responsive>.table-bordered>thead>tr>th:last-child,
+.table-responsive>.table-bordered>tbody>tr>th:last-child,
+.table-responsive>.table-bordered>tfoot>tr>th:last-child,
+.table-responsive>.table-bordered>thead>tr>td:last-child,
+.table-responsive>.table-bordered>tbody>tr>td:last-child,
+.table-responsive>.table-bordered>tfoot>tr>td:last-child {
+    border-right: 0
+}
 
-    .table-responsive>.table-bordered>tbody>tr:last-child>th,
-    .table-responsive>.table-bordered>tfoot>tr:last-child>th,
-    .table-responsive>.table-bordered>tbody>tr:last-child>td,
-    .table-responsive>.table-bordered>tfoot>tr:last-child>td {
-        border-bottom: 0
-    }
-
+.table-responsive>.table-bordered>tbody>tr:last-child>th,
+.table-responsive>.table-bordered>tfoot>tr:last-child>th,
+.table-responsive>.table-bordered>tbody>tr:last-child>td,
+.table-responsive>.table-bordered>tfoot>tr:last-child>td {
+    border-bottom: 0
 }
 
 .tipr_content {


### PR DESCRIPTION
**A Brief Overview**
The solution is to add "table-responsive" to appropriate tables and activate css for it

**Link to QA issue**
https://github.com/BroadleafCommerce/QA/issues/4278

**Actual behavior:**
Now we have scroll bar for each separate table but not for general window as before

![image](https://user-images.githubusercontent.com/42337700/102076841-08ec4480-3e11-11eb-9629-303d9b1ec95e.png)