### PR TITLE
- Fix mvel issue when parser fails to parse ?someBeanA || ?someBeanB. ?someBeanB is a valid expression, but parser fails, so need to wrap it in ()

### DIFF
--- a/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/DataDTOToMVELTranslatorTest.java
+++ b/admin/broadleaf-admin-module/src/test/java/org/broadleafcommerce/admin/web/rulebuilder/DataDTOToMVELTranslatorTest.java
@@ -266,7 +266,7 @@ public class DataDTOToMVELTranslatorTest extends TestCase {
         dataDTO.getRules().add(e2);
 
         String translated = translator.createMVEL("fulfillmentGroup", dataDTO, fulfillmentGroupFieldService);
-        String mvel = "?fulfillmentGroup.?address.?state.?name==\"Texas\"&&(?fulfillmentGroup.?retailFulfillmentPrice.getAmount()>=99&&?fulfillmentGroup.?retailFulfillmentPrice.getAmount()<=199)";
+        String mvel = "?fulfillmentGroup.?address.?state.?name==\"Texas\"&&(?fulfillmentGroup.?retailFulfillmentPrice.getAmount()>=99&&(?fulfillmentGroup.?retailFulfillmentPrice.getAmount()<=199))";
         assert (mvel.equals(translated));
     }
 
@@ -312,8 +312,8 @@ public class DataDTOToMVELTranslatorTest extends TestCase {
         
         String d1Mvel = "(MvelHelper.convertField(\"DATE\",?customer.?getCustomerAttributes()[\"invoice_date\"])" +
                 ">MvelHelper.convertField(\"DATE\",MvelHelper.subtractFromCurrentTime(12))" +
-                "&&MvelHelper.convertField(\"DATE\",?customer.?getCustomerAttributes()[\"invoice_date\"])" +
-                "<MvelHelper.convertField(\"DATE\",MvelHelper.currentTime()))";
+                "&&(MvelHelper.convertField(\"DATE\",?customer.?getCustomerAttributes()[\"invoice_date\"])" +
+                "<MvelHelper.convertField(\"DATE\",MvelHelper.currentTime())))";
 
         customerFieldService.init();
         

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/DataDTOToMVELTranslator.java
@@ -446,6 +446,12 @@ public class DataDTOToMVELTranslator {
             sb.append(formatValue(field, entityKey, type, secondaryType, value, isFieldComparison, ignoreCase, ignoreQuotes));
             sb.append(")");
         } else {
+            boolean addParenthesis = false;
+            if(sb.length()>0 && sb.charAt(sb.length()-1)!='('){
+                addParenthesis = true;
+                sb.append("(");
+            }
+
             sb.append(formatField(entityKey, type, field, ignoreCase));
             sb.append(operator);
             if (includeParenthesis) {
@@ -453,6 +459,9 @@ public class DataDTOToMVELTranslator {
             }
             sb.append(formatValue(field, entityKey, type, secondaryType, value,
                     isFieldComparison, ignoreCase, ignoreQuotes));
+            if(addParenthesis){
+                sb.append(")");
+            }
             if (includeParenthesis) {
                 sb.append(")");
             }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/MVELToDataWrapperTranslator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/rulebuilder/MVELToDataWrapperTranslator.java
@@ -183,7 +183,12 @@ public class MVELToDataWrapperTranslator {
         for (Group subgroup : group.getSubGroups()) {
             DataDTO subCriteria = createRuleDataDTO(data, subgroup, fieldService);
             if (subCriteria != null && !subCriteria.getRules().isEmpty()) {
-                data.getRules().add(subCriteria);
+                if(subCriteria.getRules().size()==1){
+                    data.getRules().add(subCriteria.getRules().get(0));
+                    subCriteria.getRules().get(0).setCreatedFromSubGroup(false);
+                }else {
+                    data.getRules().add(subCriteria);
+                }
             }
         }
         if (data.getRules() != null && !data.getRules().isEmpty()) {


### PR DESCRIPTION

Fixes: BroadleafCommerce/QA#4366

