### PR TITLE
ADDONs should have null url during duplication

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
@@ -21,6 +21,7 @@ import lombok.SneakyThrows;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.persistence.AbstractEntityDuplicationHelper;
 import org.broadleafcommerce.common.persistence.EntityDuplicatorExtensionManager;
 import org.broadleafcommerce.common.service.GenericEntityService;
@@ -32,13 +33,13 @@ import org.broadleafcommerce.core.catalog.domain.ProductImpl;
 import org.broadleafcommerce.core.catalog.domain.ProductOption;
 import org.broadleafcommerce.core.catalog.domain.ProductOptionImpl;
 import org.broadleafcommerce.core.catalog.domain.ProductOptionXref;
+import org.broadleafcommerce.core.catalog.service.extension.ProductUrlDuplicatorExtensionManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -56,6 +57,9 @@ public class ProductDuplicateModifier extends AbstractEntityDuplicationHelper<Pr
 
     @Resource(name = "blGenericEntityService")
     protected GenericEntityService genericEntityService;
+
+    @Resource(name = "blProductUrlDuplicatorExtensionManager")
+    protected ProductUrlDuplicatorExtensionManager productUrlDuplicatorExtensionManager;
 
     @Autowired
     public ProductDuplicateModifier(final Environment environment) {
@@ -154,6 +158,10 @@ public class ProductDuplicateModifier extends AbstractEntityDuplicationHelper<Pr
             }
         }
         copy.setName(name);
-        copy.setUrl("/" + copy.getName().replace("-", "").replace(" ", "-").toLowerCase());
+        String url = "/" + copy.getName().replace("-", "").replace(" ", "-").toLowerCase();
+        ExtensionResultStatusType extensionResultStatusType = productUrlDuplicatorExtensionManager.getProxy().modifyUrl(url, copy, new ExtensionResultHolder<>());
+        if(extensionResultStatusType == ExtensionResultStatusType.NOT_HANDLED) {
+            copy.setUrl(url);
+        }
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/extension/ProductUrlDuplicatorExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/extension/ProductUrlDuplicatorExtensionHandler.java
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.catalog.service.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.core.catalog.domain.Product;
+
+public interface ProductUrlDuplicatorExtensionHandler extends ExtensionHandler {
+
+    ExtensionResultStatusType modifyUrl(String url, Product product, ExtensionResultHolder<String> holder);
+}

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/extension/ProductUrlDuplicatorExtensionManager.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/extension/ProductUrlDuplicatorExtensionManager.java
@@ -1,0 +1,30 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.catalog.service.extension;
+
+import org.broadleafcommerce.common.extension.ExtensionManager;
+import org.springframework.stereotype.Service;
+
+@Service("blProductUrlDuplicatorExtensionManager")
+public class ProductUrlDuplicatorExtensionManager
+        extends ExtensionManager<ProductUrlDuplicatorExtensionHandler> {
+
+    public ProductUrlDuplicatorExtensionManager() {
+        super(ProductUrlDuplicatorExtensionHandler.class);
+    }
+}


### PR DESCRIPTION
- ADDONs should have null url

Fixes: BroadleafCommerce/QA#4580