### PR TITLE
Fixed ConfirmedPaymentRollbackHandler to make sure to archive all payments if a rollback is triggered

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ConfirmPaymentsRollbackHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ConfirmPaymentsRollbackHandler.java
@@ -150,6 +150,7 @@ public class ConfirmPaymentsRollbackHandler implements RollbackHandler<ProcessCo
                     if (!rollbackTX.getSuccess()) {
                         rollbackFailure = true;
                     }
+                    order = payment.getOrder();
                 }
             }
     


### PR DESCRIPTION
- fix to get a "fresh copy" or the order
Fixes: BroadleafCommerce/QA#4447