### PR TITLE
Validating customer id during customer password reset workflow

### DIFF
--- a/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/CustomerStateRefresher.java
+++ b/core/broadleaf-profile-web/src/main/java/org/broadleafcommerce/profile/web/core/CustomerStateRefresher.java
@@ -69,7 +69,7 @@ public class CustomerStateRefresher implements ApplicationListener<CustomerPersi
             }
             
             //Update CustomerState if the persisted Customer ID is the same
-            if (CustomerState.getCustomer() != null && CustomerState.getCustomer().getId().equals(dbCustomer.getId())) {
+            if (CustomerState.getCustomer() != null && CustomerState.getCustomer().getId() != null && CustomerState.getCustomer().getId().equals(dbCustomer.getId())) {
                 //Copy transient fields from the customer that existed in CustomerState, prior to the DB refresh, 
                 //to the customer that has been saved (merged) in the DB....
                 Customer preMergedCustomer = CustomerState.getCustomer();


### PR DESCRIPTION
**Title**
validating customer id during customer password reset workflow

**Overview**
There was an issue in reset password workflow, when user requested to reset his password. Once user set a new password and submit it, an error occurs because the CustomerId was null.

**QA:**  https://github.com/BroadleafCommerce/QA/issues/4890
