### PR TITLE
Impoved logging for SiteMap generation when timeout

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/sitemap/service/SiteMapServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sitemap/service/SiteMapServiceImpl.java
@@ -148,6 +148,9 @@ public class SiteMapServiceImpl implements SiteMapService {
                 if ((now - lastModified) > getSiteMapTimeoutInMillis().longValue()) {
                     generateSiteMap();
                     siteMapFile = broadleafFileService.getResource(fileName, getSiteMapTimeoutInMillis());
+                    if (LOG.isTraceEnabled()){
+                        LOG.trace("Generating new SiteMap after timeout");
+                    }
                 }
             }
             if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4767

Added some logs when SiteMap generates after timeout

