### PR TITLE
Remove unnecessary xalan dependency from the framework.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -306,11 +306,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-        <!--update xalan dependency for esapi for a xalan security vulnerability-->
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1311,10 +1311,6 @@
                         <artifactId>commons-fileupload</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>xalan</groupId>
-                        <artifactId>xalan</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.owasp.antisamy</groupId>
                         <artifactId>antisamy</artifactId>
                     </exclusion>
@@ -1328,18 +1324,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.5.13</version>
-            </dependency>
-            <!--update xalan dependency for esapi for a xalan security vulnerability-->
-            <dependency>
-                <groupId>xalan</groupId>
-                <artifactId>xalan</artifactId>
-                <version>2.7.2</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>


### PR DESCRIPTION
**A Brief Overview**
Xalan is a transitive dependency that was added for security vulnerability. ESAPI no longer uses it so its no longer required in the framework.

**Link to QA**
https://github.com/BroadleafCommerce/QA/issues/4713