### PR TITLE
Upgrade Hibernate from 4.3.15 to 4.3.20 for security reasons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <database.starter.version>2.0.3-GA</database.starter.version>
         <hsqldb.database.starter.version>2.0.2-GA</hsqldb.database.starter.version>
         <closure.compiler.version>v20180506</closure.compiler.version>
-        <hibernate.version>5.3.15.Final</hibernate.version>
+        <hibernate.version>5.3.20.Final</hibernate.version>
         <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
         <jaxb.version>2.3.0</jaxb.version>
         <jaxws.version>2.3.0</jaxws.version>


### PR DESCRIPTION
**A Brief Overview**
Upgrade hibernate patch to 4.3.20 for security vulnerabilities 

https://github.com/BroadleafCommerce/QA/issues/4284