### PR TITLE
Changed countOfferCodeUses to not use cross join

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferAuditDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/dao/OfferAuditDaoImpl.java
@@ -126,7 +126,7 @@ public class OfferAuditDaoImpl implements OfferAuditDao {
         CriteriaQuery<Long> criteria = builder.createQuery(Long.class);
         Root<OfferAuditImpl> root = criteria.from(OfferAuditImpl.class);
         Root<OrderImpl> orderRoot = criteria.from(OrderImpl.class);
-        Join<Object, Object> parentOrder= null;
+        Join<Object, Object> parentOrder = null;
         if (ModulePresentUtil.isPresent(BroadleafModuleRegistration.BroadleafModuleEnum.OMS)) {
             parentOrder = orderRoot.join("embeddedOmsOrder", JoinType.LEFT).join("parentOrder", JoinType.LEFT);
         }
@@ -209,39 +209,25 @@ public class OfferAuditDaoImpl implements OfferAuditDao {
 
     @Override
     public Long countOfferCodeUses(Order order, Long offerCodeId) {
-        CriteriaBuilder builder = em.getCriteriaBuilder();
-        CriteriaQuery<Long> criteria = builder.createQuery(Long.class);
-        Root<OfferAuditImpl> root = criteria.from(OfferAuditImpl.class);
-        Root<OrderImpl> orderRoot = criteria.from(OrderImpl.class);
-        Join<Object, Object> parentOrder = null;
+        StringBuilder sqlBuilder = new StringBuilder();
+        sqlBuilder.append("SELECT count(oa.id) AS countOfferCodeUses ")
+                .append("FROM OrderImpl o ");
         if (ModulePresentUtil.isPresent(BroadleafModuleRegistration.BroadleafModuleEnum.OMS)) {
-            parentOrder = orderRoot.join("embeddedOmsOrder", JoinType.LEFT).join("parentOrder", JoinType.LEFT);
+            sqlBuilder.append("LEFT JOIN OrderImpl o2 ON o.embeddedOmsOrder.parentOrder.id = o2.id ");
         }
-        criteria.select(builder.count(root));
-
-        List<Predicate> restrictions = new ArrayList<>();
-        restrictions.add(
-            builder.and(
-                builder.or(
-                    builder.notEqual(root.get("orderId"),  getOrderId(order)),
-                    builder.isNull(root.get("orderId"))
-                ),
-                builder.equal(root.get("offerCodeId"), offerCodeId),
-                builder.or(
-                        builder.isNull(root.get("orderId")),
-                        builder.and(
-                                builder.notEqual(orderRoot.get("status"),OrderStatus.CANCELLED.getType()),
-                                builder.equal(orderRoot.get("id"),root.get("orderId"))
-                        )
-                ),
-                getOmsOrderPredicate(builder, orderRoot, parentOrder)
-            )
-        );
-
-        criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
-        
+        sqlBuilder.append("LEFT JOIN OfferAuditImpl oa ON oa.orderId = o.id ")
+                .append("WHERE (oa.orderId IS NULL OR oa.orderId <> :orderId ) ")
+                .append("AND oa.offerCodeId = :offerCodeId ")
+                .append("AND (oa.orderId IS NULL OR o.status <> :orderStatus) ");
+        if (ModulePresentUtil.isPresent(BroadleafModuleRegistration.BroadleafModuleEnum.OMS)) {
+            sqlBuilder.append("AND (o.embeddedOmsOrder.parentOrder.id IS NULL OR o2.status <> :orderStatus) ");
+        }
         try {
-            return em.createQuery(criteria).getSingleResult();
+            return (Long) em.createQuery(sqlBuilder.toString())
+                    .setParameter("orderId", order.getId())
+                    .setParameter("offerCodeId", offerCodeId)
+                    .setParameter("orderStatus", OrderStatus.CANCELLED.getType())
+                    .getSingleResult();
         } catch (Exception e) {
             LOG.error("Error counting offer code uses.", e);
             return null;
@@ -266,7 +252,6 @@ public class OfferAuditDaoImpl implements OfferAuditDao {
         
         return query.getResultList();
     }
-
 
     @Override
     public Long getCurrentDateResolution() {


### PR DESCRIPTION
**A Brief Overview**
In OfferAuditDaoImpl#countOfferCodeUses() used the Criteria API and Hibernate converted the query to sql-query with "cross join". Changed the way the query is prepared for execution from the Criteria API to JPQL, and now it does not use a cross join.

Link to QA [4775 ](https://github.com/BroadleafCommerce/QA/issues/4775)
Blocked by #2722 

**Additional context**
Alternatively, we can use this query or rewrite it with DetachedCriteria or Subquery.

SELECT 
    COUNT(oa.ORDER_ID) AS countOfferCodeUses
FROM
    broadleaf.BLC_OFFER_AUDIT oa
WHERE  (oa.ORDER_ID IS NULL OR oa.ORDER_ID <> 402)
        AND oa.OFFER_CODE_ID = 1
        AND oa.ORDER_ID IN (
					SELECT  oa.ORDER_ID 
					FROM broadleaf.BLC_ORDER o
					LEFT JOIN broadleaf.BLC_ORDER o2 ON o.PARENT_ORDER_ID = o2.ORDER_ID
					WHERE
					(o.SITE_DISC IS NULL
						OR o.SITE_DISC IN (- 3))
						AND (o.SNDBX_ID IS NULL)
						AND (o.PARENT_ORDER_ID IS NULL
						OR o2.ORDER_STATUS <> 'CANCELLED')
                );

