### PR TITLE
Javadocs are needing a reference to the javax interceptor binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,13 @@
                             <sourceFileExcludes>
                                 <sourceFileExclude>org/broadleafcommerce/cms/web/PreviewTemplateController.java</sourceFileExclude>
                             </sourceFileExcludes>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>javax.interceptor</groupId>
+                                    <artifactId>javax.interceptor-api</artifactId>
+                                    <version>1.2.2</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
See https://stackoverflow.com/questions/27808734/jdk8-error-class-file-for-javax-interceptor-interceptorbinding-not-found-whe/47889602 for more details.  Addresses https://github.com/BroadleafCommerce/QA/issues/4621

