### PR TITLE
Update javadoc for AdminPresentationCollection.friendlyName

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentationCollection.java
+++ b/common/src/main/java/org/broadleafcommerce/common/presentation/AdminPresentationCollection.java
@@ -42,6 +42,8 @@ public @interface AdminPresentationCollection {
      * the friendly name may be a key to retrieve a localized friendly name using
      * the GWT support for i18N.</p>
      *
+     * <p>Note: do not use the "/" character (or encode via i18N resource).</p>
+     *
      * @return the friendly name
      */
     String friendlyName() default "";


### PR DESCRIPTION
**A Brief Overview**
A note has been added to AdminPresentationCollection.friendlyName regarding the use of special characters "/", which results in incorrect operation (error in JS).

[QA-4863](https://github.com/BroadleafCommerce/QA/issues/4863)