### PR TITLE
Add section crumbs during filter so they are available in backend

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -654,7 +654,11 @@
             // Convert JSON to request params
             var filters = JSON.parse($('#' + hiddenId).val());
             var inputs = BLCAdmin.filterBuilders.getFiltersAsURLParams(hiddenId);
-
+            if($tbody){
+                if($tbody.closest('table').data('sectioncrumbs')){
+                    inputs.push({name:'sectionCrumbs', value:$tbody.closest('table').data('sectioncrumbs')});
+                }
+            }
             if (filters.data.length <= 0) {
                 var mainContent = $filterButton.closest('.main-content');
                 if (mainContent.length) {


### PR DESCRIPTION
- Add section crumbs during filter so they are available in backend, and in case of price list filtering no filter "by" type is applied


Fixes: BroadleafCommerce/QA#4629