### PR TITLE
Added restriction for archived sku

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductOptionDaoImpl.java
@@ -97,7 +97,10 @@ public class ProductOptionDaoImpl implements ProductOptionDao {
                     root.get("productOptionValue").get("productOption").get("attributeName"),
                     root.get("productOptionValue"),
                     root.get("sku")));
-        criteria.where(builder.equal(root.get("sku").get("product").get("id"), productId));
+        List<Predicate> restrictions = new ArrayList<Predicate>();
+        restrictions.add(builder.and(builder.or(builder.equal(root.get("sku").get("archiveStatus").get("archived"), 'N'),
+                builder.isNull(root.get("sku").get("archiveStatus").get("archived"))), builder.equal(root.get("sku").get("product").get("id"), productId)));
+        criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
         criteria.orderBy(builder.asc(root.get("productOptionValue").get("productOption").get("attributeName")));
 
         TypedQuery<AssignedProductOptionDTO> query = em.createQuery(criteria);


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4802

Added client's fix into framework codebase, so the findAssignedProductOptionsByProductId method is returning archived rows

