### PR TITLE
Fixed an issue where BOGO offers can be created without specifying a qualifier

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * BroadleafCommerce Admin Module
+ * %%
+ * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.admin.persistence.validation;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
+import org.broadleafcommerce.openadmin.dto.Entity;
+import org.broadleafcommerce.openadmin.dto.FieldMetadata;
+import org.broadleafcommerce.openadmin.dto.Property;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.RuleFieldExtractionUtility;
+import org.broadleafcommerce.openadmin.server.service.persistence.validation.PropertyValidationResult;
+import org.broadleafcommerce.openadmin.server.service.persistence.validation.ValidationConfigurationBasedPropertyValidator;
+import org.broadleafcommerce.openadmin.web.rulebuilder.dto.DataWrapper;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+import java.io.Serializable;
+import java.util.Map;
+
+@Component("blOfferQualifyingCriteriaValidator")
+public class OfferQualifyingCriteriaValidator extends ValidationConfigurationBasedPropertyValidator {
+
+    public static final String BOGO_TEMPLATE = "-14105";
+    @Resource(name = "blRuleFieldExtractionUtility")
+    protected RuleFieldExtractionUtility ruleFieldExtractionUtility;
+
+
+    @Override
+    public PropertyValidationResult validate(Entity entity,
+            Serializable instance,
+            Map<String, FieldMetadata> entityFieldMetadata,
+            Map<String, String> validationConfiguration,
+            BasicFieldMetadata propertyMetadata,
+            String propertyName,
+            String value) {
+
+        Property offerTemplateProperty = entity.findProperty("embeddableAdvancedOffer.offerTemplate");
+        if (offerTemplateProperty != null &&
+                offerTemplateProperty.getValue().equals(BOGO_TEMPLATE)) {
+            String qualifyingItemCriteriaJson = entity.findProperty("qualifyingItemCriteria").getUnHtmlEncodedValue();
+            if (qualifyingItemCriteriaJson == null) {
+                qualifyingItemCriteriaJson = entity.findProperty("qualifyingItemCriteriaJson").getUnHtmlEncodedValue();
+            }
+            DataWrapper dw = ruleFieldExtractionUtility.convertJsonToDataWrapper(qualifyingItemCriteriaJson);
+
+            if (CollectionUtils.isEmpty(dw.getData()) && dw.getRawMvel() == null) {
+                return new PropertyValidationResult(false, "requiredValidationFailure");
+            }
+        }
+
+        return new PropertyValidationResult(true);
+    }
+}

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
@@ -2,7 +2,7 @@
  * #%L
  * BroadleafCommerce Admin Module
  * %%
- * Copyright (C) 2009 - 2016 Broadleaf Commerce
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
  * %%
  * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
  * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
@@ -58,7 +58,7 @@ public class OfferQualifyingCriteriaValidator extends ValidationConfigurationBas
             }
             DataWrapper dw = ruleFieldExtractionUtility.convertJsonToDataWrapper(qualifyingItemCriteriaJson);
 
-            if (CollectionUtils.isEmpty(dw.getData()) && dw.getRawMvel() == null) {
+            if (dw == null || (CollectionUtils.isEmpty(dw.getData()) && dw.getRawMvel() == null)) {
                 return new PropertyValidationResult(false, "requiredValidationFailure");
             }
         }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -295,7 +295,9 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     @AdminPresentation(friendlyName = "OfferImpl_Qualifying_Item_Rule",
         tab = TabName.Qualifiers,
         fieldType = SupportedFieldType.RULE_WITH_QUANTITY,
-        ruleIdentifier = RuleIdentifier.ORDERITEM)
+        ruleIdentifier = RuleIdentifier.ORDERITEM,
+        validationConfigurations =
+            @ValidationConfiguration(validationImplementation = "blOfferQualifyingCriteriaValidator"))
     protected Set<OfferQualifyingCriteriaXref> qualifyingItemCriteria = new HashSet<OfferQualifyingCriteriaXref>();
 
     @Transient


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4710

**A Brief Overview**
There is not any sense in defining a BOGO without a qualifier.
The purpose of this type of offer is to give a bonus to a customer that is purchasing some items.
So the qualifiers should be required for BOGO offers.
