### PR TITLE
Adding logic to FormBuilder to allow Currencies to be used in RuleBuilder dropdowns

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -766,6 +766,9 @@ public class FormBuilderServiceImpl implements FormBuilderService {
             //  "Locale" entity is a special occasion. Because it have not "ID" column with "Long" type
             } else if (e.findProperty("localeCode") != null) {
                 selectizeOption.put("id", e.findProperty("localeCode").getValue());
+                // BroadleafCurrency entity is a special occasion. Because it have not "ID" column with "Long" type
+            } else if (e.findProperty("currencyCode") != null) {
+                selectizeOption.put("id", e.findProperty("currencyCode").getValue());
             }
             if (e.findProperty(ALTERNATE_ID_PROPERTY) != null) {
                 selectizeOption.put("alternateId", e.findProperty(ALTERNATE_ID_PROPERTY).getValue());


### PR DESCRIPTION
Added special logic since Currency does not have an ID field. Using currencyCode instead. Fixes BroadleafCommerce/QA#4303