### PR TITLE
Fix for list grid filter for catalog selection when MT has a catalog selection on entity add

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -188,13 +188,13 @@ public class FormBuilderServiceImpl implements FormBuilderService {
     protected boolean useTranslationSearch;
 
     @Resource(name = "blExploitProtectionService")
-    ExploitProtectionService exploitProtectionService;
+    protected ExploitProtectionService exploitProtectionService;
 
     protected static final VisibilityEnum[] FORM_HIDDEN_VISIBILITIES = new VisibilityEnum[] { 
             VisibilityEnum.HIDDEN_ALL, VisibilityEnum.FORM_HIDDEN
     };
     
-    protected static final VisibilityEnum[] GRID_HIDDEN_VISIBILITIES = new VisibilityEnum[] { 
+    public static final VisibilityEnum[] GRID_HIDDEN_VISIBILITIES = new VisibilityEnum[] {
             VisibilityEnum.HIDDEN_ALL, VisibilityEnum.GRID_HIDDEN 
     };
 

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -678,7 +678,13 @@
             }
 
             var url = $($filterFields[0]).data('action');
-
+            var parentTable = $($filterFields[0]).closest(".list-grid-table.table.table-striped");
+            if(parentTable){
+                var currentUrl = $(parentTable).data("currenturl");
+                if(currentUrl && !currentUrl.includes(url)){
+                    url=currentUrl;
+                }
+            }
             var urlEvent = $.Event('listGrid-filter-action-lazy-load-url');
             $('body').trigger(urlEvent, [url, $tbody]);
             url = urlEvent.resultUrl || url;


### PR DESCRIPTION
- Fix for list grid filter for catalog selection when MT has a catalog selection on entity add - it could use wrong url(entity add instead of catalog selection)

Fixes: BroadleafCommerce/QA#5031