### PR TITLE
Add cache hint to order find by id query

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -86,6 +86,8 @@ public class OrderDaoImpl implements OrderDao {
     public Order readOrderById(final Long orderId) {
         TypedQuery<Order> query = em.createQuery("SELECT o FROM OrderImpl o WHERE o.id= :orderId", Order.class);
         query.setParameter("orderId", orderId);
+        query.setHint(QueryHints.HINT_CACHEABLE, true);
+        query.setHint(QueryHints.HINT_CACHE_REGION, "query.Order");
         Order order = null;
         try {
             order = query.getSingleResult();


### PR DESCRIPTION
- Add cache hint to order find by id query

Fixes: BroadleafCommerce/QA#4874