### PR TITLE
There is a potential use case where the categoryXref::getDefaultReference can be null when filtering out products during a solr catalog search

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -305,7 +305,7 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
                         iterator.remove();
                         break;
                     }
-                    Optional<CategoryXref> parentXref = parentCategory.getAllParentCategoryXrefs().stream().filter(CategoryXref::getDefaultReference).findFirst();
+                    Optional<CategoryXref> parentXref = parentCategory.getAllParentCategoryXrefs().stream().filter(xref -> xref.getDefaultReference() != null).findFirst();
                     parentCategory = parentXref.map(CategoryXref::getCategory).orElse(null);
                 }
             } else if(defaultParent.isPresent() && !defaultParent.get().getCategory().isActive()) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -305,7 +305,8 @@ public class SolrSearchServiceImpl implements SearchService, DisposableBean {
                         iterator.remove();
                         break;
                     }
-                    Optional<CategoryXref> parentXref = parentCategory.getAllParentCategoryXrefs().stream().filter(xref -> xref.getDefaultReference() != null).findFirst();
+                    Optional<CategoryXref> parentXref = parentCategory.getAllParentCategoryXrefs().stream()
+                            .filter(xref -> xref.getDefaultReference() != null && xref.getDefaultReference()).findFirst();
                     parentCategory = parentXref.map(CategoryXref::getCategory).orElse(null);
                 }
             } else if(defaultParent.isPresent() && !defaultParent.get().getCategory().isActive()) {


### PR DESCRIPTION
In that case the filter was throwing an NPE.  Fixes https://github.com/BroadleafCommerce/QA/issues/4933
