### PR TITLE
Updating spring security version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ehcache3.version>3.9.0</ehcache3.version>
         <spring.version>5.3.23</spring.version>
-        <spring.security.version>5.6.9</spring.security.version>
+        <spring.security.version>5.8.1</spring.security.version>
         <spring.boot.version>2.6.7</spring.boot.version>
         <jackson.version>2.13.3</jackson.version>
         <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
**A Brief Overview**
Updated spring.security.version to 5.8.1

**Link to QA issue**
[Link ](https://github.com/BroadleafCommerce/QA/issues/4823)

**Additional context**
This property is best kept in sync with the version in the broadleaf-module-parent.