### PR TITLE
Change the condition to evaluate if classExcludeRegexList is used

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -202,10 +202,8 @@ public abstract class MultiTenantCopier implements Ordered {
     @Deprecated
     protected Boolean excludeFromCopyRegex(final Object copy) {
         boolean match = false;
-        if (this.classExcludeRegexPatternList.isEmpty()) {
-            if(LOG.isDebugEnabled()) {
-                LOG.warn("classExcludeRegexPatternList is empty, deprecated classExcludeRegexList is used");
-            }
+        if (this.classExcludeRegexPatternList.isEmpty() && this.classExcludeRegexList!=null && !this.classExcludeRegexList.isEmpty()) {
+            LOG.warn("classExcludeRegexList is deprecated, please use excludeFromCopyRegexPattern");
             for (Matcher regex : this.classExcludeRegexList) {
                 if (regex.reset(copy.getClass().toString()).matches()) {
                     match = true;

--- a/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
+++ b/common/src/main/java/org/broadleafcommerce/common/copy/MultiTenantCopier.java
@@ -203,7 +203,9 @@ public abstract class MultiTenantCopier implements Ordered {
     protected Boolean excludeFromCopyRegex(final Object copy) {
         boolean match = false;
         if (this.classExcludeRegexPatternList.isEmpty()) {
-            LOG.warn("classExcludeRegexPatternList is empty, deprecated classExcludeRegexList is used");
+            if(LOG.isDebugEnabled()) {
+                LOG.warn("classExcludeRegexPatternList is empty, deprecated classExcludeRegexList is used");
+            }
             for (Matcher regex : this.classExcludeRegexList) {
                 if (regex.reset(copy.getClass().toString()).matches()) {
                     match = true;


### PR DESCRIPTION
**A Brief Overview**
classExcludeRegexList is not thread safe so changes were made which was causing unnecessary noisy logging. So changed the condition to evaluate if old list was used.

For https://github.com/BroadleafCommerce/QA/issues/4681