### PR TITLE
Check if the category is parent while delete

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDao.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDao.java
@@ -140,6 +140,15 @@ public interface CategoryDao {
     /**
      * Retrieve a list of all child categories of the passed in {@code Category} instance
      *
+     * @param id the parent category ID
+     * @return a list of all child categories
+     */
+    @Nonnull
+    public List<Category> readAllSubCategories(@Nonnull Long id);
+
+    /**
+     * Retrieve a list of all child categories of the passed in {@code Category} instance
+     *
      * @param category the parent category
      * @param limit the maximum number of results to return
      * @param offset the starting point in the record set

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/CategoryDaoImpl.java
@@ -221,6 +221,16 @@ public class CategoryDaoImpl implements CategoryDao {
     }
 
     @Override
+    public List<Category> readAllSubCategories(Long id) {
+        TypedQuery<Category> query = em.createNamedQuery("BC_READ_ALL_SUBCATEGORIES", Category.class);
+        query.setParameter("parentCategoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, id));
+        query.setHint(QueryHints.HINT_CACHEABLE, true);
+        query.setHint(QueryHints.HINT_CACHE_REGION, "query.Catalog");
+
+        return query.getResultList();
+    }
+
+    @Override
     public List<Category> readAllSubCategories(Category category, int limit, int offset) {
         TypedQuery<Category> query = em.createNamedQuery("BC_READ_ALL_SUBCATEGORIES", Category.class);
         query.setParameter("parentCategoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, category.getId()));


### PR DESCRIPTION
Added check for the parent category removing

**A Brief Overview**
Added new Spring parameter `allow.category.delete.with.children` which allow delete category without checking

**Link to QA issue**
https://github.com/BroadleafCommerce/QA/issues/4556
