### PR TITLE
Fixed incorrect behaviour for the Save button after Image removing

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm-status.js
@@ -567,7 +567,7 @@
             if (el) {
                 var $element = $(el);
 
-                // if changes are explcitly tracked on this input, track it
+                // if changes are explicitly tracked on this input, track it
                 if ($element.data('track-changes')) {
                     return true;
                 }
@@ -591,12 +591,8 @@
                 if ($element.closest('.field-group').find('.boolean-link').length) {
                     return false;
                 }
-
-                // Otherwise, track the changes
-                return true;
             }
-
-            return false;
+            return true;
         },
 
         /**


### PR DESCRIPTION
Fixed save button behavior

**A Brief Overview**
Save button does not have an enabled statement after removing the primary image

**Additional context**
https://github.com/BroadleafCommerce/QA/issues/4531
