### PR TITLE
Improve the handler that calls logJavaScriptError to prevent infinite loop

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1362,18 +1362,26 @@ BLC.defaultErrorHandler = function(data) {
 		BLCAdmin.showMessageAsModal(BLCAdmin.messages.error, BLCAdmin.messages.staleContent);
     } else {
         var $data;
+        try {
+            if (data.responseText.trim) {
+                $data = $(data.responseText.trim());
+            } else {
+                $data = $(data.responseText);
+            }
 
-        if (data.responseText.trim) {
-            $data = $(data.responseText.trim());
-        } else {
-            $data = $(data.responseText);
-        }
-
-        if ($data.length == 1) {
-            BLCAdmin.showElementAsModal($data);
-        } else {
-            // This shouldn't happen, but it's here as a fallback just in case
-            BLCAdmin.showMessageAsModal(BLCAdmin.messages.error, BLCAdmin.messages.errorOccurred);
+            if ($data.length == 1) {
+                BLCAdmin.showElementAsModal($data);
+            } else {
+                // This shouldn't happen, but it's here as a fallback just in case
+                BLCAdmin.showMessageAsModal(BLCAdmin.messages.error, BLCAdmin.messages.errorOccurred);
+            }
+        } catch (e) {
+            $data = data.responseJSON;
+            if ($data !== undefined && $data.error) {
+                BLCAdmin.showMessageAsModal(BLCAdmin.messages.error, $data.error);
+            } else {
+                BLCAdmin.showMessageAsModal(BLCAdmin.messages.error, BLCAdmin.messages.errorOccurred);
+            }
         }
     }
 };


### PR DESCRIPTION
**A Brief Overview**
1. **BLC.defaultErrorHandle**r should not return any Js exception in any case. The code in this handler should be sorrounded by try/catch
2. We handle the case of **Bad scenario for BLC.defaultErrorHandler**: from p.3 and show proper error description

**QA issue**
[Add any other context about the PR here.](https://github.com/BroadleafCommerce/QA/issues/4862)
