### PR TITLE
Deproxy nested fields when reading field values

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -29,6 +29,7 @@ import org.broadleafcommerce.common.value.ValueAssignable;
 import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManagerFactory;
+import org.hibernate.proxy.HibernateProxy;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
@@ -94,6 +95,10 @@ public class FieldManager {
             if (field != null) {
                 field.setAccessible(true);
                 value = field.get(value);
+                
+                if (value instanceof HibernateProxy) {
+                    value = HibernateUtils.deproxy(value);
+                }
 
                 if (mapKey != null) {
                     value = handleMapFieldExtraction(bean, fieldName, componentClass, value, fieldNamePart, mapKey);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -29,7 +29,6 @@ import org.broadleafcommerce.common.value.ValueAssignable;
 import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManagerFactory;
-import org.hibernate.proxy.HibernateProxy;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
@@ -95,10 +94,7 @@ public class FieldManager {
             if (field != null) {
                 field.setAccessible(true);
                 value = field.get(value);
-                
-                if (value instanceof HibernateProxy) {
-                    value = HibernateUtils.deproxy(value);
-                }
+                value = HibernateUtils.deproxy(value);
 
                 if (mapKey != null) {
                     value = handleMapFieldExtraction(bean, fieldName, componentClass, value, fieldNamePart, mapKey);


### PR DESCRIPTION
When viewing a collection item in the admin, nested object fields are not read properly when loading the Entity for display. For instance, when viewing a CustomerAddress, the phone number fields do not populate with the saved data.

During the resolution of a field path (eg `address.phonePrimary.phoneNumber`), this patch will check if an object is a HibernateProxy and deproxy it. This allows the values from that object to populate the entity form.

QA Issue [4313](https://github.com/BroadleafCommerce/QA/issues/4313)
