### PR TITLE
Added filtration for alt skus in case default sku is used to track inventory

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -66,6 +66,7 @@ import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.service.handler.CustomPersistenceHandlerAdapter;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManagerFactory;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.EmptyFilterValues;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.InspectHelper;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.PersistenceModule;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
@@ -94,8 +95,12 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 
 /**
  * @author Phillip Verheyden
@@ -120,6 +125,10 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
 
     @Resource(name = "blSkuCustomPersistenceHandlerExtensionManager")
     protected SkuCustomPersistenceHandlerExtensionManager extensionManager;
+
+    @Value("${enable.weave.use.default.sku.inventory:false}")
+    protected boolean enableUseDefaultSkuInventory = false;
+
 
     /**
      * This represents the field that all of the product option values will be stored in. This would be used in the case
@@ -503,6 +512,7 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
             //allow subclasses to provide additional criteria before executing the query
             applyProductOptionValueCriteria(filterMappings, cto, persistencePackage, null);
             applySkuBundleItemValueCriteria(filterMappings, cto, persistencePackage);
+            applyInventoryRestictions(filterMappings, cto, persistencePackage);
             applyAdditionalFetchCriteria(filterMappings, cto, persistencePackage);
 
             List<Serializable> records = helper.getPersistentRecords(persistencePackage.getCeilingEntityFullyQualifiedClassname(), filterMappings, cto.getFirstResult(), cto.getMaxResults());
@@ -517,6 +527,50 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
             return new DynamicResultSet(payload, totalRecords);
         } catch (Exception e) {
             throw new ServiceException("Unable to perform fetch for entity: " + ceilingEntityFullyQualifiedClassname, e);
+        }
+    }
+
+    protected void applyInventoryRestictions(List<FilterMapping> filterMappings, CriteriaTransferObject cto, PersistencePackage persistencePackage) {
+        boolean hasInventory = persistencePackage.containsCriteria("owningClass=com.broadleafcommerce.inventory.advanced.domain.InventoryImpl")
+                && persistencePackage.containsCriteria("requestingField=sku");
+        if (hasInventory && enableUseDefaultSkuInventory) {
+            filterMappings.add(new FilterMapping().withDirectFilterValues(new EmptyFilterValues()).withRestriction(new Restriction()
+                    .withPredicateProvider(new PredicateProvider() {
+                        @Override
+                        public Predicate buildPredicate(CriteriaBuilder builder, FieldPathBuilder fieldPathBuilder, From root, String ceilingEntity, String fullPropertyName, Path explicitPath, List directValues) {
+
+                            Join product = root.join("product", JoinType.LEFT);
+
+                            Subquery<Long> subquery = fieldPathBuilder.getCriteria().subquery(Long.class);
+                            Root<ProductImpl> productRoot = subquery.from(ProductImpl.class);
+                            subquery.select(builder.count(productRoot));
+                            subquery.where(
+                                    builder.and(
+                                            builder.equal(productRoot.get("embeddableSandBoxDiscriminator").get("tier"), 999999),
+                                            builder.isNull(productRoot.get("embeddableSandBoxDiscriminator").get("sandBox")),
+                                            builder.equal(productRoot.get("embeddableSandBoxDiscriminator").get("originalItemId"), root.get("product").get("id")),
+                                            builder.equal(productRoot.get("useDefaultSkuInInventory"), Boolean.TRUE)
+                                    )
+                            );
+
+                            Subquery<Long> subqueryWithoutOverride = fieldPathBuilder.getCriteria().subquery(Long.class);
+                            Root<ProductImpl> productRootWithoutOverride = subqueryWithoutOverride.from(ProductImpl.class);
+                            subqueryWithoutOverride.select(builder.count(productRootWithoutOverride));
+                            subqueryWithoutOverride.where(
+                                    builder.and(
+                                            builder.equal(productRootWithoutOverride.get("embeddableSandBoxDiscriminator").get("tier"), 999999),
+                                            builder.isNull(productRootWithoutOverride.get("embeddableSandBoxDiscriminator").get("sandBox")),
+                                            builder.equal(productRootWithoutOverride.get("embeddableSandBoxDiscriminator").get("originalItemId"), root.get("product").get("id"))
+                                    )
+                            );
+                            Predicate and = builder.and(
+                                    builder.equal(subqueryWithoutOverride, 0),
+                                    builder.or(builder.isNull(product.get("useDefaultSkuInInventory")), builder.equal(product.get("useDefaultSkuInInventory"), Boolean.FALSE))
+                            );
+                            Predicate equal = builder.and(builder.equal(subquery, 0), and);
+                            return equal;
+                        }
+                    })));
         }
     }
 


### PR DESCRIPTION
- Added filtration for alt skus in case default sku is used to track inventory

Fixes: BroadleafCommerce/QA#4963

Example of how to add filtration for the skus based on some product field. Not sure if really need it in the framework