### PR TITLE
QA-4761 - fix dependency vulnerability in broadleaf-open-admin-platform

### DIFF
--- a/admin/broadleaf-open-admin-platform/pom.xml
+++ b/admin/broadleaf-open-admin-platform/pom.xml
@@ -211,5 +211,10 @@
             <artifactId>spock-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-metadata</artifactId>
+            <version>3.7.1</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fix dependency com.twelvemonkeys.imageio:imageio-metadata:from 3.6 to 3.7.1

https://github.com/BroadleafCommerce/QA/issues/4761