### PR TITLE
Fixed an issue where filtering by name is not working for products with ampersand

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
+import org.broadleafcommerce.common.security.service.ExploitProtectionService;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.JsonResponse;
 import org.broadleafcommerce.common.web.controller.BroadleafAbstractController;
@@ -124,6 +125,9 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
 
     @Resource(name = "blFilterProductTypePersistenceHandlerExtensionManager")
     protected FilterProductTypePersistenceHandlerExtensionManager filterProductTypeExtensionManager;
+
+    @Resource(name = "blExploitProtectionService")
+    protected ExploitProtectionService eps;
 
     // *********************************************************
     // UNBOUND CONTROLLER METHODS (USED BY DIFFERENT SECTIONS) *
@@ -462,8 +466,8 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
                     for (String value : values) {
                         String decoded = null;
                         try {
-                            decoded = URLDecoder.decode(value, "UTF-8");
-                        } catch (UnsupportedEncodingException e) {
+                            decoded = eps.cleanString(URLDecoder.decode(value, "UTF-8"));
+                        } catch (UnsupportedEncodingException | ServiceException e) {
                             LOG.info("Could not decode value", e);
                         }
                         if (decoded.contains(FILTER_VALUE_SEPARATOR)) {

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -659,6 +659,12 @@
             // Convert JSON to request params
             var filters = JSON.parse($('#' + hiddenId).val());
             var inputs = BLCAdmin.filterBuilders.getFiltersAsURLParams(hiddenId);
+            if (inputs.length) {
+                for (var i in inputs) {
+                    var input = inputs[i];
+                    input.value = encodeURIComponent(input.value);
+                }
+            }
             if($tbody){
                 if($tbody.closest('table').data('sectioncrumbs')){
                     inputs.push({name:'sectionCrumbs', value:$tbody.closest('table').data('sectioncrumbs')});

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-filter.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid-filter.js
@@ -372,7 +372,7 @@ $(document).ready(function() {
         $this.removeClass('search-button').addClass('disabled');
 
         //this takes place on the main list grid screen so there should be a single list grid
-        var search = $this.closest('form').find('input').val();
+        var search = encodeURIComponent($this.closest('form').find('input').val());
         var $container = $this.closest('.listgrid-container');
         var tableId = $container.find('table').last().attr('id');
         var $firstInput = $($container.find('#listGrid-main-header th .listgrid-criteria-input')[0]);


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4718

**A Brief Overview**
The solution is to escape special characters in request parameters by encodeURIComponent
The second part of the solution:
In the case of using `exploitProtection.xssEnabled=true` we need to encode incoming request parameters before the DB search 

**Steps to reproduce:**

Use case 1: Search by name

Create product with '&' in name
Navigate to the products list and search by the product name
See that the search looks like stuck and no result are returned
Open JS console and see an error is logged

Use case 2: Filter by name

Create product  with '&' in name
Navigate to the products list and press the filter button
Create a filter by name and set the value to a product name containing '&'
Press the apply button to apply the rule
See that nothing changes
Open JS console and see an error is logged

Do the same steps for `exploitProtection.xssEnabled=true` 