### PR TITLE
Fix performance issues due to processing time of hashCode() on ProductOptionImpl

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -405,7 +405,6 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
                 .append(this.validationString, rhs.validationString)
                 .append(this.errorCode, rhs.errorCode)
                 .append(this.errorMessage, rhs.errorMessage)
-                .append(this.allowedValues, rhs.allowedValues)
                 .isEquals();
     }
 
@@ -425,7 +424,6 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
                 .append(validationString)
                 .append(errorCode)
                 .append(errorMessage)
-                .append(allowedValues)
                 .toHashCode();
     }
 }


### PR DESCRIPTION
Removed `allowedValues` from `hashCode()` and `equals()` to avoid performance issues in case a product option has multiple allowed values. Fixes BroadleafCommerce/QA#4334
