### PR TITLE
Fixed readOrderById when it couldn't find the order

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -90,9 +90,7 @@ public class OrderDaoImpl implements OrderDao {
         try {
             order = query.getSingleResult();
         } catch (NoResultException e) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn(String.format("Could not find order by ID %s", orderId));
-            }
+            LOG.warn(String.format("Could not find order by ID %s", orderId));
         }
         return order;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -74,7 +74,13 @@ public class OrderDaoImpl implements OrderDao {
     public Order readOrderById(final Long orderId) {
         TypedQuery<Order> query = em.createQuery("SELECT o FROM OrderImpl o WHERE o.id= :orderId", Order.class);
         query.setParameter("orderId", orderId);
-        return query.getSingleResult();
+        Order order = null;
+        try {
+            order = query.getSingleResult();
+        } catch (NoResultException e) {
+            LOG.warn(String.format("Could not find order by ID %s", orderId));
+        }
+        return order;
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -43,10 +43,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import javax.annotation.Resource;
-import javax.persistence.*;
+import javax.persistence.CacheRetrieveMode;
+import javax.persistence.EntityExistsException;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
@@ -78,7 +90,9 @@ public class OrderDaoImpl implements OrderDao {
         try {
             order = query.getSingleResult();
         } catch (NoResultException e) {
-            LOG.warn(String.format("Could not find order by ID %s", orderId));
+            if (LOG.isWarnEnabled()) {
+                LOG.warn(String.format("Could not find order by ID %s", orderId));
+            }
         }
         return order;
     }


### PR DESCRIPTION
**A Brief Overview**
In OrderDaoImpl#readOrderById, if we can't find an order by Id and get NoResultException, we return null;
This allows integration tests to pass as they wait for null when there is no order in the database.

Link to QA [4754](https://github.com/BroadleafCommerce/QA/issues/4754)
