### PR TITLE
QA-4728-read-customer-by-email-case-insensitive - modify read customer by email query to be case insensitive

### DIFF
--- a/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/Customer.orm.xml
+++ b/core/broadleaf-profile/src/main/resources/config/bc/jpa/domain/Customer.orm.xml
@@ -28,6 +28,6 @@
 
     <named-query name="BC_READ_CUSTOMER_BY_EMAIL" >
         <query>SELECT customer FROM org.broadleafcommerce.profile.core.domain.Customer customer
-        WHERE customer.emailAddress = :email</query>
+        WHERE UPPER(customer.emailAddress) = UPPER(:email)</query>
     </named-query>
 </entity-mappings>


### PR DESCRIPTION
Modify read customer by email query to be case insensitive

[issue 4728 ](https://github.com/BroadleafCommerce/QA/issues/4728)
