### PR TITLE
Sku with future pricelist data now don't disappear from the site 

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -53,7 +53,6 @@ import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.common.util.DateUtil;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 import org.broadleafcommerce.core.catalog.service.dynamic.DynamicSkuPrices;
-import org.broadleafcommerce.core.catalog.service.dynamic.SkuActiveDateConsiderationContext;
 import org.broadleafcommerce.core.catalog.service.dynamic.SkuPricingConsiderationContext;
 import org.broadleafcommerce.core.inventory.service.type.InventoryType;
 import org.broadleafcommerce.core.order.domain.FulfillmentOption;
@@ -834,19 +833,10 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Override
     public Date getActiveEndDate() {
-        Date returnDate = null;
-        if (SkuActiveDateConsiderationContext.hasDynamicActiveDates()) {
-            returnDate = SkuActiveDateConsiderationContext.getSkuActiveDatesService().getDynamicSkuActiveEndDate(this);
-        }
-
-        if (returnDate == null) {
-            if (activeEndDate == null && hasDefaultSku()) {
-                return lookupDefaultSku().getActiveEndDate();
-            } else {
-                return activeEndDate;
-            }
+        if (activeEndDate == null && hasDefaultSku()) {
+            return lookupDefaultSku().getActiveEndDate();
         } else {
-            return returnDate;
+            return activeEndDate;
         }
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -69,24 +69,6 @@ import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -110,6 +92,23 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * The Class SkuImpl is the default implementation of {@link Sku}. A SKU is a
@@ -821,19 +820,10 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Override
     public Date getActiveStartDate() {
-        Date returnDate = null;
-        if (SkuActiveDateConsiderationContext.hasDynamicActiveDates()) {
-            returnDate = SkuActiveDateConsiderationContext.getSkuActiveDatesService().getDynamicSkuActiveStartDate(this);
-        }
-
-        if (returnDate == null) {
-            if (activeStartDate == null && hasDefaultSku()) {
-                return lookupDefaultSku().getActiveStartDate();
-            } else {
-                return activeStartDate;
-            }
+        if (activeStartDate == null && hasDefaultSku()) {
+            return lookupDefaultSku().getActiveStartDate();
         } else {
-            return returnDate;
+            return activeStartDate;
         }
     }
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/4869

Removed a logic which checks if Sku has dynamics active dates, as it was blocking the update of Sku price with new pricelist data applied

