### PR TITLE
Update XSS Filter and Wrapper strip XSS logic

### DIFF
--- a/common/src/main/resources/esapi/validation.properties
+++ b/common/src/main/resources/esapi/validation.properties
@@ -2,7 +2,7 @@
 # #%L
 # BroadleafCommerce Common Libraries
 # %%
-# Copyright (C) 2009 - 2016 Broadleaf Commerce
+# Copyright (C) 2009 - 2020 Broadleaf Commerce
 # %%
 # Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
 # (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
@@ -23,8 +23,8 @@
 # To use:
 #
 # First set up a pattern below. You can choose any name you want, prefixed by the word
-# "Validation." For example:
-#   Validation.Email=^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\\.[a-zA-Z]{2,4}$
+# "Validator." For example:
+#   Validator.Email=^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\\.[a-zA-Z]{2,4}$
 #
 # Then you can validate in your code against the pattern like this:
 #     ESAPI.validator().isValidInput("User Email", input, "Email", maxLength, allowNull);
@@ -43,3 +43,7 @@ Validator.IPAddress=^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5
 Validator.URL=^(ht|f)tp(s?)\\:\\/\\/[0-9a-zA-Z]([-.\\w]*[0-9a-zA-Z])*(:(0-9)*)*(\\/?)([a-zA-Z0-9\\-\\.\\?\\,\\:\\'\\/\\\\\\+=&amp;%\\$#_]*)?$
 Validator.CreditCard=^(\\d{4}[- ]?){3}\\d{4}$
 Validator.SSN=^(?!000)([0-6]\\d{2}|7([0-6]\\d|7[012]))([ -]?)(?!00)\\d\\d\\3(?!0000)\\d{4}$
+Validator.BroadleafHttpParameterValue=^[a-zA-Z0-9.\\-\\/+=@_ #]*$
+
+# Maximum size of HTTP parameter values
+HttpUtilities.BroadleafMaxInputLength=99999

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
@@ -76,24 +76,14 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
     }
 
     private String stripXSS(String value) {
-        if (value != null) {
-            boolean customStripXss = Boolean.parseBoolean(environment.getProperty("custom.strip.xss", "false"));
-            if (customStripXss) {
-                value = customStripXss(value);
-            } else {
-                String newValue;
-                try {
-                    newValue = ESAPI.validator().getValidSafeHTML("context", value, 99999, true);
-                } catch (ValidationException e) {
-                    newValue = ESAPI.encoder().encodeForHTML(value);
-                }
-                value = newValue;
-            }
-        }
-        return value;
+        return customStripXssEnabled ? customStripXss(value) : ESAPI.encoder().encodeForHTML(value);
     }
 
     private String customStripXss(String value) {
+        if (value == null) {
+            return null;
+        }
+
         // Avoid null characters
         value = value.replaceAll("", "");
 

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
@@ -17,8 +17,10 @@
  */
 package org.broadleafcommerce.core.web.security;
 
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.esapi.ESAPI;
 import org.springframework.beans.factory.annotation.Value;
+import org.owasp.esapi.errors.ValidationException;
 import org.springframework.core.env.Environment;
 
 import javax.servlet.http.HttpServletRequest;
@@ -29,6 +31,8 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
 
     protected final Environment environment;
     private String[] whiteListParamNames;
+    private final int MAX_INPUT_LENGTH = ESAPI.securityConfiguration().getIntProp("HttpUtilities.BroadleafMaxInputLength");
+    private final String BLC_PARAM_VALUE_INPUT_TYPE = "BroadleafHttpParameterValue";
 
     @Value("${custom.strip.xss:false}")
     protected boolean customStripXssEnabled;
@@ -53,7 +57,7 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         int count = values.length;
         String[] encodedValues = new String[count];
         for (int i = 0; i < count; i++) {
-            encodedValues[i] = stripXSS(values[i]);
+            encodedValues[i] = stripXss(values[i], BLC_PARAM_VALUE_INPUT_TYPE);
         }
 
         return encodedValues;
@@ -74,11 +78,22 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         if(checkWhitelist(parameter)){
             return value;
         }
-        return stripXSS(value);
+        return stripXss(value, BLC_PARAM_VALUE_INPUT_TYPE);
     }
 
-    protected String stripXSS(String value) {
-        return customStripXssEnabled ? customStripXss(value) : ESAPI.encoder().encodeForHTML(value);
+    protected String stripXss(String value) {
+        return stripXss(value, null);
+    }
+
+    /**
+     * When {@link #customStripXssEnabled} is false, it will run ESAPI's logic based on the esapiInputType.
+     * If esapiInputType is null or empty, it will run {@link #stripXssAsHTML(String)}.
+     *
+     * @param value - value to be stripped
+     * @param esapiInputType - The name of the ESAPI validation rule defined in ESAPI validation configuration file.
+     */
+    protected String stripXss(String value, String esapiInputType) {
+        return customStripXssEnabled ? customStripXss(value) : stripXssWithESAPI(value, esapiInputType);
     }
 
     protected String customStripXss(String value) {
@@ -128,5 +143,25 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         scriptPattern = Pattern.compile("onload(.*?)=", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
         value = scriptPattern.matcher(value).replaceAll("");
         return value;
+    }
+
+    protected String stripXssWithESAPI(String value, String esapiInputType) {
+        if (StringUtils.isEmpty(esapiInputType)) {
+            return stripXssAsHTML(value);
+        }
+
+        try {
+            return ESAPI.validator().getValidInput("Value: " + value, value, esapiInputType, MAX_INPUT_LENGTH, true, false);
+        } catch (ValidationException e) {
+            return stripXssAsHTML(value);
+        }
+    }
+
+    protected String stripXssAsHTML(String value) {
+        try {
+            return ESAPI.validator().getValidSafeHTML("Value: " + value, value, MAX_INPUT_LENGTH, true);
+        } catch (ValidationException e2) {
+            return ESAPI.encoder().encodeForHTML(value);
+        }
     }
 }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
@@ -17,9 +17,8 @@
  */
 package org.broadleafcommerce.core.web.security;
 
-import org.broadleafcommerce.common.util.StringUtil;
 import org.owasp.esapi.ESAPI;
-import org.owasp.esapi.errors.ValidationException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,6 +30,9 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
     protected final Environment environment;
     private String[] whiteListParamNames;
 
+    @Value("${custom.strip.xss:false}")
+    protected boolean customStripXssEnabled;
+
     public XssRequestWrapper(HttpServletRequest servletRequest, Environment environment, String[] whiteListParamNames) {
         super(servletRequest);
         this.environment = environment;
@@ -41,11 +43,11 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
     public String[] getParameterValues(String parameter) {
 
         String[] values = super.getParameterValues(parameter);
-        if(checkWhitelist(parameter)){
-            return values;
-        }
         if (values == null) {
             return null;
+        }
+        if(checkWhitelist(parameter)){
+            return values;
         }
 
         int count = values.length;
@@ -57,7 +59,7 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         return encodedValues;
     }
 
-    private boolean checkWhitelist(String parameter) {
+    protected boolean checkWhitelist(String parameter) {
         for (String whiteListParamName : whiteListParamNames) {
             if(whiteListParamName.equals(parameter)){
                 return true;
@@ -75,11 +77,11 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         return stripXSS(value);
     }
 
-    private String stripXSS(String value) {
+    protected String stripXSS(String value) {
         return customStripXssEnabled ? customStripXss(value) : ESAPI.encoder().encodeForHTML(value);
     }
 
-    private String customStripXss(String value) {
+    protected String customStripXss(String value) {
         if (value == null) {
             return null;
         }


### PR DESCRIPTION
**Main Changes**
- Update `stripXSS` logic to use `ESAPI.encoder().encodeForHTML` instead of `ESAPI.validator(). getValidSafeHTML` so that input isn't completely removed
- Update `XssFilter` and `XssRequestWrapper` for easier client override

**A Brief Overview**
Fixes https://github.com/BroadleafCommerce/QA/issues/4328

**Additional context**
As I was providing the override classes for FlyWire as a hot fix, it was not easy to override the methods that I needed because they were all private. That's why I made the changes to make those methods protected.

`ESAPI.encoder().encodeForHTML` vs. `ESAPI.validator(). getValidSafeHTML`: 
- `encodeForHTML` simply encodes every special characters in user input, but `getValidSafeHTML` completely removes all input that is a XSS threat. Because of that, FlyWire was not able to use `\` in their product option input