### PR TITLE
Java calendar starts from 0 for the month so added 1 to make it natural count.

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/TimeDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/TimeDTO.java
@@ -100,7 +100,7 @@ public class TimeDTO {
      */
     public MonthType getMonth() {
         if (month == null) {
-            month = cal.get(Calendar.MONTH + 1);
+            month = cal.get(Calendar.MONTH) + 1;
         }
         return MonthType.getInstance(month.toString());
     }

--- a/common/src/main/java/org/broadleafcommerce/common/TimeDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/TimeDTO.java
@@ -100,7 +100,7 @@ public class TimeDTO {
      */
     public MonthType getMonth() {
         if (month == null) {
-            month = cal.get(Calendar.MONTH);
+            month = cal.get(Calendar.MONTH + 1);
         }
         return MonthType.getInstance(month.toString());
     }

--- a/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
@@ -34,18 +34,18 @@ public class MonthType implements Serializable, BroadleafEnumerationType {
 
     private static final Map<String, MonthType> TYPES = new LinkedHashMap<String, MonthType>();
 
-    public static final MonthType JANUARY  = new MonthType("1", "January");
-    public static final MonthType FEBRUARY  = new MonthType("2", "February");
-    public static final MonthType MARCH  = new MonthType("3", "March");
-    public static final MonthType APRIL  = new MonthType("4", "April");
-    public static final MonthType MAY  = new MonthType("5", "May");
-    public static final MonthType JUNE  = new MonthType("6", "June");
-    public static final MonthType JULY  = new MonthType("7", "July");
-    public static final MonthType AUGUST  = new MonthType("8", "August");
-    public static final MonthType SEPTEMBER  = new MonthType("9", "September");
-    public static final MonthType OCTOBER  = new MonthType("10", "October");
-    public static final MonthType NOVEMBER  = new MonthType("11", "November");
-    public static final MonthType DECEMBER  = new MonthType("12", "December");
+    public static final MonthType JANUARY  = new MonthType("0", "January");
+    public static final MonthType FEBRUARY  = new MonthType("1", "February");
+    public static final MonthType MARCH  = new MonthType("2", "March");
+    public static final MonthType APRIL  = new MonthType("3", "April");
+    public static final MonthType MAY  = new MonthType("4", "May");
+    public static final MonthType JUNE  = new MonthType("5", "June");
+    public static final MonthType JULY  = new MonthType("6", "July");
+    public static final MonthType AUGUST  = new MonthType("7", "August");
+    public static final MonthType SEPTEMBER  = new MonthType("8", "September");
+    public static final MonthType OCTOBER  = new MonthType("9", "October");
+    public static final MonthType NOVEMBER  = new MonthType("10", "November");
+    public static final MonthType DECEMBER  = new MonthType("11", "December");
 
     public static MonthType getInstance(final String type) {
         return TYPES.get(type);

--- a/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
@@ -47,7 +47,6 @@ public class MonthType implements Serializable, BroadleafEnumerationType {
     public static final MonthType NOVEMBER  = new MonthType("11", "November");
     public static final MonthType DECEMBER  = new MonthType("12", "December");
 
-
     public static MonthType getInstance(final String type) {
         return TYPES.get(type);
     }

--- a/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
+++ b/common/src/main/java/org/broadleafcommerce/common/time/MonthType.java
@@ -34,18 +34,19 @@ public class MonthType implements Serializable, BroadleafEnumerationType {
 
     private static final Map<String, MonthType> TYPES = new LinkedHashMap<String, MonthType>();
 
-    public static final MonthType JANUARY  = new MonthType("0", "January");
-    public static final MonthType FEBRUARY  = new MonthType("1", "February");
-    public static final MonthType MARCH  = new MonthType("2", "March");
-    public static final MonthType APRIL  = new MonthType("3", "April");
-    public static final MonthType MAY  = new MonthType("4", "May");
-    public static final MonthType JUNE  = new MonthType("5", "June");
-    public static final MonthType JULY  = new MonthType("6", "July");
-    public static final MonthType AUGUST  = new MonthType("7", "August");
-    public static final MonthType SEPTEMBER  = new MonthType("8", "September");
-    public static final MonthType OCTOBER  = new MonthType("9", "October");
-    public static final MonthType NOVEMBER  = new MonthType("10", "November");
-    public static final MonthType DECEMBER  = new MonthType("11", "December");
+    public static final MonthType JANUARY  = new MonthType("1", "January");
+    public static final MonthType FEBRUARY  = new MonthType("2", "February");
+    public static final MonthType MARCH  = new MonthType("3", "March");
+    public static final MonthType APRIL  = new MonthType("4", "April");
+    public static final MonthType MAY  = new MonthType("5", "May");
+    public static final MonthType JUNE  = new MonthType("6", "June");
+    public static final MonthType JULY  = new MonthType("7", "July");
+    public static final MonthType AUGUST  = new MonthType("8", "August");
+    public static final MonthType SEPTEMBER  = new MonthType("9", "September");
+    public static final MonthType OCTOBER  = new MonthType("10", "October");
+    public static final MonthType NOVEMBER  = new MonthType("11", "November");
+    public static final MonthType DECEMBER  = new MonthType("12", "December");
+
 
     public static MonthType getInstance(final String type) {
         return TYPES.get(type);


### PR DESCRIPTION
BroadleafCommerce/QA#4657

I have changed a core MonthType class, so months starts from 0 to 11, this solution helps to avoid issues in future


- Fixes the issue where timed offer code wasn't available because months in Java Calendar is starting from 0





