### PR TITLE
Upgraded log4j and excluded from xmlbeans for 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -768,7 +768,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.11.1</version>
+                <version>2.15.0</version>
                 <scope>import</scope>
                 <type>pom</type>
                 <optional>true</optional>
@@ -839,6 +839,16 @@
                 <version>5.0.0</version>
                 <type>jar</type>
                 <scope>compile</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
**A Brief Overview**
Upgrade the log4j. Needed to exclude in XMLBeans to make sure latest version will get used.

[QA Link](https://github.com/BroadleafCommerce/QA/issues/4606) 