### PR TITLE
Use createStandaloneElement for the CSS link tag so it closes properly

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ResourceBundleProcessor.java
@@ -302,7 +302,7 @@ public class ResourceBundleProcessor extends AbstractResourceProcessor {
                 model.addElement(element);
             }
         } else {
-            model.addElement(context.createNonVoidElement("link", getNormalCssAttributes(attributes), true));
+            model.addElement(context.createStandaloneElement("link", getNormalCssAttributes(attributes), true));
         }
     }
 


### PR DESCRIPTION
**A Brief Overview**
When resource bundling is enabled, the `<link>` tag generated by the ResourceBundleProcessor is not closed correctly. It renders as `<link></link>` instead of `<link />`. Technically, including `</link>` is incorrect since it is an empty element.

This PR updates the ResourceBundleProcessor to use `createStandaloneElement` instead of `createNonVoidElement` when creating link elements.

**Additional context**
This was found in an HTML validation scan by UWO

QA: https://github.com/BroadleafCommerce/QA/issues/4406