### PR TITLE
Replace const with var on js files to avoid minification issues

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -936,7 +936,7 @@
             }
         },
 
-        updateAppliedFiltersView(filterBuilder) {
+        updateAppliedFiltersView: function(filterBuilder) {
             var $container = $("#filter-pillow-container-" + filterBuilder.hiddenId);
             var $wrapper = $container.closest('.filter-pillow-wrapper');
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -669,7 +669,7 @@
 
             var url = $($filterFields[0]).data('action');
 
-            const urlEvent = $.Event('listGrid-filter-action-lazy-load-url');
+            var urlEvent = $.Event('listGrid-filter-action-lazy-load-url');
             $('body').trigger(urlEvent, [url, $tbody]);
             url = urlEvent.resultUrl || url;
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-filter.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-filter.js
@@ -306,7 +306,7 @@ $(document).ready(function() {
 
         url = getFilteredParams($(this), url);
 
-        const urlEvent = $.Event('listGrid-filter-lazy-load-url');
+        var urlEvent = $.Event('listGrid-filter-lazy-load-url');
         $('body').trigger(urlEvent, [url, $tbody]);
         url = urlEvent.resultUrl || url;
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-paginate.js
@@ -1006,7 +1006,7 @@
                                 url += "&sectionCrumbs=" + sectionCrumbs;
                             }
 
-                            const urlEvent = $.Event('listGrid-paginate-lazy-load-url');
+                            var urlEvent = $.Event('listGrid-paginate-lazy-load-url');
                             $('body').trigger(urlEvent, [url, $tbody]);
                             url = urlEvent.resultUrl || url;
 


### PR DESCRIPTION
BroadleafCommerce/QA#4294

Replace `const` with `var` on js files to avoid minification issues. 
As the current language to compile is ECMASCRIPT5, we cannot use some new features like const or let (since ES6).