### PR TITLE
Updating version of jettison, esapi, dependency-check-maven

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -100,6 +100,7 @@ import org.broadleafcommerce.openadmin.web.rulebuilder.dto.DataDTO;
 import org.broadleafcommerce.openadmin.web.rulebuilder.dto.DataWrapper;
 import org.broadleafcommerce.openadmin.web.rulebuilder.dto.FieldDTO;
 import org.broadleafcommerce.openadmin.web.rulebuilder.dto.FieldWrapper;
+import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
@@ -334,7 +335,12 @@ public class FormBuilderServiceImpl implements FormBuilderService {
                 enumMap.put(enumerationValue[0], enumerationValue[1]);
             }
 
-            fieldDTO.setValues(new JSONObject(enumMap).toString());
+            try {
+                fieldDTO.setValues(new JSONObject(enumMap).toString());
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+
         } else if (field.getFieldType().equals("ADDITIONAL_FOREIGN_KEY")) {
             fieldDTO.setOperators("blcFilterOperators_Selectize");
             fieldDTO.setType("string");

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
-                      <version>7.0.1</version>
+                      <version>7.3.2</version>
                       <executions>
                           <execution>
                               <goals>
@@ -1278,7 +1278,7 @@
             <dependency>
                 <groupId>org.owasp.esapi</groupId>
                 <artifactId>esapi</artifactId>
-                <version>2.4.0.0</version>
+                <version>2.5.1.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-beanutils</groupId>
@@ -1321,7 +1321,7 @@
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
-                <version>1.5.1</version>
+                <version>1.5.3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**A Brief Overview**
Updating version of:
- jettison to 1.5.3;
- dependency-check-maven to 7.3.2;
- esapi(has dependency on dependency-check-maven) to 2.5.1.0;

Wrapped in try/catch JSONObject (in new version throws JSONException)

**Link to QA issue**
[QA-4877](https://github.com/BroadleafCommerce/QA/issues/4877)
