### PR TITLE
Don't use sneakyThrows ProductDuplicateModifier#modifyInitialDuplicateState

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/AbstractEntityDuplicationHelper.java
@@ -66,5 +66,5 @@ public abstract class AbstractEntityDuplicationHelper<T> implements EntityDuplic
     }
 
     @Override 
-    public abstract void modifyInitialDuplicateState(final T original, final T copy, MultiTenantCopyContext context);
+    public abstract void modifyInitialDuplicateState(final T original, final T copy, MultiTenantCopyContext context) throws CloneNotSupportedException;
 }

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/EntityDuplicationHelper.java
@@ -42,5 +42,5 @@ public interface EntityDuplicationHelper<T> {
     
     void addCopyHint(final String name, final String hint);
 
-    void modifyInitialDuplicateState(T original, T copy, MultiTenantCopyContext context);
+    void modifyInitialDuplicateState(T original, T copy, MultiTenantCopyContext context) throws CloneNotSupportedException;
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
@@ -70,9 +70,8 @@ public class ProductDuplicateModifier extends AbstractEntityDuplicationHelper<Pr
         return Product.class.isAssignableFrom(candidate.getClass());
     }
 
-    @SneakyThrows
     @Override
-    public void modifyInitialDuplicateState(final Product original, final Product copy, final MultiTenantCopyContext context) {
+    public void modifyInitialDuplicateState(final Product original, final Product copy, final MultiTenantCopyContext context) throws CloneNotSupportedException {
         if(context.getCopyHints().get(PROPAGATION)!=null && "TRUE".equalsIgnoreCase(context.getCopyHints().get(PROPAGATION))){
             for (CategoryProductXref allParentCategoryXref : original.getAllParentCategoryXrefs()) {
                 final CategoryProductXref clone = allParentCategoryXref.createOrRetrieveCopyInstance(context).getClone();


### PR DESCRIPTION
- Don't use sneakyThrows

Fixes: BroadleafCommerce/QA#4585