### PR TITLE
another attempt to show placeholder instead of corrupted img

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/new-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/new-admin.js
@@ -50,6 +50,14 @@ $(document).ready(function(){
 
     $(window).on('load', function() {
         equalHeight('.equals .equal');
+        $('img').each(function() {
+            if ( !this.complete
+                ||   typeof this.naturalWidth == "undefined"
+                ||   this.naturalWidth == 0                  ) {
+                // image was broken, replace with your new image
+                this.src = 'https://via.placeholder.com/64x64';
+            }
+        });
     });
 
 


### PR DESCRIPTION
- another attempt to show placeholder instead of corrupted img
Fixes: BroadleafCommerce/QA#4584