### PR TITLE
Got rid of deprecated processors in Core module

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/ContentExpression.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/ContentExpression.java
@@ -1,0 +1,36 @@
+/*-
+ * #%L
+ * BroadleafCommerce CMS Module
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.cms.web.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+public interface ContentExpression {
+    String REQUEST_DTO = "blRequestDTO";
+    String BLC_RULE_MAP_PARAM = "blRuleMap";
+
+    String getName();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+
+    boolean isSecure(HttpServletRequest request);
+}

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/ContentProcessor.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/ContentProcessor.java
@@ -18,6 +18,7 @@
 
 package org.broadleafcommerce.cms.web.processor;
 
+import com.google.common.primitives.Ints;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
@@ -36,13 +37,12 @@ import org.broadleafcommerce.common.time.SystemTime;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.common.web.deeplink.DeepLink;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafAssignation;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
-import com.google.common.primitives.Ints;
-
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -50,9 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-
-import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Processor used to display structured content that is maintained with the Broadleaf CMS.
@@ -94,11 +91,9 @@ import javax.servlet.http.HttpServletRequest;
  */
 @Component("blContentProcessor")
 @ConditionalOnTemplating
-public class ContentProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class ContentProcessor implements ContentExpression {
 
     protected final Log LOG = LogFactory.getLog(getClass());
-    public static final String REQUEST_DTO = "blRequestDTO";
-    public static final String BLC_RULE_MAP_PARAM = "blRuleMap";
 
     @Resource(name = "blStructuredContentService")
     protected StructuredContentService structuredContentService;
@@ -342,6 +337,7 @@ public class ContentProcessor extends AbstractBroadleafVariableModifierProcessor
         return mvelParameters;
     }
 
+    @Override
     public boolean isSecure(HttpServletRequest request) {
         boolean secure = false;
         if (request != null) {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminFieldBuilderProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminFieldBuilderProcessor.java
@@ -17,28 +17,26 @@
  */
 package org.broadleafcommerce.openadmin.processor;
 
+import com.google.common.collect.ImmutableMap;
+import org.broadleafcommerce.common.web.expression.BroadleafVariableModifierExpression;
 import org.broadleafcommerce.openadmin.web.rulebuilder.dto.FieldWrapper;
 import org.broadleafcommerce.openadmin.web.rulebuilder.service.RuleBuilderFieldService;
 import org.broadleafcommerce.openadmin.web.rulebuilder.service.RuleBuilderFieldServiceFactory;
 import org.broadleafcommerce.openadmin.web.service.AdminFieldBuilderProcessorExtensionManager;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.dialect.BroadleafDialectPrefix;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.ImmutableMap;
-
-import java.util.Map;
-
 import javax.annotation.Resource;
+import java.util.Map;
 
 /**
  * @author Elbert Bautista (elbertbautista)
  */
 @Component("blAdminFieldBuilderProcessor")
 @ConditionalOnTemplating
-public class AdminFieldBuilderProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class AdminFieldBuilderProcessor implements BroadleafVariableModifierExpression {
 
     @Resource(name = "blRuleBuilderFieldServiceFactory")
     protected RuleBuilderFieldServiceFactory ruleBuilderFieldServiceFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminModuleExpression.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminModuleExpression.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface AdminModuleExpression {
+    String getName();
+
+    String getPrefix();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminModuleProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminModuleProcessor.java
@@ -22,7 +22,6 @@ import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
 import org.broadleafcommerce.openadmin.server.security.service.AdminSecurityService;
 import org.broadleafcommerce.openadmin.server.security.service.navigation.AdminNavigationService;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.dialect.BroadleafDialectPrefix;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.security.core.Authentication;
@@ -31,10 +30,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * A Thymeleaf processor that will add the appropriate AdminModules to the model. It does this by
@@ -47,7 +45,7 @@ import javax.annotation.Resource;
  */
 @Component("blAdminModuleProcessor")
 @ConditionalOnTemplating
-public class AdminModuleProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class AdminModuleProcessor implements AdminModuleExpression {
 
     private static final String ANONYMOUS_USER_NAME = "anonymousUser";
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminUserProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/AdminUserProcessor.java
@@ -21,7 +21,6 @@ package org.broadleafcommerce.openadmin.processor;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
 import org.broadleafcommerce.openadmin.server.security.service.AdminSecurityService;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.dialect.BroadleafDialectPrefix;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.security.core.Authentication;
@@ -30,10 +29,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * A Thymeleaf processor that will add the appropriate AdminUser to the model.
@@ -42,7 +40,7 @@ import javax.annotation.Resource;
  */
 @Component("blAdminUserProcessor")
 @ConditionalOnTemplating
-public class AdminUserProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class AdminUserProcessor implements AdminModuleExpression {
 
     private static final String ANONYMOUS_USER_NAME = "anonymousUser";
     

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/ErrorsExpression.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/ErrorsExpression.java
@@ -1,0 +1,35 @@
+/*-
+ * #%L
+ * BroadleafCommerce Open Admin Platform
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.openadmin.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface ErrorsExpression {
+    String GENERAL_ERRORS_TAB_KEY = "generalErrors";
+    String GENERAL_ERROR_FIELD_KEY = "generalError";
+
+    String getName();
+
+    String getPrefix();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, String attributeName, String attributeValue, BroadleafTemplateContext context);
+}

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/ErrorsProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/processor/ErrorsProcessor.java
@@ -27,7 +27,6 @@ import org.broadleafcommerce.openadmin.web.form.entity.EntityForm;
 import org.broadleafcommerce.openadmin.web.form.entity.Field;
 import org.broadleafcommerce.openadmin.web.form.entity.Tab;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierAttrProcessor;
 import org.broadleafcommerce.presentation.dialect.BroadleafDialectPrefix;
 import org.broadleafcommerce.presentation.model.BroadleafBindStatus;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
@@ -55,12 +54,9 @@ import java.util.Map;
  */
 @Component("blErrorsProcessor")
 @ConditionalOnTemplating
-public class ErrorsProcessor extends AbstractBroadleafVariableModifierAttrProcessor {
+public class ErrorsProcessor implements ErrorsExpression {
 
     protected static final Log LOG = LogFactory.getLog(ErrorsProcessor.class);
-
-    public static final String GENERAL_ERRORS_TAB_KEY = "generalErrors";
-    public static final String GENERAL_ERROR_FIELD_KEY = "generalError";
 
     @Value("${admin.form.validation.errors.hideTopLevelFieldErrors:false}")
     protected boolean hideTopLevelFieldErrors;

--- a/common/src/main/java/org/broadleafcommerce/common/breadcrumbs/processor/BreadcrumbExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/breadcrumbs/processor/BreadcrumbExpression.java
@@ -1,0 +1,30 @@
+/*-
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.breadcrumbs.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface BreadcrumbExpression {
+    String getName();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/breadcrumbs/processor/BreadcrumbProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/breadcrumbs/processor/BreadcrumbProcessor.java
@@ -18,20 +18,17 @@
 
 package org.broadleafcommerce.common.breadcrumbs.processor;
 
+import com.google.common.collect.ImmutableMap;
 import org.broadleafcommerce.common.breadcrumbs.dto.BreadcrumbDTO;
 import org.broadleafcommerce.common.web.expression.BreadcrumbVariableExpression;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import com.google.common.collect.ImmutableMap;
-
+import javax.annotation.Resource;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * A Thymeleaf processor that will add a list of BreadcrumbDTOs to the model.
@@ -40,7 +37,7 @@ import javax.annotation.Resource;
  */
 @Component("blBreadcrumbProcessor")
 @ConditionalOnTemplating
-public class BreadcrumbProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class BreadcrumbProcessor implements BreadcrumbExpression {
 
     @Resource
     protected BreadcrumbVariableExpression breadcrumbVariableExpression;

--- a/common/src/main/java/org/broadleafcommerce/common/web/expression/BroadleafVariableModifierExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/expression/BroadleafVariableModifierExpression.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.web.expression;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface BroadleafVariableModifierExpression extends BroadleafVariableExpression {
+    public boolean useGlobalScope();
+
+    String getPrefix();
+
+    int getPrecedence();
+
+    public Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}
+

--- a/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/CreditCardTypesExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/CreditCardTypesExpression.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.web.payment.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface CreditCardTypesExpression {
+    String getName();
+
+    int getPrecedence();
+
+    boolean useGlobalScope();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/CreditCardTypesProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/CreditCardTypesProcessor.java
@@ -18,19 +18,16 @@
 
 package org.broadleafcommerce.common.web.payment.processor;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.ImmutableMap;
-
+import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * <p>The following processor will add any Payment Gateway specific Card Type 'codes' to the model if
@@ -57,7 +54,7 @@ import javax.annotation.Resource;
  */
 @Component("blCreditCardTypesProcessor")
 @ConditionalOnTemplating
-public class CreditCardTypesProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class CreditCardTypesProcessor implements CreditCardTypesExpression {
 
     protected static final Log LOG = LogFactory.getLog(CreditCardTypesProcessor.class);
 

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/ConfigVariableProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/ConfigVariableProcessor.java
@@ -17,14 +17,12 @@
  */
 package org.broadleafcommerce.common.web.processor;
 
+import com.google.common.collect.ImmutableMap;
 import org.broadleafcommerce.common.util.BLCSystemProperty;
 import org.broadleafcommerce.common.web.expression.PropertiesVariableExpression;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
-
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
@@ -46,7 +44,7 @@ import java.util.Map;
 @Deprecated
 @Component("blConfigVariableProcessor")
 @ConditionalOnTemplating
-public class ConfigVariableProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class ConfigVariableProcessor implements DataDrivenEnumerationExpression {
 
     @Override
     public String getName() {

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/DataDrivenEnumerationExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/DataDrivenEnumerationExpression.java
@@ -1,0 +1,30 @@
+/*-
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.web.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface DataDrivenEnumerationExpression {
+    String getName();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/processor/DataDrivenEnumerationProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/processor/DataDrivenEnumerationProcessor.java
@@ -17,21 +17,18 @@
  */
 package org.broadleafcommerce.common.web.processor;
 
+import com.google.common.collect.ImmutableMap;
 import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumeration;
 import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValue;
 import org.broadleafcommerce.common.enumeration.service.DataDrivenEnumerationService;
 import org.broadleafcommerce.common.web.expression.DataDrivenEnumVariableExpression;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.ImmutableMap;
-
+import javax.annotation.Resource;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 
 /**
@@ -50,7 +47,7 @@ import javax.annotation.Resource;
 @Deprecated
 @Component("blDataDrivenEnumerationProcessor")
 @ConditionalOnTemplating
-public class DataDrivenEnumerationProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class DataDrivenEnumerationProcessor implements DataDrivenEnumerationExpression {
 
     @Resource(name = "blDataDrivenEnumerationService")
     protected DataDrivenEnumerationService enumService;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/CategoriesExpression.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/CategoriesExpression.java
@@ -1,0 +1,30 @@
+/*-
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface CategoriesExpression {
+    String getName();
+
+    int getPrecedence();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/CategoriesProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/CategoriesProcessor.java
@@ -25,17 +25,15 @@ import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.CategoryXref;
 import org.broadleafcommerce.core.catalog.service.CatalogService;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * A Thymeleaf processor that will add the desired categories to the model. It does this by
@@ -50,7 +48,7 @@ import javax.annotation.Resource;
  */
 @Component("blCategoriesProcessor")
 @ConditionalOnTemplating
-public class CategoriesProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class CategoriesProcessor implements CategoriesExpression {
 
     @Resource(name = "blCatalogService")
     protected CatalogService catalogService;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/NamedOrderProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/NamedOrderProcessor.java
@@ -23,16 +23,14 @@ import org.broadleafcommerce.core.order.domain.Order;
 import org.broadleafcommerce.core.order.service.OrderService;
 import org.broadleafcommerce.core.web.expression.OrderVariableExpression;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * <p>
@@ -56,7 +54,7 @@ import javax.annotation.Resource;
 @Deprecated
 @Component("blNamedOrderProcessor")
 @ConditionalOnTemplating
-public class NamedOrderProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class NamedOrderProcessor implements CategoriesExpression {
 
     @Resource(name = "blOrderService")
     protected OrderService orderService;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/OnePageCheckoutExpression.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/OnePageCheckoutExpression.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * BroadleafCommerce Framework Web
+ * %%
+ * Copyright (C) 2009 - 2022 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.core.web.processor;
+
+import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
+
+import java.util.Map;
+
+public interface OnePageCheckoutExpression {
+    String getName();
+
+    int getPrecedence();
+
+    boolean useGlobalScope();
+
+    Map<String, Object> populateModelVariables(String tagName, Map<String, String> tagAttributes, BroadleafTemplateContext context);
+}

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/OnePageCheckoutProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/OnePageCheckoutProcessor.java
@@ -46,13 +46,14 @@ import org.broadleafcommerce.core.web.checkout.service.CheckoutFormService;
 import org.broadleafcommerce.core.web.order.CartState;
 import org.broadleafcommerce.core.web.order.service.CartStateService;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.broadleafcommerce.profile.core.service.CountryService;
 import org.broadleafcommerce.profile.core.service.CustomerAddressService;
 import org.broadleafcommerce.profile.core.service.StateService;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -60,9 +61,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
-
-import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * <p>
@@ -88,7 +86,7 @@ import javax.servlet.http.HttpServletRequest;
 @Deprecated
 @Component("blOnePageCheckoutProcessor")
 @ConditionalOnTemplating
-public class OnePageCheckoutProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class OnePageCheckoutProcessor implements OnePageCheckoutExpression {
 
     @Resource(name = "blStateService")
     protected StateService stateService;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionDisplayProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionDisplayProcessor.java
@@ -18,17 +18,14 @@
 
 package org.broadleafcommerce.core.web.processor;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
-import org.broadleafcommerce.core.catalog.domain.ProductOption;
 import org.broadleafcommerce.core.catalog.domain.ProductOptionXref;
 import org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXref;
 import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
-
-import com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +35,7 @@ import java.util.Map;
  */
 @Component("blProductOptionDisplayProcessor")
 @ConditionalOnTemplating
-public class ProductOptionDisplayProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class ProductOptionDisplayProcessor implements OnePageCheckoutExpression {
 
     @Override
     public String getName() {

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionsProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/ProductOptionsProcessor.java
@@ -18,6 +18,8 @@
 
 package org.broadleafcommerce.core.web.processor;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.collections4.map.LRUMap;
@@ -36,13 +38,10 @@ import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXref;
 import org.broadleafcommerce.core.catalog.service.CatalogService;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import javax.annotation.Resource;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -51,8 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.annotation.Resource;
 
 /**
  * This processor will add the following information to the model, available for consumption by a template:
@@ -64,7 +61,7 @@ import javax.annotation.Resource;
  */
 @Component("blProductOptionsProcessor")
 @ConditionalOnTemplating
-public class ProductOptionsProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class ProductOptionsProcessor implements CategoriesExpression {
 
     private static final Log LOG = LogFactory.getLog(ProductOptionsProcessor.class);
     protected static final Map<Object, String> JSON_CACHE = Collections.synchronizedMap(new LRUMap<Object, String>(500));

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RatingsProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/RatingsProcessor.java
@@ -24,16 +24,14 @@ import org.broadleafcommerce.core.rating.domain.ReviewDetail;
 import org.broadleafcommerce.core.rating.service.RatingService;
 import org.broadleafcommerce.core.rating.service.type.RatingType;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.broadleafcommerce.presentation.dialect.AbstractBroadleafVariableModifierProcessor;
 import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.broadleafcommerce.profile.core.domain.Customer;
 import org.broadleafcommerce.profile.web.core.CustomerState;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Resource;
 
 /**
  * A Thymeleaf processor that will add the product ratings and reviews to the model
@@ -42,7 +40,7 @@ import javax.annotation.Resource;
  */
 @Component("blRatingsProcessor")
 @ConditionalOnTemplating
-public class RatingsProcessor extends AbstractBroadleafVariableModifierProcessor {
+public class RatingsProcessor implements CategoriesExpression {
 
     @Resource(name = "blRatingService")
     protected RatingService ratingService;


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4832

We got rid of deprecated processors in CommonPresentation module. There were a lot of classes which were implementing deprecated logic, so I made some new interfaces as it is mentioned in deprecation docs (@deprecated instead of using this processor you should instead write a custom {@link org.broadleafcommerce.common.web.expression.BraodleafVariableExpression})

