### PR TITLE
Fix for not adding empty(undefined) filter in the end

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -660,7 +660,7 @@
             var filters = JSON.parse($('#' + hiddenId).val());
             var inputs = BLCAdmin.filterBuilders.getFiltersAsURLParams(hiddenId);
             if (inputs.length) {
-                for (var i in inputs) {
+                for (var i=0;i<inputs.length;i++) {
                     var input = inputs[i];
                     input.value = encodeURIComponent(input.value);
                 }


### PR DESCRIPTION
- Fix for not adding empty(undefined) filter in the end.... for some reason the last iteration with key last which results in undefined. simple loop fixed the issue

Fixes: BroadleafCommerce/QA#4993