### PR TITLE
Changing Money evaluations against Money.ZERO to use compareTo instead of equals

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/OrderOfferProcessorImpl.java
@@ -532,7 +532,7 @@ public class OrderOfferProcessorImpl extends AbstractBaseProcessor implements Or
     }
 
     protected boolean fgContainsFutureCreditAdjustment(FulfillmentGroup fg) {
-        return !fg.getFutureCreditFulfillmentGroupAdjustmentsValue().equals(Money.ZERO);
+        return !(fg.getFutureCreditFulfillmentGroupAdjustmentsValue().compareTo(Money.ZERO) == 0);
     }
 
     protected void syncFulfillmentPrice(FulfillmentGroup fg) {


### PR DESCRIPTION
An expression (Money Value).equals(Money.ZERO) will not work if the current for the (Money Value) is using a defaultFractionDigit of 0.  The expression ends up basically being 0.equals(0.00) and will evaluate false.  The expression needs to change to ((Money Value).compareTo(Money.ZERO) == 0).  Fixes https://github.com/BroadleafCommerce/QA/issues/4421