### PR TITLE
In MultiTenantCopier, deprecating direct use of Matcher for regex evaluations and instead using Pattern Matcher.  Now using classExcludeRegexPatternList as list of expressions to exclude.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -191,6 +191,7 @@ public abstract class MultiTenantCopier implements Ordered {
     protected Boolean excludeFromCopyRegex(final Object copy) {
         boolean match = false;
         if (this.classExcludeRegexPatternList.isEmpty()) {
+            LOG.warn("classExcludeRegexPatternList is empty, deprecated classExcludeRegexList is used");
             for (Matcher regex : this.classExcludeRegexList) {
                 if (regex.reset(copy.getClass().toString()).matches()) {
                     match = true;


### PR DESCRIPTION
In MultiTenantCopier marked classExcludeRegexList as Deprecated and added classExcludeRegexPatternList
Added excludeFromCopyRegexPattern () and used in excludeFromCopyRegex before classExcludeRegexList has not been removed yet.

Link to QA
[BroadleafCommerce/QA#4618](https://github.com/BroadleafCommerce/QA/issues/4618)