### PR TITLE
QA4762 - Fix dependency vulnerabilities

### DIFF
--- a/admin/broadleaf-open-admin-platform/pom.xml
+++ b/admin/broadleaf-open-admin-platform/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-metadata</artifactId>
-            <version>3.7.1</version>
+            <version>${imageio-metadata.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/core/broadleaf-framework/pom.xml
+++ b/core/broadleaf-framework/pom.xml
@@ -157,5 +157,15 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${eclipse.jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${eclipse.jetty.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,8 @@
         <javax.version>2.3.1</javax.version>
         <sunxml.version>3.0.2</sunxml.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
+        <eclipse.jetty.version>9.4.47.v20220610</eclipse.jetty.version>
+        <imageio-metadata.version>3.7.1</imageio-metadata.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:BroadleafCommerce/BroadleafCommerce.git</connection>


### PR DESCRIPTION
Fix dependency vulnerabilities
Change org.eclipse.**jetty:jetty-client** and  **org.eclipse.jetty:jetty-http** from **9.4.46.v20220331** to **9.4.47.v20220610**

https://github.com/BroadleafCommerce/QA/issues/4762
