### PR TITLE
Fixed an issue where a product with add-ons cannot be added to the cart when their SKU is out of stock

### DIFF
--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
@@ -166,24 +166,26 @@ public class UncacheableDataProcessor extends AbstractBroadleafTagReplacementPro
 
     protected void defineOutOfStockProducts(BroadleafTemplateContext context, Set<Product> allProducts, Set<Long> outOfStockProducts) {
         Product baseProduct = (Product) context.getVariable("product");
-        boolean isBundle = this.isBundle(baseProduct);
-        for (Product product : allProducts) {
-            if (product.getDefaultSku() != null) {
-                boolean qtyAvailable = inventoryService.isAvailable(product.getDefaultSku(), 1);
-                if (!qtyAvailable) {
-                    outOfStockProducts.add(product.getId());
-                    if (!baseProduct.getId().equals(product.getId()) && this.isBlockingAvailabilityOfProduct(baseProduct, product)) {
-                        outOfStockProducts.add(baseProduct.getId());
-                    }
-                } else {
-                    if (isBundle) {
-                        InventoryServiceExtensionHandler handler = inventoryServiceExtensionManager.getProxy();
-                        ExtensionResultHolder<Boolean> holder = new ExtensionResultHolder<>();
-                        ExtensionResultStatusType result = handler.isProductBundleAvailable(product, 1, holder);
-                        if (!ExtensionResultStatusType.NOT_HANDLED.equals(result)) {
-                            Boolean available = holder.getResult();
-                            if (available != null && !available) {
-                                outOfStockProducts.add(product.getId());
+        if (baseProduct != null) {
+            boolean isBundle = this.isBundle(baseProduct);
+            for (Product product : allProducts) {
+                if (product.getDefaultSku() != null) {
+                    boolean qtyAvailable = inventoryService.isAvailable(product.getDefaultSku(), 1);
+                    if (!qtyAvailable) {
+                        outOfStockProducts.add(product.getId());
+                        if (!baseProduct.getId().equals(product.getId()) && this.isBlockingAvailabilityOfProduct(baseProduct, product)) {
+                            outOfStockProducts.add(baseProduct.getId());
+                        }
+                    } else {
+                        if (isBundle) {
+                            InventoryServiceExtensionHandler handler = inventoryServiceExtensionManager.getProxy();
+                            ExtensionResultHolder<Boolean> holder = new ExtensionResultHolder<>();
+                            ExtensionResultStatusType result = handler.isProductBundleAvailable(product, 1, holder);
+                            if (!ExtensionResultStatusType.NOT_HANDLED.equals(result)) {
+                                Boolean available = holder.getResult();
+                                if (available != null && !available) {
+                                    outOfStockProducts.add(product.getId());
+                                }
                             }
                         }
                     }

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
@@ -192,7 +192,7 @@ public class UncacheableDataProcessor extends AbstractBroadleafTagReplacementPro
         }
     }
 
-    private boolean isBlockingAvailabilityOfProduct(Product baseProduct, Product product) {
+    protected boolean isBlockingAvailabilityOfProduct(Product baseProduct, Product product) {
         boolean isBlockingAvailabilityOfProduct = false;
         InventoryServiceExtensionHandler handler = inventoryServiceExtensionManager.getProxy();
         ExtensionResultHolder<Boolean> holder = new ExtensionResultHolder<>();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/AbstractInventoryServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/AbstractInventoryServiceExtensionHandler.java
@@ -53,4 +53,9 @@ public abstract class AbstractInventoryServiceExtensionHandler extends AbstractE
     public ExtensionResultStatusType isProductBundleAvailable(Product product, int quantity, ExtensionResultHolder<Boolean> holder) {
         return ExtensionResultStatusType.NOT_HANDLED;
     }
+
+    @Override
+    public ExtensionResultStatusType isBlockingAvailabilityOfProduct(Product baseProduct,Product product, ExtensionResultHolder<Boolean> holder) {
+        return ExtensionResultStatusType.NOT_HANDLED;
+    }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceExtensionHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceExtensionHandler.java
@@ -84,4 +84,15 @@ public interface InventoryServiceExtensionHandler extends ExtensionHandler {
      * @param holder
      */
     ExtensionResultStatusType isProductBundleAvailable(Product product, int quantity, ExtensionResultHolder<Boolean> holder);
+
+    /**
+     * This determines if the missing quantity is critical (blocking) to be added to the cart
+     * Usually invoked via the UncacheableDataProcessor to determine the availability of product.
+     *
+     * @param baseProduct base product with add-ons
+     * @param product     one of the add-on products of the base product
+     * @param holder      holder for result
+     * @return ExtensionResultStatusType status after operation
+     */
+    ExtensionResultStatusType isBlockingAvailabilityOfProduct(Product baseProduct, Product product, ExtensionResultHolder<Boolean> holder);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/service/InventoryServiceImpl.java
@@ -69,8 +69,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
     protected ApplicationContext applicationContext;
 
     @Value("${enable.weave.use.default.sku.inventory:false}")
-    protected boolean enableUseDegaultSkuInventory = false;
-
+    protected boolean enableUseDefaultSkuInventory = false;
 
     @Override
     public boolean checkBasicAvailablility(Sku sku) {
@@ -144,7 +143,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
 
             for (Sku sku : skus) {
                 Sku skuForInventory = sku;
-                if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+                if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
                     skuForInventory = sku.getProduct().getDefaultSku();
                 }
                 Integer quantityAvailable = 0;
@@ -170,12 +169,12 @@ public class InventoryServiceImpl implements ContextualInventoryService {
     //here
     @Override
     public boolean isAvailable(Sku sku, int quantity, Map<String, Object> context) {
-        Sku skuForInventory = sku;
-        if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
-            skuForInventory = sku.getProduct().getDefaultSku();
-        }
         if (quantity < 1) {
             throw new IllegalArgumentException("Quantity " + quantity + " is not valid. Must be greater than zero.");
+        }
+        Sku skuForInventory = sku;
+        if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()) {
+            skuForInventory = sku.getProduct().getDefaultSku();
         }
         if (checkBasicAvailablility(skuForInventory)) {
             if (InventoryType.CHECK_QUANTITY.equals(skuForInventory.getInventoryType())) {
@@ -211,7 +210,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
         for (Entry<Sku, Integer> entry : skuQuantities.entrySet()) {
             Sku sku = entry.getKey();
             Sku skuForInventory = sku;
-            if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+            if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
                 skuForInventory = sku.getProduct().getDefaultSku();
             }
             Integer quantity = entry.getValue();
@@ -264,7 +263,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
             Sku sku = entry.getKey();
 
             Sku skuForInventory = sku;
-            if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+            if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
                 skuForInventory = sku.getProduct().getDefaultSku();
             }
             Integer quantity = entry.getValue();
@@ -309,7 +308,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
             if (orderItem instanceof DiscreteOrderItem) {
                 Sku sku = ((DiscreteOrderItem) orderItem).getSku();
                 Sku skuForInventory = sku;
-                if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+                if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
                     skuForInventory = sku.getProduct().getDefaultSku();
                 }
                 Integer quantity = skuInventoryMap.get(skuForInventory);
@@ -324,7 +323,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
             } else if (orderItem instanceof BundleOrderItem) {
                 BundleOrderItem bundleItem = (BundleOrderItem) orderItem;
                 Sku bundleSku = bundleItem.getSku();
-                if (enableUseDegaultSkuInventory && ((ProductSkuUsage) bundleSku.getProduct()).getUseDefaultSkuInInventory()){
+                if (enableUseDefaultSkuInventory && ((ProductSkuUsage) bundleSku.getProduct()).getUseDefaultSkuInInventory()){
                     bundleSku = bundleSku.getProduct().getDefaultSku();
                 }
                 if (InventoryType.CHECK_QUANTITY.equals(bundleSku.getInventoryType())) {
@@ -336,7 +335,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
                 List<DiscreteOrderItem> discreteItems = bundleItem.getDiscreteOrderItems();
                 for (DiscreteOrderItem discreteItem : discreteItems) {
                     Sku sku = discreteItem.getSku();
-                    if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+                    if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
                         sku = sku.getProduct().getDefaultSku();
                     }
                     if (InventoryType.CHECK_QUANTITY.equals(sku.getInventoryType())) {
@@ -415,7 +414,7 @@ public class InventoryServiceImpl implements ContextualInventoryService {
     @Override
     public void checkSkuAvailability(Order order, Sku sku, Integer requestedQuantity) throws InventoryUnavailableException {
         Sku skuForInventory = sku;
-        if (enableUseDegaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
+        if (enableUseDefaultSkuInventory && ((ProductSkuUsage) sku.getProduct()).getUseDefaultSkuInInventory()){
             skuForInventory = sku.getProduct().getDefaultSku();
         }
         // First check if this Sku is available

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -1158,10 +1158,12 @@ public class OrderServiceImpl implements OrderService {
     public void preValidateCartOperation(Order cart) {
         ExtensionResultHolder erh = new ExtensionResultHolder();
         extensionManager.getProxy().preValidateCartOperation(cart, erh);
-        if (erh.getThrowable() instanceof IllegalCartOperationException) {
-            throw ((IllegalCartOperationException) erh.getThrowable());
-        } else if (erh.getThrowable() != null) {
-            throw new RuntimeException(erh.getThrowable());
+        if (erh.getThrowable() != null) {
+            if (erh.getThrowable() instanceof IllegalCartOperationException) {
+                throw ((IllegalCartOperationException) erh.getThrowable());
+            } else {
+                throw new RuntimeException(erh.getThrowable());
+            }
         }
     }
 


### PR DESCRIPTION
**A Brief Overview**
- fixed logic for not bundle products; 
- extracted logic of defineOutOfStockProducts in separate method;
- renamed enableUseDefaultSkuInventory.

**Link to QA issue**
[QA-4740](https://github.com/BroadleafCommerce/QA/issues/4740)