### PR TITLE
Added canonicalization for ESAPI (fixed log output)

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/security/XssRequestWrapper.java
@@ -151,7 +151,7 @@ public class XssRequestWrapper extends HttpServletRequestWrapper {
         }
 
         try {
-            return ESAPI.validator().getValidInput("Value: " + value, value, esapiInputType, MAX_INPUT_LENGTH, true, false);
+            return ESAPI.validator().getValidInput("Value: " + value, value, esapiInputType, MAX_INPUT_LENGTH, true, true);
         } catch (ValidationException e) {
             return stripXssAsHTML(value);
         }


### PR DESCRIPTION
Set canonicalize input in the Esapi String Validation URL

**A Brief Overview**
Disable StringValidationRule logs

**Additional context**
https://github.com/BroadleafCommerce/QA/issues/4399
