### PR TITLE
Improve logic on building invalid product option error message

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/ProductOptionValidationServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/ProductOptionValidationServiceImpl.java
@@ -79,11 +79,12 @@ public class ProductOptionValidationServiceImpl implements ProductOptionValidati
 
             if (requiresValidation(productOption, value) && !validateRegex(validationString, value)) {
                 String errorMessage = productOption.getErrorMessage();
-                String fullErrorMessage = StringUtil.sanitize(errorMessage) + ". Value [" + StringUtil.sanitize(value) + "] does not match regex string [" + validationString + "]";
-                String message = StringUtils.isEmpty(errorMessage) ? fullErrorMessage : errorMessage;
+                if (StringUtils.isEmpty(errorMessage)) {
+                    errorMessage = "Value [" + StringUtil.sanitize(value) + "] does not match regex string [" + validationString + "]";
+                }
 
-                LOG.error(message);
-                throw new ProductOptionValidationException(message, productOption.getErrorCode(),
+                LOG.error(errorMessage);
+                throw new ProductOptionValidationException(errorMessage, productOption.getErrorCode(),
                                                            attributeName, value, validationString,
                                                            errorMessage);
             }


### PR DESCRIPTION
**A Brief Overview**
Fixes https://github.com/BroadleafCommerce/QA/issues/4327
- Call StringUtil#sanitize only when productOption#getErrorMessage is empty
- Don't add productOption#getErrorMessage to log if it's empty
