### PR TITLE
Fix to validate required properties first and not allow rules persistent providers to save entity without required fields

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -345,7 +345,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 ) {
                     //because RuleFieldPersistenceProvider can attempt to persist instance of entity we can face situation
                     //when instance will have empty required fields and so will result null constraint violation DB error
-                    if (entity.getPropertyValidationErrors() != null && !entity.getPropertyValidationErrors().isEmpty()) {
+                    if (entity.isValidationFailure()) {
                         break;
                     }
                 }
@@ -432,7 +432,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 }
             }
             // Only check validation if not the initial add
-            if (!entity.isPreAdd() && entity.getPropertyValidationErrors() != null && entity.getPropertyValidationErrors().isEmpty()) {
+            if (!entity.isPreAdd() && entity.isValidationFailure()) {
                 validate(entity, instance, mergedProperties, validateUnsubmittedProperties);
             }
             //if validation failed, refresh the current instance so that none of the changes will be persisted

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -432,7 +432,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 }
             }
             // Only check validation if not the initial add
-            if (!entity.isPreAdd() && entity.isValidationFailure()) {
+            if (!entity.isPreAdd() && !entity.isValidationFailure()) {
                 validate(entity, instance, mergedProperties, validateUnsubmittedProperties);
             }
             //if validation failed, refresh the current instance so that none of the changes will be persisted


### PR DESCRIPTION
- Fix to validate required properties first and not allow rules persistent providers to save entity without required fields

Fixes: BroadleafCommerce/QA#4688