### PR TITLE
Added new exclusions for the SandBoxClassTransformer from the new Java versions

### DIFF
--- a/common/src/main/resources/bl-common-applicationContext.xml
+++ b/common/src/main/resources/bl-common-applicationContext.xml
@@ -61,6 +61,8 @@
                             <value>org.broadleafcommerce.openadmin.web.compatibility.JSCompatibilityRequestWrapper</value>
                             <value>org\.hibernate.*</value>
                             <value>org\.quartz.*</value>
+                            <value>org\.terracotta.*</value>
+                            <value>java.*</value>
                         </array>
                     </property>
                 </bean>


### PR DESCRIPTION
Added new exclusions for the SandBoxClassTransformer from the new Java versions

Fixes: BroadleafCommerce/QA#4818
