### PR TITLE
Change admin references to use self provided libraries instead of using cdnjs

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/jquery.mCustomScrollbar.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/plugins/jquery.mCustomScrollbar.js
@@ -927,7 +927,7 @@ plugin home: http://manos.malihu.gr/jquery-custom-content-scroller
 	$.support.msPointer=window.navigator.msPointerEnabled; /*MSPointer support*/
 	/*plugin dependencies*/
 	var _dlp=("https:"==document.location.protocol) ? "https:" : "http:";
-	$.event.special.mousewheel || document.write('<script src="'+_dlp+'//cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.0.6/jquery.mousewheel.min.js"><\/script>');
+	$.event.special.mousewheel || document.write('<script src="[[@{/js/lib/jquery-3.5.1.js}]]"><\/script>');
 	/*plugin fn*/
 	$.fn.mCustomScrollbar=function(method){
 		if(methods[method]){


### PR DESCRIPTION
Updated to newer version and switched to pulling jquery lib directly from our servers in jquery.mCustomScrollbar.js

Link to QA issue
[QA-4612](https://github.com/BroadleafCommerce/QA/issues/4612)