### PR TITLE
make sure that if value is string but metadata is broadleaf enumeration final value will be a friendly type of broadleaf enumeration

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.BroadleafEnumerationType;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.exception.SecurityServiceException;
@@ -132,6 +133,8 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
+
+import static org.broadleafcommerce.common.presentation.client.SupportedFieldType.BROADLEAF_ENUMERATION;
 
 /**
  * @author jfischer
@@ -678,6 +681,14 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                     Object value = null;
                     try {
                         value = fieldManager.getFieldValue(entity, property);
+                        if(value != null && BROADLEAF_ENUMERATION == metadata.getFieldType()){
+                            try {
+                                Class<?> aClass = Class.forName(metadata.getEnumerationClass());
+                                Method method = aClass.getMethod("getInstance", String.class);
+                                value = method.invoke(null,value);
+                            } catch (NoSuchMethodException e) {
+                            }
+                        }
                     } catch (FieldNotAvailableException e) {
                         isFieldAccessible = false;
                     }
@@ -785,6 +796,8 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                 strVal = getDecimalFormatter().format(value);
             } else if (BigDecimal.class.isAssignableFrom(value.getClass())) {
                 strVal = getDecimalFormatter().format(value);
+            } else if (BroadleafEnumerationType.class.isAssignableFrom(value.getClass())){
+                strVal = ((BroadleafEnumerationType)value).getFriendlyType();
             } else {
                 strVal = value.toString();
             }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/DefaultFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/DefaultFieldPersistenceProvider.java
@@ -19,6 +19,7 @@ package org.broadleafcommerce.openadmin.server.service.persistence.module.provid
 
 import java.io.Serializable;
 
+import org.broadleafcommerce.common.BroadleafEnumerationType;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceException;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request.ExtractValueRequest;
@@ -59,7 +60,12 @@ public class DefaultFieldPersistenceProvider extends FieldPersistenceProviderAda
     @Override
     public MetadataProviderResponse extractValue(ExtractValueRequest extractValueRequest, Property property) throws PersistenceException {
         if (extractValueRequest.getRequestedValue() != null) {
-            String val = extractValueRequest.getRequestedValue().toString();
+            String val;
+            if(extractValueRequest.getRequestedValue() instanceof BroadleafEnumerationType){
+                val = ((BroadleafEnumerationType)extractValueRequest.getRequestedValue()).getType();
+            }else {
+                val = extractValueRequest.getRequestedValue().toString();
+            }
             property.setValue(val);
             property.setDisplayValue(extractValueRequest.getDisplayVal());
         }


### PR DESCRIPTION
- make sure that if value is string but metadata is broadleaf enumeration final value will be a friendly type of broadleaf enumeration

Fixes: BroadleafCommerce/QA#4846