### PR TITLE
Refresh customer after change of address

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDao.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDao.java
@@ -108,4 +108,6 @@ public interface CustomerDao {
     void detach(Customer customer);
 
     Long readNumberOfCustomers();
+
+    void refreshCustomer(Customer customer);
 }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDaoImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/dao/CustomerDaoImpl.java
@@ -35,6 +35,7 @@ import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import javax.transaction.Transactional;
 
 @Repository("blCustomerDao")
 public class CustomerDaoImpl implements CustomerDao {
@@ -180,5 +181,11 @@ public class CustomerDaoImpl implements CustomerDao {
         TypedQuery<Long> query = em.createQuery(criteria);
 
         return query.getSingleResult();
+    }
+
+    @Override
+    @Transactional
+    public void refreshCustomer(Customer customer) {
+        em.refresh(customer);
     }
 }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerAddressServiceImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/service/CustomerAddressServiceImpl.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.profile.core.service;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.util.TransactionUtils;
 import org.broadleafcommerce.profile.core.dao.CustomerAddressDao;
+import org.broadleafcommerce.profile.core.dao.CustomerDao;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.core.domain.CustomerAddress;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,9 @@ public class CustomerAddressServiceImpl implements CustomerAddressService {
 
     @Resource(name="blCustomerAddressDao")
     protected CustomerAddressDao customerAddressDao;
+
+    @Resource(name="blCustomerDao")
+    protected CustomerDao customerDao;
 
     @Override
     @Transactional(TransactionUtils.DEFAULT_TRANSACTION_MANAGER)
@@ -51,6 +55,7 @@ public class CustomerAddressServiceImpl implements CustomerAddressService {
         if (customerAddress.getAddress().isDefault()) {
             customerAddressDao.makeCustomerAddressDefault(customerAddress.getId(), customer.getId());
         }
+        customerDao.refreshCustomer(customerAddress.getCustomer());
 
         return customerAddress;
     }
@@ -74,7 +79,9 @@ public class CustomerAddressServiceImpl implements CustomerAddressService {
     @Override
     @Transactional(TransactionUtils.DEFAULT_TRANSACTION_MANAGER)
     public void deleteCustomerAddressById(Long customerAddressId){
+        CustomerAddress customerAddress = customerAddressDao.readCustomerAddressById(customerAddressId);
         customerAddressDao.deleteCustomerAddressById(customerAddressId);
+        customerDao.refreshCustomer(customerAddress.getCustomer());
     }
 
     @Override


### PR DESCRIPTION
Refresh customer after change of address
Fixes: BroadleafCommerce/QA#4398
There might be situation when you change address(add new address to customer in site or remove address) but customer that's in CustomerState doesn't reflect changes to its collection, so refresh it