### PR TITLE
Set active dates for product duplication to current

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
@@ -118,10 +118,8 @@ public class ProductDuplicateModifier extends AbstractEntityDuplicationHelper<Pr
                 copy.setProductOptionXrefs(productOptionXrefs);
             }
         }
-        Calendar instance = Calendar.getInstance();
-        instance.add(Calendar.YEAR, 1);
-        copy.setActiveStartDate(instance.getTime());
-        copy.setActiveEndDate(null);
+        copy.setActiveStartDate(new Date());
+        copy.setActiveEndDate(new Date());
 
         setNameAndUrl(copy);
 


### PR DESCRIPTION
Set active start and end date for product duplication to current date

**Link to issue**
https://github.com/BroadleafCommerce/QA/issues/4569
