### PR TITLE
Fixes of InaccessibleObjectException with Java 17

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.BroadleafEnumerationType;
@@ -573,7 +572,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
             try {
                 Property p = new Property();
                 p.setName(MAIN_ENTITY_NAME_PROPERTY);
-                String mainEntityName = (String) MethodUtils.invokeMethod(entity, "getMainEntityName");
+                String mainEntityName = ((AdminMainEntity)entity).getMainEntityName();
                 p.setValue(mainEntityName);
                 props.add(p);
             } catch (Exception e) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -17,7 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.beanutils.MethodUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.commons.lang.StringUtils;
@@ -68,6 +67,21 @@ import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -91,23 +105,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * The Class SkuImpl is the default implementation of {@link Sku}. A SKU is a
@@ -1050,15 +1047,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @Override
     @Deprecated
     public List<ProductOptionValue> getProductOptionValues() {
-        //Changing this API to Set is ill-advised (especially in a patch release). The tendrils are widespread. Instead
-        //we just migrate the call from the List to the internal Set representation. This is in response
-        //to https://github.com/BroadleafCommerce/BroadleafCommerce/issues/917.
-        return (List<ProductOptionValue>) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{List.class}, new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return MethodUtils.invokeMethod(getProductOptionValuesCollection(), method.getName(), args, method.getParameterTypes());
-            }
-        });
+        return new ArrayList<>(getProductOptionValuesCollection());
     }
 
     @Override


### PR DESCRIPTION
**A Brief Overview**
Removed MethodUtils.invokeMethod as a blocker when using Java 17 in SkuImpl.getProductOptionValues() and BasicPersistenceModule.getRecords()

**Link to QA issue**
[QA-4815](https://github.com/BroadleafCommerce/QA/issues/4815)

**Additional context**
Needed to add this to VM option (for java 17):
--add-opens java.base/java.lang=ALL-UNNAMED
