### PR TITLE
Removed an unused static reference to TranslationImpl in TranslationServiceImpl.  This reference can cause a startup issue with class transformations.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/TranslationServiceImpl.java
@@ -52,8 +52,7 @@ import net.sf.ehcache.CacheManager;
 public class TranslationServiceImpl implements TranslationService, TranslationSupport {
 
     protected static final Log LOG = LogFactory.getLog(TranslationServiceImpl.class);
-    private static final Translation DELETED_TRANSLATION = new TranslationImpl();
-    
+
     @Resource(name = "blTranslationDao")
     protected TranslationDao dao;
 


### PR DESCRIPTION
Fixes https://github.com/BroadleafCommerce/QA/issues/4513