### PR TITLE
Do not assign id to anonymous customers

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -35,7 +35,6 @@ import org.broadleafcommerce.core.order.domain.OrderLock;
 import org.broadleafcommerce.core.order.service.type.OrderStatus;
 import org.broadleafcommerce.core.payment.domain.OrderPayment;
 import org.broadleafcommerce.core.payment.domain.PaymentTransaction;
-import org.broadleafcommerce.profile.core.dao.CustomerDao;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.jpa.QueryHints;
@@ -62,9 +61,6 @@ public class OrderDaoImpl implements OrderDao {
 
     @Resource(name = "blEntityConfiguration")
     protected EntityConfiguration entityConfiguration;
-
-    @Resource(name = "blCustomerDao")
-    protected CustomerDao customerDao;
 
     @Resource(name = "blOrderDaoExtensionManager")
     protected OrderDaoExtensionManager extensionManager;
@@ -225,17 +221,6 @@ public class OrderDaoImpl implements OrderDao {
     @Override
     public Order createNewCartForCustomer(Customer customer) {
         Order order = create();
-        if (customer.getUsername() == null) {
-            customer.setUsername(String.valueOf(customer.getId()));
-            if (customerDao.readCustomerById(customer.getId()) != null) {
-                throw new IllegalArgumentException("Attempting to save a customer with an id (" + customer.getId() + ") " +
-                        "that already exists in the database. This can occur when legacy customers have been migrated to " +
-                        "Broadleaf customers, but the batchStart setting has not been declared for id generation. In " +
-                        "such a case, the defaultBatchStart property of IdGenerationDaoImpl (spring id of " +
-                        "blIdGenerationDao) should be set to the appropriate start value.");
-            }
-            customer = customerDao.save(customer);
-        }
         order.setCustomer(customer);
         order.setEmailAddress(customer.getEmailAddress());
         order.setStatus(OrderStatus.IN_PROCESS);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -71,6 +71,7 @@ import org.broadleafcommerce.core.workflow.ProcessContext;
 import org.broadleafcommerce.core.workflow.Processor;
 import org.broadleafcommerce.core.workflow.WorkflowException;
 import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.service.CustomerService;
 import org.hibernate.FlushMode;
 import org.hibernate.Session;
 import org.hibernate.exception.LockAcquisitionException;
@@ -119,6 +120,9 @@ public class OrderServiceImpl implements OrderService {
     protected NullOrderFactory nullOrderFactory;
     
     /* Services */
+    @Resource(name = "blCustomerService")
+    protected CustomerService customerService;
+
     @Resource(name = "blPricingService")
     protected PricingService pricingService;
     
@@ -213,6 +217,11 @@ public class OrderServiceImpl implements OrderService {
     @Override
     @Transactional("blTransactionManager")
     public Order createNewCartForCustomer(Customer customer) {
+        // Persist anonymous customer before mapping it with the new cart
+        if (customer.isAnonymous()) {
+            customer = customerService.saveCustomer(customer);
+        }
+
         return orderDao.createNewCartForCustomer(customer);
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -217,11 +217,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     @Transactional("blTransactionManager")
     public Order createNewCartForCustomer(Customer customer) {
-        // Persist anonymous customer before mapping it with the new cart
-        if (customer.isAnonymous()) {
-            customer = customerService.saveCustomer(customer);
-        }
-
+        customer = customerService.saveCustomer(customer);
         return orderDao.createNewCartForCustomer(customer);
     }
 

--- a/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/controller/RegisterCustomerController.java
+++ b/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/controller/RegisterCustomerController.java
@@ -93,7 +93,7 @@ public class RegisterCustomerController {
     @ModelAttribute("registerCustomerForm")
     public RegisterCustomerForm initCustomerRegistrationForm() {
         RegisterCustomerForm customerRegistrationForm = new RegisterCustomerForm();
-        Customer customer = customerService.createNewCustomer();
+        Customer customer = customerService.createCustomerWithNullId();
         customerRegistrationForm.setCustomer(customer);
         return customerRegistrationForm;
     }

--- a/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/security/CustomerStateRequestProcessor.java
+++ b/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/security/CustomerStateRequestProcessor.java
@@ -47,7 +47,7 @@ import javax.annotation.Resource;
 
 /**
  * @author Phillip Verheyden
- * @see {@link CustomerStateFilter}
+ * @see {@link org.broadleafcommerce.profile.web.site.security.CustomerStateFilter}
  */
 @Component("blCustomerStateRequestProcessor")
 public class CustomerStateRequestProcessor extends AbstractBroadleafWebRequestProcessor implements ApplicationEventPublisherAware {
@@ -257,8 +257,8 @@ public class CustomerStateRequestProcessor extends AbstractBroadleafWebRequestPr
      * @param request
      * @return
      * @see {@link #getAnonymousCustomer(WebRequest)}
-     * @see {@link #getAnonymousCustomerAttributeName()}
-     * @see {@link #getAnonymousCustomerIdAttributeName()}
+     * @see {@link #getAnonymousCustomerSessionAttributeName()}
+     * @see {@link #getAnonymousCustomerIdSessionAttributeName()}
      */
     public Customer resolveAnonymousCustomer(WebRequest request) {
         Customer customer;
@@ -320,7 +320,7 @@ public class CustomerStateRequestProcessor extends AbstractBroadleafWebRequestPr
      * Some implementations may wish to have a different anonymous customer instance (and as a result a different cart). 
      * 
      * The entire Customer should be stored in session ONLY if that Customer has not already been persisted to the database.
-     * Once it has been persisted (like once the user has added something to the cart) then {@link #getAnonymousCustomerIdAttributeName()}
+     * Once it has been persisted (like once the user has added something to the cart) then {@link #getAnonymousCustomerIdSessionAttributeName()}
      * should be used instead.
      * 
      * @return the session attribute for an anonymous {@link Customer} that has not been persisted to the database yet 

--- a/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/security/CustomerStateRequestProcessor.java
+++ b/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/security/CustomerStateRequestProcessor.java
@@ -248,7 +248,7 @@ public class CustomerStateRequestProcessor extends AbstractBroadleafWebRequestPr
      *      </ul>
      *      <li>If no there is no customer ID in session (and thus no {@link Customer})</li>
      *      <ol>
-     *          <li>Create a new customer</li>
+     *          <li>Create a new customer with null customer id</li>
      *          <li>Put the newly-created {@link Customer} in session</li>
      *      </ol>
      *  </ul>
@@ -267,7 +267,7 @@ public class CustomerStateRequestProcessor extends AbstractBroadleafWebRequestPr
         //If there is no Customer object in session, AND no customer id in session, create a new customer
         //and store the entire customer in session (don't persist to DB just yet)
         if (customer == null) {
-            customer = customerService.createNewCustomer();
+            customer = customerService.createCustomerWithNullId();
             if (BLCRequestUtils.isOKtoUseSession(request)) {
                 request.setAttribute(getAnonymousCustomerSessionAttributeName(), customer, WebRequest.SCOPE_SESSION);
             }

--- a/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/service/register/RegistrationServiceImpl.java
+++ b/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/service/register/RegistrationServiceImpl.java
@@ -39,7 +39,7 @@ public class RegistrationServiceImpl implements RegistrationService {
     public RegisterCustomerForm initCustomerRegistrationForm() {
         Customer customer = CustomerState.getCustomer();
         if (customer == null || ! customer.isAnonymous()) {
-            customer = customerService.createCustomerFromId(null);
+            customer = customerService.createCustomerWithNullId();
         }
 
         RegisterCustomerForm customerRegistrationForm = new RegisterCustomerForm();

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerService.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerService.java
@@ -50,6 +50,13 @@ public interface CustomerService {
     public Customer createCustomer();
 
     /**
+     * Returns a non-persisted {@link Customer} with a null id. Typically used with registering a new
+     * customer or creating a new anonymous customer. Creating a customer with null id so that we don't
+     * need to query the database for the next id everytime an anonymous customer browses the site.
+     */
+    Customer createCustomerWithNullId();
+
+    /**
      * Delete the customer entity from the persistent store
      *
      * @param customer the customer entity to remove
@@ -71,8 +78,11 @@ public interface CustomerService {
     public Customer createCustomerFromId(Long customerId);
 
     /**
-     * Returns a non-persisted {@link Customer}. Typically used with registering a new customer.
+     * Returns a non-persisted {@link Customer}.
+     *
+     * @deprecated use {@link #createCustomer()} or {@link #createCustomerWithNullId()}} instead.
      */
+    @Deprecated
     public Customer createNewCustomer();
 
     /**

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
@@ -223,12 +223,20 @@ public class CustomerServiceImpl implements CustomerService {
     }
 
     @Override
+    public Customer createCustomerWithNullId() {
+        return customerDao.create();
+    }
+
+    @Override
     public Customer createCustomerFromId(Long customerId) {
         Customer customer = customerId != null ? readCustomerById(customerId) : null;
         if (customer == null) {
             customer = customerDao.create();
-            // allow null IDs to be set. ID will be assigned when the customer is being persisted
-            customer.setId(customerId);
+            if (customerId != null) {
+                customer.setId(customerId);
+            } else {
+                customer.setId(findNextCustomerId());
+            }
         }
         return customer;
     }
@@ -239,6 +247,7 @@ public class CustomerServiceImpl implements CustomerService {
     }
 
     @Override
+    @Deprecated
     public Customer createNewCustomer() {
         return createCustomerFromId(null);
     }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerServiceImpl.java
@@ -79,10 +79,6 @@ public class CustomerServiceImpl implements CustomerService {
     @Resource(name = "blCustomerForgotPasswordSecurityTokenDao")
     protected CustomerForgotPasswordSecurityTokenDao customerForgotPasswordSecurityTokenDao;
 
-    /**
-     * <p>This is simply a placeholder to be used by {@link #setupPasswordEncoder()} to determine if we're using the
-     * new {@link PasswordEncoder} or the deprecated {@link org.springframework.security.authentication.encoding.PasswordEncoder PasswordEncoder}
-     */
     @Resource(name = "blPasswordEncoder")
     protected PasswordEncoder passwordEncoderBean;
 
@@ -105,6 +101,21 @@ public class CustomerServiceImpl implements CustomerService {
     @Override
     @Transactional(TransactionUtils.DEFAULT_TRANSACTION_MANAGER)
     public Customer saveCustomer(Customer customer, boolean register) {
+        if (customer.getId() == null) {
+            customer.setId(findNextCustomerId());
+        }
+
+        if (customer.getUsername() == null) {
+            customer.setUsername(String.valueOf(customer.getId()));
+            if (readCustomerById(customer.getId()) != null) {
+                throw new IllegalArgumentException("Attempting to save a customer with an id (" + customer.getId() + ") " +
+                        "that already exists in the database. This can occur when legacy customers have been migrated to " +
+                        "Broadleaf customers, but the batchStart setting has not been declared for id generation. In " +
+                        "such a case, the defaultBatchStart property of IdGenerationDaoImpl (spring id of " +
+                        "blIdGenerationDao) should be set to the appropriate start value.");
+            }
+        }
+
         if (register && !customer.isRegistered()) {
             customer.setRegistered(true);
         }
@@ -132,9 +143,6 @@ public class CustomerServiceImpl implements CustomerService {
         customer.setRegistered(true);
 
         // When unencodedPassword is set the save() will encode it
-        if (customer.getId() == null) {
-            customer.setId(findNextCustomerId());
-        }
         customer.setUnencodedPassword(password);
         Customer retCustomer = saveCustomer(customer);
         createRegisteredCustomerRoles(retCustomer);
@@ -219,11 +227,8 @@ public class CustomerServiceImpl implements CustomerService {
         Customer customer = customerId != null ? readCustomerById(customerId) : null;
         if (customer == null) {
             customer = customerDao.create();
-            if (customerId != null) {
-                customer.setId(customerId);
-            } else {
-                customer.setId(findNextCustomerId());
-            }
+            // allow null IDs to be set. ID will be assigned when the customer is being persisted
+            customer.setId(customerId);
         }
         return customer;
     }

--- a/integration/src/test/java/org/broadleafcommerce/core/offer/service/OfferServiceTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/core/offer/service/OfferServiceTest.java
@@ -84,7 +84,7 @@ public class OfferServiceTest extends CommonSetupBaseTest {
     protected FulfillmentGroupService fulfillmentGroupService;
 
     private Order createTestOrderWithOfferAndGiftWrap() throws PricingException {
-        Customer customer = customerService.createCustomerFromId(null);
+        Customer customer = createCustomer();
         Order order = orderService.createNewCartForCustomer(customer);
 
         customerService.saveCustomer(order.getCustomer());

--- a/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
@@ -110,8 +110,8 @@ public abstract class CommonSetupBaseTest extends TestNGSiteIntegrationSetup {
     }
     
     public Customer createCustomer() {
-        Customer customer = customerService.createCustomerFromId(null);
-        return customer;
+        Long customerId = customerService.findNextCustomerId();
+        return customerService.createCustomerFromId(customerId);
     }
     
     /**

--- a/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
+++ b/integration/src/test/java/org/broadleafcommerce/test/CommonSetupBaseTest.java
@@ -110,8 +110,7 @@ public abstract class CommonSetupBaseTest extends TestNGSiteIntegrationSetup {
     }
     
     public Customer createCustomer() {
-        Long customerId = customerService.findNextCustomerId();
-        return customerService.createCustomerFromId(customerId);
+        return customerService.createCustomerFromId(null);
     }
     
     /**


### PR DESCRIPTION
**A Brief Overview**
Fixes https://github.com/BroadleafCommerce/QA/issues/4305 by not assigning `customerId` until persisting the `Customer`