### PR TITLE
fix(sec): upgrade org.apache.commons:commons-dbcp2 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -203,7 +203,7 @@
                                 		</goals>
                                 	</pluginExecutionFilter>
                                 	<action>
-                                		<ignore />
+                                		<ignore/>
                                 	</action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -224,7 +224,7 @@
                                 		</goals>
                                 	</pluginExecutionFilter>
                                 	<action>
-                                		<ignore />
+                                		<ignore/>
                                 	</action>
                                 </pluginExecution>
                             </pluginExecutions>
@@ -367,7 +367,7 @@
                         <id>default-cli</id>
                         <configuration>
                             <rules>
-                                <banDuplicatePomDependencyVersions />
+                                <banDuplicatePomDependencyVersions/>
                             </rules>
                         </configuration>
                         <goals>
@@ -722,7 +722,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
-                <version>2.8.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-dbcp2 2.8.0
- [MPS-2022-12024](https://www.oscs1024.com/hd/MPS-2022-12024)


### What did I do？
Upgrade org.apache.commons:commons-dbcp2 from 2.8.0 to 2.9.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS