### PR TITLE
Disable login user by email

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/user/AdminUserDetailsServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/user/AdminUserDetailsServiceImpl.java
@@ -56,12 +56,6 @@ public class AdminUserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
         AdminUser adminUser = adminUserDao.readAdminUserByUserName(username);
-        if (adminUser == null) {
-            List<AdminUser> results = adminUserDao.readAdminUserByEmail(username);
-            if (!CollectionUtils.isEmpty(results)) {
-                adminUser = results.get(0);
-            }
-        }
         if (adminUser == null || adminUser.getActiveStatusFlag() == null || !adminUser.getActiveStatusFlag()) {
             throw new UsernameNotFoundException("The user was not found");
         }


### PR DESCRIPTION
Disabled possibility login to the admin site via the email address

**A Brief Overview**
When the user tries to login with an email then the site returns 500 exception

**Link to QA issue**
BroadleafCommerce/QA#4362

**Additional context**
https://secure.helpscout.net/conversation/1416568513/45041?folderId=305491