### PR TITLE
Changed definition of validationStringExists

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/ProductOptionValidationServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/ProductOptionValidationServiceImpl.java
@@ -99,8 +99,8 @@ public class ProductOptionValidationServiceImpl implements ProductOptionValidati
 
     protected boolean requiresValidation(ProductOption productOption, String value) {
         ProductOptionValidationType validationType = productOption.getProductOptionValidationType();
-        boolean typeRequiresValidation = validationType != null && validationType == ProductOptionValidationType.REGEX;
-        boolean validationStringExists = productOption.getValidationString() != null;
+        boolean typeRequiresValidation = validationType == ProductOptionValidationType.REGEX;
+        boolean validationStringExists = StringUtils.isNotEmpty(productOption.getValidationString());
         boolean isRequired = productOption.getRequired();
         boolean hasValue = StringUtils.isNotEmpty(value);
 


### PR DESCRIPTION
Changed definition of validationStringExists in ProductOptionValidationServiceImpl.requiresValidation

Link to QA
[BroadleafCommerce/QA#4611](https://github.com/BroadleafCommerce/QA/issues/4611)