### PR TITLE
Upgrading Apache Commons-Validator library to latest available (version 1.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -653,7 +653,7 @@
             <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
-                <version>1.5.1</version>
+                <version>1.7</version>
                 <type>jar</type>
                 <scope>compile</scope>
                 <exclusions>


### PR DESCRIPTION
**Add proper title**
This version supports new domain extensions like ".shop"

Fixes https://github.com/BroadleafCommerce/QA/issues/4363