### PR TITLE
Fixing caret position in redactor when switching WYSIWG mode and caret inside style tag

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/lib/redactor.js
@@ -3191,6 +3191,19 @@
                             }
                             else if (html[i] == '<' || i == htmlLength)
                             {
+                                if (i + 1 < htmlLength) {
+                                    //closing tag
+                                    if (html[i + 1] == '/') {
+                                        var closeTag = html.indexOf('>', i + 1);
+                                        if (closeTag > 0) {
+                                            var tagName = html.substring(i + 2, closeTag);
+                                            if (tagName.toLowerCase() === "style") {
+                                                c = closeTag + 1;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                                 c = 0;
                                 break;
                             }


### PR DESCRIPTION
- Fix for caret position when it is inside style tag

Fixes: BroadleafCommerce/QA#4915