### PR TITLE
QA-4885: fixed recursion call of window.resize()

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -411,6 +411,8 @@
             for (var i = 0; i < initializationHandlers.length; i++) {
                 initializationHandlers[i]($container.find('table:not([id$="-header"])'));
             }
+
+            $(window).resize();
         },
 
         getListGridCount: function ($container) {
@@ -424,7 +426,6 @@
             maxWidth -= 70;
 
             $titlebar.find('.listgrid-friendly-name').css('max-width', maxWidth + 'px');
-            $(window).resize();
         },
 
         addInitializationHandler: function (fn) {


### PR DESCRIPTION
**A Brief Overview**
In listGrid.updateGridTitleBarSize() had "window.resize()" which was called in "addInitializationHandler" and caused recursion.
Solution: call window.resize() in "initialize" after "addInitializationHandler"

**Link to QA**
[issue](https://github.com/BroadleafCommerce/QA/issues/4885)
