### PR TITLE
Ensure order lock can be released

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/CheckoutServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/CheckoutServiceImpl.java
@@ -65,14 +65,14 @@ public class CheckoutServiceImpl implements CheckoutService {
         if (lockObject != null) {
             throw new CheckoutException("This order is already in the process of being submitted, unable to checkout order -- id: " + order.getId(), new CheckoutSeed(order, new HashMap<String, Object>()));
         }
-
-        // Immediately fail if this order has already been checked out previously
-        if (hasOrderBeenCompleted(order)) {
-            throw new CheckoutException("This order has already been submitted or cancelled, unable to checkout order -- id: " + order.getId(), new CheckoutSeed(order, new HashMap<String, Object>()));
-        }
         
         CheckoutSeed seed = null;
         try {
+            // Immediately fail if this order has already been checked out previously
+            if (hasOrderBeenCompleted(order)) {
+                throw new CheckoutException("This order has already been submitted or cancelled, unable to checkout order -- id: " + order.getId(), new CheckoutSeed(order, new HashMap<String, Object>()));
+            }
+
             // Do a final save of the order before going through with the checkout workflow
             order = orderService.save(order, false);
             seed = new CheckoutSeed(order, new HashMap<String, Object>());


### PR DESCRIPTION
**Performcheckout order lock**
- Fixes the issue that order lock may be not released finally

**Brief Overview**
move validation code into try-finally block to ensure that lock will always be released correctly

**Labels:**
 - Bug or Enhancement
