### PR TITLE
Renamed property to differentiate by groupId and updated dependencies from sun.xml which now resolves txw2 properly to 2.3.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
         <closure.compiler.version>v20180506</closure.compiler.version>
         <hibernate.version>5.4.33.Final</hibernate.version>
         <hibernate-validator.version>6.1.7.Final</hibernate-validator.version>
-        <jaxb.version>2.3.1</jaxb.version>
-        <jaxws.version>2.3.1</jaxws.version>
+        <javax.version>2.3.1</javax.version>
+        <sunxml.version>3.0.2</sunxml.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
     </properties>
     <scm>
@@ -764,22 +764,22 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
+                <version>${javax.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml.ws</groupId>
                 <artifactId>jaxws-api</artifactId>
-                <version>${jaxws.version}</version>
+                <version>${javax.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${sunxml.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-rt</artifactId>
-                <version>${jaxws.version}</version>
+                <version>${sunxml.version}</version>
             </dependency>
 
             <!-- XML Libraries -->


### PR DESCRIPTION
**A Brief Overview**
Renamed property to differentiate by groupId. There are no new versions from javax after 2.3.1. So changed one of the version name to `javax` and set it to 2.3.1. Similarly changed another version name to `sunxml` and set to 3.0.2 which was released in Aug 2021. There are newer [milestones](https://mvnrepository.com/artifact/com.sun.xml.ws/jaxws-rt) but decided to use release. 

This resolves txw2 properly to 2.3.1.

**Link to QA**
https://github.com/BroadleafCommerce/QA/issues/4726
