### PR TITLE
Refactor entity cache regions for better performance tuning

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/config/CmsCacheConfiguration.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/config/CmsCacheConfiguration.java
@@ -59,4 +59,9 @@ public class CmsCacheConfiguration {
     public JCacheRegionConfiguration cmsUrlHandlerCache() {
         return new JCacheRegionConfiguration("cmsUrlHandlerCache", 3600, 5000);
     }
+
+    @Bean
+    public JCacheRegionConfiguration blUrlHandler() {
+        return new JCacheRegionConfiguration("blUrlHandler", 86400, 1000);
+    }
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
@@ -45,7 +45,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_PAGE_ATTRIBUTES")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
@@ -54,7 +54,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_URL_HANDLER")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blUrlHandler")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "URLHandlerImpl_friendyName")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),

--- a/common/src/main/java/org/broadleafcommerce/common/config/CommonCacheConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/CommonCacheConfiguration.java
@@ -42,7 +42,7 @@ public class CommonCacheConfiguration {
 
     @Bean
     public JCacheRegionConfiguration blStandardElements() {
-        return new JCacheRegionConfiguration("blStandardElements", 86400, 100000);
+        return new JCacheRegionConfiguration("blStandardElements", 86400, 5000);
     }
 
     @Bean
@@ -57,7 +57,7 @@ public class CommonCacheConfiguration {
 
     @Bean
     public JCacheRegionConfiguration blCategories() {
-        return new JCacheRegionConfiguration("blCategories", 86400, 100000);
+        return new JCacheRegionConfiguration("blCategories", 86400, 3000);
     }
 
     @Bean
@@ -199,4 +199,25 @@ public class CommonCacheConfiguration {
     public JCacheRegionConfiguration blProductOverrideCache() {
         return new JCacheRegionConfiguration("blProductOverrideCache", -1, 100);
     }
+
+    @Bean
+    public JCacheRegionConfiguration blCountryElements() {
+        return new JCacheRegionConfiguration("blCountryElements", -1, 2000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blDataDrivenEnumeration() {
+        return new JCacheRegionConfiguration("blDataDrivenEnumeration", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blMediaElements() {
+        return new JCacheRegionConfiguration("blMediaElements", 86400, 20000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSystemProperties() {
+        return new JCacheRegionConfiguration("blSystemProperties", 86400, 2000);
+    }
+
 }

--- a/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
@@ -55,7 +55,7 @@ import javax.persistence.Table;
         @Index(name = "IDX_BLSYPR_PROPERTY_NAME", columnList = "PROPERTY_NAME")
     })
 @Inheritance(strategy = InheritanceType.JOINED)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSystemProperties")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX)
@@ -191,6 +191,7 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
         this.friendlyTab = friendlyTab;
     }
 
+    @Override
     public SystemPropertyFieldType getPropertyType() {
         if (propertyType != null) {
             SystemPropertyFieldType returnType = SystemPropertyFieldType.getInstance(propertyType);
@@ -201,6 +202,7 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
         return SystemPropertyFieldType.STRING_TYPE;
     }
 
+    @Override
     public void setPropertyType(SystemPropertyFieldType propertyType) {
         this.propertyType = propertyType.getType();
     }

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
@@ -49,7 +49,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_DATA_DRVN_ENUM")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "DataDrivenEnumerationImpl_friendyName")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
@@ -82,7 +82,7 @@ public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
     protected Boolean modifiable = false;
 
     @OneToMany(mappedBy = "type", targetEntity = DataDrivenEnumerationValueImpl.class, cascade = {CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
     @AdminPresentationCollection(addType = AddMethodType.PERSIST, friendlyName = "DataDrivenEnumerationImpl_Enum_Values", order = 3)
     protected List<DataDrivenEnumerationValue> enumValues = new ArrayList<DataDrivenEnumerationValue>();
     

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
@@ -47,7 +47,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_DATA_DRVN_ENUM_VAL")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
 @AdminPresentationClass(friendlyName = "DataDrivenEnumerationValueImpl_friendyName")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/ISOCountryImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/ISOCountryImpl.java
@@ -41,7 +41,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ISO_COUNTRY")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCountryElements")
 @AdminPresentationClass(friendlyName = "ISOCountryImpl_baseCountry")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)

--- a/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
@@ -45,7 +45,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_MEDIA")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blMediaElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/common/src/main/resources/bl-common-ehcache.xml
+++ b/common/src/main/resources/bl-common-ehcache.xml
@@ -63,7 +63,7 @@
         <expiry>
             <ttl>86400</ttl>
         </expiry>
-        <heap>100000</heap>
+        <heap>5000</heap>
     </cache>
     
     <cache alias="blProducts" uses-template="hydratedCacheTemplate">
@@ -84,7 +84,7 @@
         <expiry>
             <ttl>86400</ttl>
         </expiry>
-        <heap>100000</heap>
+        <heap>3000</heap>
     </cache>
 
     <cache alias="blCategoryUrlCache">
@@ -282,6 +282,34 @@
              <none/>
          </expiry>
         <heap>100</heap>
+    </cache>
+    
+    <cache alias="blCountryElements" >
+        <expiry>
+             <none/>
+         </expiry>
+        <heap>2000</heap>
+    </cache>
+    
+    <cache alias="blDataDrivenEnumeration" >
+        <expiry>
+             <ttl>86400</ttl>
+         </expiry>
+        <heap>1000</heap>
+    </cache>
+    
+     <cache alias="blMediaElements" >
+        <expiry>
+             <ttl>86400</ttl>
+         </expiry>
+        <heap>20000</heap>
+    </cache>
+    
+    <cache alias="blSystemProperties" >
+        <expiry>
+             <ttl>86400</ttl>
+         </expiry>
+        <heap>2000</heap>
     </cache>
     
 </config>

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
@@ -17,15 +17,14 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
@@ -51,7 +50,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_CATEGORY_ATTRIBUTE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @AdminPresentationClass(friendlyName = "baseCategoryAttribute")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
@@ -297,7 +297,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @OneToMany(targetEntity = CategoryXrefImpl.class, mappedBy = "category", orphanRemoval = true,
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
     @OrderBy(value="displayOrder")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
             targetObjectProperty = "subCategory",
@@ -311,7 +311,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @OneToMany(targetEntity = CategoryXrefImpl.class, mappedBy = "subCategory", orphanRemoval = true,
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
     @OrderBy(value="displayOrder")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
             targetObjectProperty = "category",
@@ -325,7 +325,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @OneToMany(targetEntity = CategoryProductXrefImpl.class, mappedBy = "category", orphanRemoval = true,
             cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
     @OrderBy(value="displayOrder")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryProduct")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
             targetObjectProperty = "product",
@@ -338,7 +338,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @OneToMany(mappedBy = "category", targetEntity = CategoryMediaXrefImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
     @MapKey(name = "key")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "CategoryImpl_Category_Media",
         tab = TabName.Media,
@@ -364,7 +364,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @OneToMany(mappedBy = "category", targetEntity = FeaturedProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @OrderBy(value="sequence")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(friendlyName = "featuredProductsTitle", order = 1000,
@@ -377,7 +377,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @OneToMany(mappedBy = "category", targetEntity = CrossSaleProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @OrderBy(value="sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "crossSaleProductsTitle", order = 2000,
             tab = TabName.Marketing,
@@ -389,7 +389,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @OneToMany(mappedBy = "category", targetEntity = UpSaleProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @OrderBy(value="sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "upsaleProductsTitle", order = 3000,
             tab = TabName.Marketing,
@@ -400,7 +400,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     protected List<RelatedProduct> upSaleProducts  = new ArrayList<RelatedProduct>();
 
     @OneToMany(mappedBy = "category", targetEntity = CategorySearchFacetImpl.class, cascade = {CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @OrderBy(value="sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "categoryFacetsTitle", order = 1000,
             tab = TabName.Search,
@@ -411,7 +411,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     protected List<CategorySearchFacet> searchFacets  = new ArrayList<CategorySearchFacet>();
 
     @OneToMany(mappedBy = "category", targetEntity = CategoryExcludedSearchFacetImpl.class, cascade = { CascadeType.ALL })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "excludedFacetsTitle", order = 2000,
             tab = TabName.Search,
@@ -422,7 +422,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     protected List<CategoryExcludedSearchFacet> excludedSearchFacets = new ArrayList<CategoryExcludedSearchFacet>(10);
 
     @OneToMany(mappedBy = "category", targetEntity = CategoryAttributeImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "categoryAttributesTitle",
             tab = TabName.General, order = FieldOrder.CustomAttributes)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
@@ -36,12 +36,21 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CATEGORY_MEDIA_MAP")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
@@ -63,7 +63,7 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CATEGORY_PRODUCT_XREF")
 @AdminPresentationClass(excludeFromPolymorphism = false)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryProduct")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
@@ -30,14 +30,24 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
 import java.math.BigDecimal;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CATEGORY_XREF")
 @AdminPresentationClass(excludeFromPolymorphism = false)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
@@ -32,6 +32,8 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import java.math.BigDecimal;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,12 +44,11 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_PRODUCT_CROSS_SALE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
@@ -30,6 +30,8 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import java.math.BigDecimal;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -40,12 +42,11 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_FEATURED")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
@@ -17,15 +17,14 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
@@ -49,7 +48,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_PRODUCT_ATTRIBUTE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
 @AdminPresentationClass(friendlyName = "ProductAttributeImpl_baseProductAttribute")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductBundleImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductBundleImpl.java
@@ -88,7 +88,7 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
 
     @OneToMany(mappedBy = "bundle", targetEntity = SkuBundleItemImpl.class, cascade = { CascadeType.ALL })
     @OrderBy(value = "sequence")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "skuBundleItemsTitle",
         sortProperty = "sequence",

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -268,7 +268,7 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
     @OneToMany(mappedBy = "product", targetEntity = CrossSaleProductImpl.class, cascade = {CascadeType.ALL})
     @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "crossSaleProductsTitle",
             tab = TabName.Marketing, order = 1000,
@@ -280,7 +280,7 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
     @OneToMany(mappedBy = "product", targetEntity = UpSaleProductImpl.class, cascade = {CascadeType.ALL})
     @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "upsaleProductsTitle",
             tab = TabName.Marketing, order = 2000,
@@ -311,7 +311,7 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     @OneToMany(targetEntity = CategoryProductXrefImpl.class, mappedBy = "product",
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
     @OrderBy(value = "displayOrder")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryProduct")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(friendlyName = "allParentCategoriesTitle",
             tab = TabName.Marketing, order = 3000,
@@ -321,7 +321,7 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     protected List<CategoryProductXref> allParentCategoryXrefs = new ArrayList<CategoryProductXref>();
 
     @OneToMany(mappedBy = "product", targetEntity = ProductAttributeImpl.class, cascade = {CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "productAttributesTitle",
             tab = TabName.General, order = 6000)
@@ -329,7 +329,7 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
     @OneToMany(targetEntity = ProductOptionXrefImpl.class, mappedBy = "product",
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(friendlyName = "productOptionsTitle",
             tab = TabName.ProductOptions,

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -61,7 +61,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_OPTION")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
@@ -165,7 +165,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     protected String errorMessage;
 
     @OneToMany(mappedBy = "productOption", targetEntity = ProductOptionValueImpl.class, cascade = {CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
     @OrderBy(value = "displayOrder")
     @AdminPresentationCollection(friendlyName = "ProductOptionImpl_Allowed_Values",
         group = GroupName.General,
@@ -173,7 +173,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     protected List<ProductOptionValue> allowedValues = new ArrayList<>();
 
     @OneToMany(targetEntity = ProductOptionXrefImpl.class, mappedBy = "productOption")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
     @BatchSize(size = 50)
     @ClonePolicyCollectionOverride
     protected List<ProductOptionXref> products = new ArrayList<>();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -52,7 +52,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_OPTION_VALUE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
@@ -48,7 +48,7 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_OPTION_XREF")
 @AdminPresentationClass(excludeFromPolymorphism = false)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
@@ -17,14 +17,13 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
@@ -62,7 +61,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_SKU_ATTRIBUTE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG, skipOverlaps=true)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
@@ -64,7 +64,7 @@ import javax.persistence.Transient;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU_BUNDLE_ITEM")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
@@ -59,7 +59,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_SKU_FEE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true)
 })
@@ -105,7 +105,7 @@ public class SkuFeeImpl implements SkuFee {
     @JoinTable(name = "BLC_SKU_FEE_XREF",
             joinColumns = @JoinColumn(name = "SKU_FEE_ID", referencedColumnName = "SKU_FEE_ID", nullable = true),
             inverseJoinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID", nullable = true))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     protected List<Sku> skus;
     
     @ManyToOne(targetEntity = BroadleafCurrencyImpl.class)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -303,7 +303,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @OneToMany(mappedBy = "sku", targetEntity = SkuMediaXrefImpl.class, cascade = { CascadeType.ALL })
     @MapKey(name = "key")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSkuMedia")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "SkuImpl_Sku_Media",
         tab = TabName.Media,
@@ -348,14 +348,14 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     protected Product product;
 
     @OneToMany(mappedBy = "sku", targetEntity = SkuAttributeImpl.class, cascade = { CascadeType.ALL })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "skuAttributesTitle",
             tab = TabName.Advanced, order = 1000)
     protected List<SkuAttribute> skuAttributes = new ArrayList<SkuAttribute>();
 
     @OneToMany(targetEntity = SkuProductOptionValueXrefImpl.class, cascade = CascadeType.ALL, mappedBy = "sku")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     @ClonePolicyCollectionOverride
     @ClonePolicyArchive
@@ -369,7 +369,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @JoinTable(name = "BLC_SKU_FEE_XREF",
             joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID", nullable = true),
             inverseJoinColumns = @JoinColumn(name = "SKU_FEE_ID", referencedColumnName = "SKU_FEE_ID", nullable = true))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     protected List<SkuFee> fees = new ArrayList<SkuFee>();
 
@@ -380,7 +380,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @MapKeyClass(FulfillmentOptionImpl.class)
     @Column(name = "RATE", precision = 19, scale = 5)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     protected Map<FulfillmentOption, BigDecimal> fulfillmentFlatRates = new HashMap<FulfillmentOption, BigDecimal>();
 
@@ -388,7 +388,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @JoinTable(name = "BLC_SKU_FULFILLMENT_EXCLUDED",
             joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID"),
             inverseJoinColumns = @JoinColumn(name = "FULFILLMENT_OPTION_ID",referencedColumnName = "FULFILLMENT_OPTION_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     protected List<FulfillmentOption> excludedFulfillmentOptions = new ArrayList<FulfillmentOption>();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
@@ -50,7 +50,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU_MEDIA_MAP")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSkuMedia")
 @AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
@@ -48,7 +48,7 @@ import javax.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU_OPTION_VALUE_XREF")
 @AdminPresentationClass(excludeFromPolymorphism = false)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blProducts")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
@@ -31,6 +31,8 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import java.math.BigDecimal;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,12 +44,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import java.math.BigDecimal;
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_PRODUCT_UP_SALE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/config/FrameworkCacheConfiguration.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/config/FrameworkCacheConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2021 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.config;
+
+import org.broadleafcommerce.common.extensibility.cache.JCacheRegionConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FrameworkCacheConfiguration {
+
+    @Bean
+    public JCacheRegionConfiguration blCategoryProduct() {
+        return new JCacheRegionConfiguration("blCategoryProduct", 86400, 40000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blCategoryRelationships() {
+        return new JCacheRegionConfiguration("blCategoryRelationships", 86400, 10000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blFulfillmentOptionElements() {
+        return new JCacheRegionConfiguration("blFulfillmentOptionElements", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProductAttributes() {
+        return new JCacheRegionConfiguration("blProductAttributes", 86400, 10000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProductOptions() {
+        return new JCacheRegionConfiguration("blProductOptions", 86400, 5000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blProductRelationships() {
+        return new JCacheRegionConfiguration("blProductRelationships", 86400, 30000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blRelatedProducts() {
+        return new JCacheRegionConfiguration("blRelatedProducts", 86400, 1000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSearchElements() {
+        return new JCacheRegionConfiguration("blSearchElements", 86400, 5000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blSkuMedia() {
+        return new JCacheRegionConfiguration("blSkuMedia", 86400, 40000);
+    }
+
+    @Bean
+    public JCacheRegionConfiguration blStoreElements() {
+        return new JCacheRegionConfiguration("blStoreElements", 86400, 1000);
+    }
+
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
@@ -67,7 +67,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "BLC_OFFER_CODE")
 @Inheritance(strategy=InheritanceType.JOINED)
-@Cache(usage=CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blOrderElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blOrderElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE, friendlyName = "OfferCodeImpl_baseOfferCode")
 @SQLDelete(sql="UPDATE BLC_OFFER_CODE SET ARCHIVED = 'Y' WHERE OFFER_CODE_ID = ?")
 @DirectCopyTransform({

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
@@ -47,7 +47,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FULFILLMENT_OPTION")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blFulfillmentOptionElements")
 @AdminPresentationClass(friendlyName = "Fulfillment Option")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/BandedPriceFulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/BandedPriceFulfillmentOptionImpl.java
@@ -47,7 +47,7 @@ public class BandedPriceFulfillmentOptionImpl extends FulfillmentOptionImpl impl
     private static final long serialVersionUID = 1L;
     
     @OneToMany(mappedBy="option", targetEntity=FulfillmentPriceBandImpl.class)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blFulfillmentOptionElements")
     @AdminPresentationCollection(friendlyName = "BandedPriceFulfillmentOptionBands", excluded = true)
     protected List<FulfillmentPriceBand> bands = new ArrayList<FulfillmentPriceBand>();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/BandedWeightFulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/BandedWeightFulfillmentOptionImpl.java
@@ -47,7 +47,7 @@ public class BandedWeightFulfillmentOptionImpl extends FulfillmentOptionImpl imp
     private static final long serialVersionUID = 1L;
 
     @OneToMany(mappedBy="option", targetEntity=FulfillmentWeightBandImpl.class)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blFulfillmentOptionElements")
     @AdminPresentationCollection(friendlyName = "BandedWeightFulfillmentOptionBands", excluded = true)
     protected List<FulfillmentWeightBand> bands = new ArrayList<FulfillmentWeightBand>();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentPriceBandImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentPriceBandImpl.java
@@ -25,6 +25,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,7 +36,6 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.math.BigDecimal;
 
 /**
  * 
@@ -43,7 +44,7 @@ import java.math.BigDecimal;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FULFILLMENT_PRICE_BAND")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blFulfillmentOptionElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentWeightBandImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentWeightBandImpl.java
@@ -28,6 +28,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -37,7 +39,6 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import java.math.BigDecimal;
 
 /**
  * 
@@ -46,7 +47,7 @@ import java.math.BigDecimal;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FULFILLMENT_WEIGHT_BAND")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blFulfillmentOptionElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
@@ -32,14 +32,24 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CAT_SEARCH_FACET_EXCL_XREF")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
@@ -50,7 +50,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CAT_SEARCH_FACET_XREF")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategories")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
@@ -48,7 +48,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FIELD")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
     @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
     @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
@@ -59,7 +59,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_INDEX_FIELD")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.ARCHIVE_ONLY)
@@ -100,7 +100,7 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
     protected Field field;
 
     @OneToMany(mappedBy = "indexField", targetEntity = IndexFieldTypeImpl.class, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @BatchSize(size = 50)
     @Where(clause = "(ARCHIVED != 'Y' OR ARCHIVED IS NULL)")
     @AdminPresentationCollection(friendlyName = "IndexFieldImpl_fieldTypes", order = 1000)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
@@ -22,7 +22,11 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.*;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
@@ -35,8 +39,17 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
 import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 /**
  * @author Nick Crum (ncrum)
@@ -45,7 +58,7 @@ import java.io.Serializable;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_INDEX_FIELD_TYPE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.ARCHIVE_ONLY)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
@@ -44,7 +44,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SEARCH_FACET_XREF")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG, skipOverlaps=true)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -66,7 +66,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SEARCH_FACET")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY),
@@ -156,7 +156,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable, AdminMainEnti
     
     @OneToMany(mappedBy = "searchFacet", targetEntity = SearchFacetRangeImpl.class, cascade = {CascadeType.ALL})
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @Where(clause = "(ARCHIVED != 'Y' OR ARCHIVED IS NULL)")
     @AdminPresentationCollection(addType = AddMethodType.PERSIST,
             friendlyName = "newRangeTitle",
@@ -165,7 +165,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable, AdminMainEnti
     
     @OneToMany(mappedBy = "searchFacet", targetEntity = RequiredFacetImpl.class, cascade = {CascadeType.ALL})
     @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @AdminPresentationAdornedTargetCollection(targetObjectProperty = "requiredFacet", friendlyName = "requiredFacetTitle",
             gridVisibleFields = { "name", "label", "fieldType.indexField.field.friendlyName" },
             group = GroupName.Dependent,

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
@@ -58,7 +58,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SEARCH_FACET_RANGE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @AdminPresentationMergeOverrides(
     value = { 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
@@ -32,7 +32,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "BLC_SEARCH_SYNONYM")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 public class SearchSynonymImpl implements SearchSynonym {
     
     @Id

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
@@ -54,7 +54,7 @@ import javax.persistence.Transient;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SEARCH_INTERCEPT")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
@@ -46,7 +46,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "BLC_STORE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStoreElements")
 @SQLDelete(sql="UPDATE BLC_STORE SET ARCHIVED = 'Y' WHERE STORE_ID = ?")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StoreImpl_baseStore")
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-applicationContext.xml
@@ -243,4 +243,17 @@
             </list>
         </property>
     </bean>
+    
+    <bean id="blMergedCacheConfigLocations-framework" class="org.springframework.beans.factory.config.ListFactoryBean">
+        <property name="sourceList">
+            <list>
+                <value>classpath:bl-framework-ehcache.xml</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.broadleafcommerce.common.extensibility.context.merge.EarlyStageMergeBeanPostProcessor">
+        <property name="collectionRef" value="blMergedCacheConfigLocations-framework"/>
+        <property name="targetRef" value="blMergedCacheConfigLocations"/>
+    </bean>
 </beans>

--- a/core/broadleaf-framework/src/main/resources/bl-framework-ehcache.xml
+++ b/core/broadleaf-framework/src/main/resources/bl-framework-ehcache.xml
@@ -1,8 +1,8 @@
 <!--
   #%L
-  BroadleafCommerce CMS Module
+  BroadleafCommerce Framework
   %%
-  Copyright (C) 2009 - 2016 Broadleaf Commerce
+  Copyright (C) 2009 - 2021 Broadleaf Commerce
   %%
   Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
   (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
@@ -18,59 +18,75 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://www.ehcache.org/v3"
         xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.3.xsd">
-    
-    <cache alias="blCMSElements">
+        
+    <cache alias="blCategoryProduct">
         <expiry>
-            <ttl>3600</ttl>
+            <ttl>86400</ttl>
+        </expiry>
+        <heap>40000</heap>
+    </cache>
+    
+    <cache alias="blCategoryRelationships">
+        <expiry>
+            <ttl>86400</ttl>
         </expiry>
         <heap>10000</heap>
     </cache>
-
-    <cache alias="cmsPageCache">
-        <expiry>
-            <ttl>3600</ttl>
-        </expiry>
-        <heap>1000</heap>
-    </cache>
     
-    <cache alias="cmsPageMapCache">
-        <expiry>
-            <ttl>3600</ttl>
-        </expiry>
-        <heap>1000</heap>
-    </cache>
-    
-    <!-- Caches Page URIs by date added to Cache to reduce 
-         number of queries to find Pages by URI.
-         Cache for a day -->
-    <cache alias="uriCachedDateCache">
+    <cache alias="blFulfillmentOptionElements">
         <expiry>
             <ttl>86400</ttl>
         </expiry>
         <heap>1000</heap>
     </cache>
-
-    <!-- Structured Content Cache - 1 hour cache -->
-    <cache alias="cmsStructuredContentCache">
+    
+    <cache alias="blProductAttributes">
         <expiry>
-            <ttl>3600</ttl>
+            <ttl>86400</ttl>
+        </expiry>
+        <heap>10000</heap>
+    </cache>
+    
+    <cache alias="blProductOptions">
+        <expiry>
+            <ttl>86400</ttl>
         </expiry>
         <heap>5000</heap>
     </cache>
     
-    <!--  URLHandlerCache -->
-    <cache alias="cmsUrlHandlerCache">
+    <cache alias="blProductRelationships">
         <expiry>
-            <ttl>3600</ttl>
+            <ttl>86400</ttl>
         </expiry>
-        <heap>5000</heap>
+        <heap>30000</heap>
     </cache>
     
-    <cache alias="blUrlHandler">
+    <cache alias="blRelatedProducts">
         <expiry>
             <ttl>86400</ttl>
         </expiry>
         <heap>1000</heap>
     </cache>
-
+    
+    <cache alias="blSearchElements">
+        <expiry>
+            <ttl>86400</ttl>
+        </expiry>
+        <heap>5000</heap>
+    </cache>
+    
+    <cache alias="blSkuMedia">
+        <expiry>
+            <ttl>86400</ttl>
+        </expiry>
+        <heap>40000</heap>
+    </cache>
+    
+    <cache alias="blStoreElements">
+        <expiry>
+            <ttl>86400</ttl>
+        </expiry>
+        <heap>1000</heap>
+    </cache>
+    
 </config>

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
@@ -36,7 +36,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CHALLENGE_QUESTION")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
 @AdminPresentationClass(friendlyName = "ChallengeQuestionImpl_baseChallengeQuestion")
 public class ChallengeQuestionImpl implements ChallengeQuestion {
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountryImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountryImpl.java
@@ -37,7 +37,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_COUNTRY")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCountryElements")
 @AdminPresentationClass(friendlyName = "CountryImpl_baseCountry")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
@@ -54,18 +54,22 @@ public class CountryImpl implements Country, AdminMainEntity {
     @AdminPresentation(friendlyName = "CountryImpl_Country", order=12, group = "CountryImpl_Address", prominent = true, translatable = true)
     protected String name;
 
+    @Override
     public String getAbbreviation() {
         return abbreviation;
     }
 
+    @Override
     public void setAbbreviation(String Abbreviation) {
         this.abbreviation = Abbreviation;
     }
 
+    @Override
     public String getName() {
         return DynamicTranslationProvider.getValue(this, "name", name);
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
@@ -43,7 +43,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_COUNTRY_SUB_CAT")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCountryElements")
 @AdminPresentationClass(friendlyName = "CountrySubdivisionCategoryImpl_baseCategory")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionImpl.java
@@ -44,7 +44,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_COUNTRY_SUB")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCountryElements")
 @AdminPresentationClass(friendlyName = "CountrySubdivisionImpl_baseSubdivision")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
@@ -17,9 +17,9 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
@@ -40,7 +40,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name="BLC_CUSTOMER_ATTRIBUTE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
 public class CustomerAttributeImpl implements CustomerAttribute {
 
     /** The Constant serialVersionUID. */

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
@@ -197,7 +197,7 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
     protected Locale customerLocale;
 
     @OneToMany(mappedBy = "customer", targetEntity = CustomerAttributeImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @MapKey(name = "name")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "CustomerAttributeImpl_Attribute_Name",
@@ -208,7 +208,7 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
     @OneToMany(mappedBy = "customer", targetEntity = CustomerAddressImpl.class, cascade = { CascadeType.ALL })
     @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @Where(clause = "archived != 'Y'")
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Addresses",
             group = GroupName.ContactInfo, order = FieldOrder.ADDRESSES,
@@ -217,7 +217,7 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
     @OneToMany(mappedBy = "customer", targetEntity = CustomerPhoneImpl.class, cascade = { CascadeType.ALL })
     @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Phones",
             group = GroupName.ContactInfo, order = FieldOrder.PHONES,
             addType = AddMethodType.PERSIST)
@@ -225,7 +225,7 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
     @OneToMany(mappedBy = "customer", targetEntity = CustomerPaymentImpl.class, cascade = { CascadeType.ALL })
     @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Payments",
             tab = TabName.PaymentMethods, order = 1000,

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
@@ -138,7 +138,7 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
     @MapKeyColumn(name = "FIELD_NAME", nullable = false)
     @Column(name = "FIELD_VALUE", length = Integer.MAX_VALUE - 1)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @AdminPresentationMap(friendlyName = "CustomerPaymentImpl_additionalFields",
             tab = TabName.Payment,
             keyPropertyFriendlyName = "CustomerPaymentImpl_additional_field_key",

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/StateImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/StateImpl.java
@@ -40,7 +40,7 @@ import javax.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_STATE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCountryElements")
 @AdminPresentationClass(friendlyName = "StateImpl_baseState")
 public class StateImpl implements State {
 
@@ -59,26 +59,32 @@ public class StateImpl implements State {
     @JoinColumn(name = "COUNTRY")
     protected Country country;
 
+    @Override
     public String getAbbreviation() {
         return abbreviation;
     }
 
+    @Override
     public void setAbbreviation(String abbreviation) {
         this.abbreviation = abbreviation;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public Country getCountry() {
         return country;
     }
 
+    @Override
     public void setCountry(Country country) {
         this.country = country;
     }


### PR DESCRIPTION
Refactored entity cache regions so that blStandardElements didn't have so many entities in it and blCategories, and blProducts could be more efficiently utilized in larger catalog implementations.

BroadleafCommerce/QA#4335 
