### PR TITLE
Prevent duplication of elements in classExcludeRegexPatternList

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -79,6 +79,9 @@ public abstract class MultiTenantCopier implements Ordered {
     @Deprecated
     protected List<Matcher> classExcludeRegexList = new ArrayList<>();
 
+    /**
+     * To add elements use {@link #addPattern(Pattern)}
+     */
     protected List<Pattern> classExcludeRegexPatternList = new ArrayList<>();
 
     /**
@@ -387,6 +390,28 @@ public abstract class MultiTenantCopier implements Ordered {
                 return genericEntityService.readAllGenericEntity(clazz, limit, offset);
             }
         }, site, site, catalog);
+    }
+
+    /**
+     * Checks for similar items before adding to avoid duplication
+     *
+     * @param pattern input pattern
+     */
+    protected void addPattern(final Pattern pattern) {
+        if (this.needToAdd(pattern)) {
+            this.classExcludeRegexPatternList.add(pattern);
+        }
+    }
+
+    protected boolean needToAdd(final Pattern pattern) {
+        boolean exist = false;
+        for (Pattern item : this.classExcludeRegexPatternList) {
+            if (item.pattern().equals(pattern.pattern())) {
+                exist = true;
+                break;
+            }
+        }
+        return !exist;
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -129,7 +129,7 @@ public abstract class MultiTenantCopier implements Ordered {
     }
 
     protected void persistCopyObjectTreeInternal(Object copy, Set<Integer> library, MultiTenantCopyContext context) {
-        // TODO: 1/19/2022 replace excludeFromCopyRegex with excludeFromCopyRegexPattern
+        // TODO: 1/19/2022 replace excludeFromCopyRegex() with excludeFromCopyRegexPattern() after remove property classExcludeRegexList
         if (library.contains(System.identityHashCode(copy)) || !(copy instanceof MultiTenantCloneable)
                 || excludeFromCopyRegex(copy)) {
             return;

--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -129,6 +129,7 @@ public abstract class MultiTenantCopier implements Ordered {
     }
 
     protected void persistCopyObjectTreeInternal(Object copy, Set<Integer> library, MultiTenantCopyContext context) {
+        // TODO: 1/19/2022 replace excludeFromCopyRegex with excludeFromCopyRegexPattern
         if (library.contains(System.identityHashCode(copy)) || !(copy instanceof MultiTenantCloneable)
                 || excludeFromCopyRegex(copy)) {
             return;


### PR DESCRIPTION
In MultiTenantCopier added functionality to prevent duplication of elements in classExcludeRegexPatternList

Link to QA issue
[QA-4616](https://github.com/BroadleafCommerce/QA/issues/4616)