### PR TITLE
Redactor Edit Link checkbox change event fix

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
@@ -5939,7 +5939,9 @@
                     this.link.getData();
                     this.link.cleanUrl();
 
-                    if (this.link.target == '_blank') $('#redactor-link-blank').prop('checked', true);
+                    var linkCheckbox = $('#redactor-link-blank');
+                    if (this.link.target == '_blank') linkCheckbox.prop('checked', true);
+                    linkCheckbox.attr('data-orig-val', "")
 
                     this.link.$inputUrl = $('#redactor-link-url');
                     this.link.$inputText = $('#redactor-link-url-text');


### PR DESCRIPTION
Added property for Edit Link checkbox and correctly handle changes event

**A Brief Overview**
The 'Save' button didn't change state after a click on the Edit Link checkbox

**Link to QA issue**
BroadleafCommerce/QA#4343

**Additional context**
https://secure.helpscout.net/conversation/1401798075/44756?folderId=387708