### PR TITLE
Make RMA list grid to look a bit more similar to rma grid in customer's returns tab

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
@@ -800,4 +800,12 @@ public class ListGrid {
         return StringUtils.join(this.cssClasses, " ");
     }
 
+    public String getFirstSearchableFieldFriendlyName(){
+        Optional<Field> first = headerFields.stream().filter(t -> t.getFilterSortDisabled() == null || !t.getFilterSortDisabled()).findFirst();
+        if(first.isPresent()){
+            return first.get().getFriendlyName();
+        }else{
+            return headerFields.iterator().next().getFriendlyName();
+        }
+    }
 }

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/searchFields.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/searchFields.html
@@ -3,7 +3,7 @@
     <div class="col6">
         <form class="custom-entity-search" th:action="${currentUrl}" method="GET">
             <input id="listgrid-search" type="search" name="table-search"
-                   th:placeholder="#{Search_Placeholder(#{${listGrid.headerFields[0].friendlyName}}, #{${entityFriendlyName}})}" />
+                   th:placeholder="#{Search_Placeholder(#{${listGrid.firstSearchableFieldFriendlyName}}, #{${entityFriendlyName}})}" />
             <div class="listgrid-search-actions">
                 <button class="button primary search-button" th:inline="text" th:utext="#{Search}"></button>
                 <div th:replace="components/listGridToolbar" ></div>


### PR DESCRIPTION
- Make RMA list grid to look a bit more similar to rma grid in customer's returns tab

Fixes: BroadleafCommerce/QA#4919