### PR TITLE
Fix case when saving invalid rule will delete all other rules, because client side validation is returning empty rules

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/RuleFieldValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/RuleFieldValidator.java
@@ -64,6 +64,9 @@ public class RuleFieldValidator implements PopulateValueRequestValidator {
                 //AntiSamy HTML encodes the rule JSON - pass the unHTMLEncoded version
                 DataWrapper dw = ruleFieldExtractionUtility.convertJsonToDataWrapper(populateValueRequest.getProperty().getUnHtmlEncodedValue());
                 if (dw != null && StringUtils.isNotEmpty(dw.getError())) {
+                    if("Invalid Rule".equals(dw.getError())){
+                        return new PropertyValidationResult(false, dw.getError());
+                    }
                     return new PropertyValidationResult(false, "Could not serialize JSON from rule builder: " + dw.getError());
                 }
                 if (dw == null || StringUtils.isEmpty(dw.getError())) {
@@ -93,6 +96,9 @@ public class RuleFieldValidator implements PopulateValueRequestValidator {
                 if (!StringUtils.isEmpty(jsonPropertyValue)) {
                     DataWrapper dw = ruleFieldExtractionUtility.convertJsonToDataWrapper(jsonPropertyValue);
                     if (dw != null && StringUtils.isNotEmpty(dw.getError())) {
+                        if("Invalid Rule".equals(dw.getError())){
+                            return new PropertyValidationResult(false, dw.getError());
+                        }
                         return new PropertyValidationResult(false, "Could not serialize JSON from rule builder: " + dw.getError());
                     }
                     if (dw != null && StringUtils.isEmpty(dw.getError())) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -757,6 +757,11 @@
             collectedData.data = [];
             for (var j = 0; j < ruleBuilder.builders.length; j++) {
                 var builder = ruleBuilder.builders[j];
+                $(builder).one('validationError.queryBuilder', function(e, node, error, value) {
+                    if(value != null && error != "no_filter"){
+                        collectedData.error = "Invalid Rule";
+                    }
+                });
                 var dataDTO = $(builder).queryBuilder('getRules', { displayErrors : ruleBuilder.displayErrors });
                 if (dataDTO.rules) {
                     dataDTO.pk = $(builder).find(".rules-group-header-item-pk").val();
@@ -768,6 +773,8 @@
                     }
 
                     collectedData.data.push(dataDTO);
+                }else{
+
                 }
             }
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/ruleBuilder-v2.js
@@ -758,7 +758,7 @@
             for (var j = 0; j < ruleBuilder.builders.length; j++) {
                 var builder = ruleBuilder.builders[j];
                 $(builder).one('validationError.queryBuilder', function(e, node, error, value) {
-                    if(value != null && error != "no_filter"){
+                    if(value != null && error !== "no_filter"){
                         collectedData.error = "Invalid Rule";
                     }
                 });
@@ -773,8 +773,6 @@
                     }
 
                     collectedData.data.push(dataDTO);
-                }else{
-
                 }
             }
 


### PR DESCRIPTION
- Fix case when saving invalid rule will delete all other rules, because client side validation is returning empty rules
Fixes: BroadleafCommerce/QA#4572