### PR TITLE
Fixed an issue when Empty rows can be selected in newly created entities

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -901,4 +901,9 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
             return error.getCode();
         }
     }
+
+    protected void declareForceUseAdditionStatusFilter() {
+        Map<String, Object> additionalProperties = BroadleafRequestContext.getBroadleafRequestContext().getAdditionalProperties();
+        additionalProperties.put("forceUseAdditionStatusFilter", true);
+    }
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -1361,6 +1361,7 @@ public class AdminBasicEntityController extends AdminAbstractController {
 
             ClassMetadata collectionMetadata = service.getClassMetadata(ppr).getDynamicResultSet().getClassMetaData();
 
+            declareForceUseAdditionStatusFilter();
             DynamicResultSet drs = service.getRecords(ppr).getDynamicResultSet();
             ListGrid listGrid = formService.buildCollectionListGrid(id, drs, collectionProperty, sectionKey, sectionCrumbs);
             listGrid.setSubCollectionFieldName(collectionField);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicOperationsController.java
@@ -132,6 +132,7 @@ public class AdminBasicOperationsController extends AdminAbstractController {
 
         ExtensionResultStatusType extensionResultStatusType = extensionManager.getProxy().buildLookupListGrid(ppr, targetClassMetadata, ppr.getCeilingEntityClassname(), sectionCrumbs, model, requestParams);
         if (extensionResultStatusType.equals(ExtensionResultStatusType.NOT_HANDLED)) {
+            declareForceUseAdditionStatusFilter();
             DynamicResultSet drs = service.getRecords(ppr).getDynamicResultSet();
 
             ListGrid listGrid = null;


### PR DESCRIPTION
**A Brief Overview**
Add a new additional property in BroadleafRequestContext - **forceUseAdditionStatusFilter** - to check it then in AdditionStatusPersistenceEventHandler

https://github.com/BroadleafCommerce/QA/issues/5022
