### PR TITLE
Fix ProductBundleImpl stackoverflow when calling equals or hashcode

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
@@ -296,12 +296,10 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
                 .append(this.id, rhs.id)
                 .append(this.quantity, rhs.quantity)
                 .append(this.itemSalePrice, rhs.itemSalePrice)
-                .append(this.bundle, rhs.bundle)
                 .append(this.sku, rhs.sku)
                 .append(this.sequence, rhs.sequence)
                 .append(this.dynamicPrices, rhs.dynamicPrices)
                 .append(this.deproxiedSku, rhs.deproxiedSku)
-                .append(this.deproxiedBundle, rhs.deproxiedBundle)
                 .isEquals();
     }
 
@@ -311,12 +309,10 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
                 .append(id)
                 .append(quantity)
                 .append(itemSalePrice)
-                .append(bundle)
                 .append(sku)
                 .append(sequence)
                 .append(dynamicPrices)
                 .append(deproxiedSku)
-                .append(deproxiedBundle)
                 .toHashCode();
     }
 }


### PR DESCRIPTION
Fix stackoverflow exception caused by calling equals or hashcode on ProductBundleImpl which then calls equals or hashcode on SkuBundleItemImpl which then calls equals or hashcode on ProductBundleImpl.