### PR TITLE
Replace hash in the URL during duplication of product with underscore.

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/ProductDuplicateModifier.java
@@ -157,7 +157,7 @@ public class ProductDuplicateModifier extends AbstractEntityDuplicationHelper<Pr
             }
         }
         copy.setName(name);
-        String url = "/" + copy.getName().replace("-", "").replace(" ", "-").toLowerCase();
+        String url = "/" + copy.getName().replace("-", "").replace(" ", "-").replace("#","_").toLowerCase();
         ExtensionResultStatusType extensionResultStatusType = productUrlDuplicatorExtensionManager.getProxy().modifyUrl(url, copy, new ExtensionResultHolder<>());
         if(extensionResultStatusType == ExtensionResultStatusType.NOT_HANDLED) {
             copy.setUrl(url);


### PR DESCRIPTION
**A Brief Overview**
Having a '#' character in the url of the duplicated product is truncating the URL. Therefore replace it with underscore. 

[QA Link](https://github.com/BroadleafCommerce/QA/issues/4596)