### PR TITLE
Upgraded Spring Framework to 5.2.22 for 6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.0.20.RELEASE</spring.version>
+        <spring.version>5.2.22.RELEASE</spring.version>
         <spring.security.version>5.0.19.RELEASE</spring.security.version>
         <spring.boot.version>2.0.9.RELEASE</spring.boot.version>
         <spring.mobile.version>2.0.0.M3</spring.mobile.version>


### PR DESCRIPTION
upgraded Spring Framework to version 5.2.22

https://github.com/BroadleafCommerce/QA/issues/4695