### PR TITLE
Upgrade plugin to configure doclint from javadoc's config section.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -485,6 +485,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <doclint>none</doclint>
                             <minmemory>128m</minmemory>
                             <maxmemory>1g</maxmemory>
                             <excludePackageNames>
@@ -538,16 +539,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>disable-java8-doclint</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
-                <doclint>none</doclint>
-            </properties>
         </profile>
     </profiles>
     <dependencyManagement>


### PR DESCRIPTION
**A Brief Overview**
For versions 3.0.0 and above `doclint` is available to config as part of Plugin Configuration. This will eliminate the need of having separate `disable-java8-doclint` profile just to disable `doclint`. So upgraded plugin to latest version and disabled doclint in plugin. Then removed the profile.

Just run `mvn javadoc:aggregate-jar -P javadocs`

**Link to QA**
https://github.com/BroadleafCommerce/QA/issues/4621
