### PR TITLE
Fix for invalid chars in file name of static asset

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
+++ b/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
@@ -71,3 +71,10 @@ admin.image.file.extensions=bmp,jpg,jpeg,png,img,tiff,gif
 # If blank all extensions are available.
 # Implementors should tune this according to their needs.
 disabled.file.extensions=pdf
+
+#if static asset file name that is uploading contains the following chars they will be replaced(no effect on existing assets)
+static.asset.not.allowed.chars.in.filename=+,*,%
+#the string that will replace invalid chars from above
+static.asset.invalid.chars.replacement=_
+#in case this property is set to true, error will be presented instead of invalid chars replacement
+static.asset.exception.on.invalid.char.in.filename=false

--- a/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
+++ b/admin/broadleaf-contentmanagement-module/src/main/resources/config/bc/cms/common.properties
@@ -73,7 +73,7 @@ admin.image.file.extensions=bmp,jpg,jpeg,png,img,tiff,gif
 disabled.file.extensions=pdf
 
 #if static asset file name that is uploading contains the following chars they will be replaced(no effect on existing assets)
-static.asset.not.allowed.chars.in.filename=+,*,%
+static.asset.invalid.chars.in.filename=+,*,%
 #the string that will replace invalid chars from above
 static.asset.invalid.chars.replacement=_
 #in case this property is set to true, error will be presented instead of invalid chars replacement


### PR DESCRIPTION
- Fix for invalid chars in file name

Fixes: BroadleafCommerce/QA#4579

New properties were introduced:
- if static asset file name that is uploading contains the following chars they will be replaced(no effect on existing assets)
 
**static.asset.invalid.chars.in.filename=+,*,%**

- the string that will replace invalid chars from above

**static.asset.invalid.chars.replacement=_**

- in case this property is set to true, error will be presented instead of invalid chars replacement

**static.asset.exception.on.invalid.char.in.filename=false**