### PR TITLE
SessionOrderLockManager marked as deprecated

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/SessionOrderLockManager.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/order/SessionOrderLockManager.java
@@ -38,9 +38,11 @@ import javax.servlet.http.HttpSession;
 /**
  * An {@link HttpSession} based {@link OrderLockManager}. This implementation is less concerned with the given Order
  * and instead will lock on the user's session to serialize order modification requests.
- * 
+ *
+ * @deprecated it is no longer needed and will be deleted
  * @author Andre Azzolini (apazzolini)
  */
+@Deprecated
 public class SessionOrderLockManager implements OrderLockManager, ApplicationListener<HttpSessionDestroyedEvent> {
 
     private static final Log LOG = LogFactory.getLog(SessionOrderLockManager.class);


### PR DESCRIPTION
SessionOrderLockManager is not used  in 6.1 and 6.2 and is not really advised to be used.

Link to QA
https://github.com/BroadleafCommerce/QA/issues/4588
