### PR TITLE
Upgrade libs for security

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogURLServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogURLServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.core.catalog.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.Product;
@@ -62,7 +63,11 @@ public class CatalogURLServiceImpl implements CatalogURLService {
     protected String buildRelativeUrlWithParam(String currentUrl, String fragment, String idParam, String idValue) {
         try {
             URIBuilder builder = new URIBuilder(currentUrl);
-            builder.setPath(builder.getPath() + "/" + fragment);
+            String path = builder.getPath();
+            if (StringUtils.isEmpty(currentUrl) || currentUrl.equals("/")) {
+                path = "";
+            }
+            builder.setPath(path + "/" + fragment);
 
             if (appendIdToRelativeURI) {
                 builder.setParameter(idParam, String.valueOf(idValue));

--- a/pom.xml
+++ b/pom.xml
@@ -1248,7 +1248,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.6</version>
+                <version>4.5.13</version>
             </dependency>
             <!--update xalan dependency for esapi for a xalan security vulnerability-->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1259,7 +1259,7 @@
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>6.0.18.Final</version>
+                <version>6.0.22.Final</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>


### PR DESCRIPTION
**Upgraded libs**
- hibernate-validator to 6.0.22
- httpclient to 4.5.13

**QA Link**
https://github.com/BroadleafCommerce/QA/issues/4462