### PR TITLE
This fix is to force the currency to be instantiated by called the getCurrencyCode() method instead of the field currencyCode.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/currency/domain/BroadleafCurrencyImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/currency/domain/BroadleafCurrencyImpl.java
@@ -122,7 +122,7 @@ public class BroadleafCurrencyImpl implements BroadleafCurrency, AdminMainEntity
 
         BroadleafCurrencyImpl currency = (BroadleafCurrencyImpl) o;
 
-        if (currencyCode != null ? !currencyCode.equals(currency.currencyCode) : currency.currencyCode != null) {
+        if (currencyCode != null ? !currencyCode.equals(currency.getCurrencyCode()) : currency.getCurrencyCode() != null) {
             return false;
         }
 


### PR DESCRIPTION
In select use cases the BroadleafCurrency.equals method was failing to properly compare currencies because one of the currencies being compared was a HibernateProxy (LazyInitialization).  This fix is to force the currency to be instantiated by called the getCurrencyCode() method instead of the field currencyCode.  Fixes https://github.com/BroadleafCommerce/QA/issues/4558.
