### PR TITLE
When an offer is configured with "apply to items already on sale" = No and the salePrice + discount < retail + discount then the sale price only is incorrectly getting used

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
@@ -90,7 +90,14 @@ public class PromotableOfferUtilityImpl implements PromotableOfferUtility {
 
     @Override
     public Money computeSalesAdjustmentValue(PromotableCandidateItemOffer promotableCandidateItemOffer, PromotableOrderItemPriceDetail orderItemPriceDetail) {
-        return computeAdjustmentValue(promotableCandidateItemOffer, orderItemPriceDetail, true);
+        if (promotableCandidateItemOffer.getOffer().getApplyDiscountToSalePrice()) {
+            return computeAdjustmentValue(promotableCandidateItemOffer, orderItemPriceDetail, true);
+        } else {
+            //If we aren't evaluating the sale price then the adjustment will be zero
+            PromotableOrderItem promotableOrderItem = orderItemPriceDetail.getPromotableOrderItem();
+            BroadleafCurrency currency = promotableOrderItem.getCurrency();
+            return new Money(currency);
+        }
     }
 
     @Override


### PR DESCRIPTION
This update takes into account the "apply to items already on sale" = No when assessing the discount value.  In this case, the salePrice adjustment will always be $0.  Fixes https://github.com/BroadleafCommerce/QA/issues/4451
