### PR TITLE
Updated deprecated design in @GenericGenerator for Hibernate 6

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -10,30 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.field.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumeration;
-import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.RequiredOverride;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +26,24 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumeration;
+import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by bpolster.
@@ -51,9 +51,9 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FLD_DEF")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE)
@@ -64,79 +64,79 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     @Id
     @GeneratedValue(generator = "FieldDefinitionId")
     @GenericGenerator(
-        name="FieldDefinitionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="FieldDefinitionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.field.domain.FieldDefinitionImpl")
-        }
+            name = "FieldDefinitionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FieldDefinitionImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldDefinitionImpl")
+            }
     )
     @Column(name = "FLD_DEF_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     @AdminPresentation(fieldType = SupportedFieldType.HIDDEN)
     protected String name;
 
-    @Column (name = "FRIENDLY_NAME")
+    @Column(name = "FRIENDLY_NAME")
     @AdminPresentation(friendlyName = "FieldDefinitionImpl_friendlyName", order = 2000, prominent = true, gridOrder = 2000)
     protected String friendlyName;
 
-    @Column (name = "FLD_TYPE")
-    @AdminPresentation(fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.common.presentation.client.DynamicSupportedFieldType",
-        prominent = true, gridOrder = 3000, order = 1000,
-        requiredOverride = RequiredOverride.REQUIRED,
-        friendlyName = "FieldDefinitionImpl_fieldType")
+    @Column(name = "FLD_TYPE")
+    @AdminPresentation(fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.presentation.client.DynamicSupportedFieldType",
+            prominent = true, gridOrder = 3000, order = 1000,
+            requiredOverride = RequiredOverride.REQUIRED,
+            friendlyName = "FieldDefinitionImpl_fieldType")
     protected String fieldType;
 
-    @Column (name = "SECURITY_LEVEL")
+    @Column(name = "SECURITY_LEVEL")
     protected String securityLevel;
 
-    @Column (name = "HIDDEN_FLAG")
+    @Column(name = "HIDDEN_FLAG")
     protected Boolean hiddenFlag = false;
 
-    @Column (name = "VLDTN_REGEX")
+    @Column(name = "VLDTN_REGEX")
     protected String validationRegEx;
 
-    @Column (name = "VLDTN_ERROR_MSSG_KEY")
+    @Column(name = "VLDTN_ERROR_MSSG_KEY")
     protected String validationErrorMesageKey;
 
-    @Column (name = "MAX_LENGTH")
+    @Column(name = "MAX_LENGTH")
     protected Integer maxLength;
 
-    @Column (name = "COLUMN_WIDTH")
+    @Column(name = "COLUMN_WIDTH")
     protected String columnWidth;
 
-    @Column (name = "TEXT_AREA_FLAG")
+    @Column(name = "TEXT_AREA_FLAG")
     protected Boolean textAreaFlag = false;
-    
+
     @Column(name = "REQUIRED_FLAG")
-    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000,gridOrder = 4000, defaultValue = "false")
+    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000, gridOrder = 4000, defaultValue = "false")
     protected Boolean requiredFlag = false;
 
     @ManyToOne(targetEntity = DataDrivenEnumerationImpl.class)
     @JoinColumn(name = "ENUM_ID")
     protected DataDrivenEnumeration dataDrivenEnumeration;
 
-    @Column (name = "ALLOW_MULTIPLES")
+    @Column(name = "ALLOW_MULTIPLES")
     protected Boolean allowMultiples = false;
 
     @ManyToOne(targetEntity = FieldGroupImpl.class)
     @JoinColumn(name = "FLD_GROUP_ID")
     protected FieldGroup fieldGroup;
 
-    @Column(name="FLD_ORDER")
+    @Column(name = "FLD_ORDER")
     @AdminPresentation(friendlyName = "FieldDefinitionImpl_fieldOrder", order = 3000)
     protected Integer fieldOrder = 0;
 
-    @Column (name = "TOOLTIP")
+    @Column(name = "TOOLTIP")
     protected String tooltip;
 
-    @Column (name = "HELP_TEXT")
+    @Column(name = "HELP_TEXT")
     protected String helpText;
 
-    @Column (name = "HINT")
+    @Column(name = "HINT")
     protected String hint;
 
     @Override
@@ -164,11 +164,11 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
         if (fieldType == null) {
             return null;
         }
-        
+
         if (fieldType.startsWith(SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
             return SupportedFieldType.ADDITIONAL_FOREIGN_KEY;
         }
-        
+
         return SupportedFieldType.valueOf(fieldType);
     }
 
@@ -176,28 +176,28 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     public String getFieldTypeVal() {
         return fieldType;
     }
-    
+
     @Override
     public String getAdditionalForeignKeyClass() {
         if (fieldType == null || !fieldType.startsWith(SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
             return null;
         }
-        
+
         return fieldType.substring(fieldType.indexOf('|') + 1);
     }
-    
+
     @Override
     public void setAdditionalForeignKeyClass(String className) {
         if (fieldType == null || !SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString().equals(fieldType)) {
             throw new IllegalArgumentException("Cannot set an additional foreign key class when the field type is not ADDITIONAL_FOREIGN_KEY");
         }
-        
+
         this.fieldType = SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|' + className;
     }
 
     @Override
     public void setFieldType(SupportedFieldType fieldType) {
-        this.fieldType = fieldType!=null?fieldType.toString():null;
+        this.fieldType = fieldType != null ? fieldType.toString() : null;
     }
 
     @Override
@@ -264,7 +264,7 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     public void setTextAreaFlag(Boolean textAreaFlag) {
         this.textAreaFlag = textAreaFlag;
     }
-    
+
     @Override
     public Boolean getRequiredFlag() {
         return requiredFlag;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldDefinitionImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumeration;
@@ -45,6 +36,16 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -53,7 +54,8 @@ import org.hibernate.annotations.Parameter;
 @Table(name = "BLC_FLD_DEF")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE)
@@ -68,7 +70,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "FieldDefinitionImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldDefinitionImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.field.domain.FieldDefinitionImpl")
             }
     )
     @Column(name = "FLD_DEF_ID")
@@ -79,7 +82,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected String name;
 
     @Column(name = "FRIENDLY_NAME")
-    @AdminPresentation(friendlyName = "FieldDefinitionImpl_friendlyName", order = 2000, prominent = true, gridOrder = 2000)
+    @AdminPresentation(friendlyName = "FieldDefinitionImpl_friendlyName", order = 2000,
+            prominent = true, gridOrder = 2000)
     protected String friendlyName;
 
     @Column(name = "FLD_TYPE")
@@ -112,7 +116,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     protected Boolean textAreaFlag = false;
 
     @Column(name = "REQUIRED_FLAG")
-    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000, gridOrder = 4000, defaultValue = "false")
+    @AdminPresentation(friendlyName = "FieldDefinitionImpl_requiredFlag", order = 4000,
+            gridOrder = 4000, defaultValue = "false")
     protected Boolean requiredFlag = false;
 
     @ManyToOne(targetEntity = DataDrivenEnumerationImpl.class)
@@ -179,7 +184,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
 
     @Override
     public String getAdditionalForeignKeyClass() {
-        if (fieldType == null || !fieldType.startsWith(SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
+        if (fieldType == null || !fieldType.startsWith(
+                SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|')) {
             return null;
         }
 
@@ -188,8 +194,10 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
 
     @Override
     public void setAdditionalForeignKeyClass(String className) {
-        if (fieldType == null || !SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString().equals(fieldType)) {
-            throw new IllegalArgumentException("Cannot set an additional foreign key class when the field type is not ADDITIONAL_FOREIGN_KEY");
+        if (fieldType == null || !SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString()
+                .equals(fieldType)) {
+            throw new IllegalArgumentException(
+                    "Cannot set an additional foreign key class when the field type is not ADDITIONAL_FOREIGN_KEY");
         }
 
         this.fieldType = SupportedFieldType.ADDITIONAL_FOREIGN_KEY.toString() + '|' + className;
@@ -217,7 +225,7 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
 
     @Override
     public Boolean getHiddenFlag() {
-        return hiddenFlag == null ? false : hiddenFlag;
+        return hiddenFlag != null && hiddenFlag;
     }
 
     @Override
@@ -369,7 +377,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
     }
 
     @Override
-    public <G extends FieldDefinition> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+    public <G extends FieldDefinition> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context)
             throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -388,7 +397,8 @@ public class FieldDefinitionImpl implements FieldDefinition, ProfileEntity {
         cloned.setTextAreaFlag(textAreaFlag);
         cloned.setRequiredFlag(requiredFlag);
         if (dataDrivenEnumeration != null) {
-            cloned.setDataDrivenEnumeration(dataDrivenEnumeration.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setDataDrivenEnumeration(
+                    dataDrivenEnumeration.createOrRetrieveCopyInstance(context).getClone());
         }
         cloned.setAllowMultiples(allowMultiples);
         if (fieldGroup != null) {

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationImpl.java
@@ -10,22 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.field.domain;
-
-import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -37,15 +27,26 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.List;
 
 /**
  * Created by jfischer
+ *
  * @deprecated use {@link DataDrivenEnumerationImpl} instead
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FLD_ENUM")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @Deprecated
 public class FieldEnumerationImpl implements FieldEnumeration {
 
@@ -54,22 +55,22 @@ public class FieldEnumerationImpl implements FieldEnumeration {
     @Id
     @GeneratedValue(generator = "FieldEnumerationId")
     @GenericGenerator(
-        name="FieldEnumerationId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="FieldEnumerationImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.field.domain.FieldEnumerationImpl")
-        }
+            name = "FieldEnumerationId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FieldEnumerationImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationImpl")
+            }
     )
     @Column(name = "FLD_ENUM_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     protected String name;
 
     @OneToMany(mappedBy = "fieldEnumeration", targetEntity = FieldEnumerationItemImpl.class, cascade = {CascadeType.ALL})
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("fieldOrder")
     @BatchSize(size = 20)
     protected List<FieldEnumerationItem> enumerationItems;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.hibernate.annotations.BatchSize;
@@ -37,6 +27,17 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
 
 /**
  * Created by jfischer
@@ -59,7 +60,8 @@ public class FieldEnumerationImpl implements FieldEnumeration {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "FieldEnumerationImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationImpl")
             }
     )
     @Column(name = "FLD_ENUM_ID")
@@ -68,8 +70,10 @@ public class FieldEnumerationImpl implements FieldEnumeration {
     @Column(name = "NAME")
     protected String name;
 
-    @OneToMany(mappedBy = "fieldEnumeration", targetEntity = FieldEnumerationItemImpl.class, cascade = {CascadeType.ALL})
-    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @OneToMany(mappedBy = "fieldEnumeration", targetEntity = FieldEnumerationItemImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("fieldOrder")
     @BatchSize(size = 20)

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationItemImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationItemImpl.java
@@ -17,6 +17,13 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
+import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -26,12 +33,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 /**
  * Created by jfischer
@@ -54,7 +55,8 @@ public class FieldEnumerationItemImpl implements FieldEnumerationItem {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "FieldEnumerationItemImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationItemImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationItemImpl")
             }
     )
     @Column(name = "FLD_ENUM_ITEM_ID")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationItemImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldEnumerationItemImpl.java
@@ -10,18 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.field.domain;
-
-import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,16 +26,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by jfischer
+ *
  * @deprecated use {@link DataDrivenEnumerationValueImpl} instead
  */
 @Deprecated
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FLD_ENUM_ITEM")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 public class FieldEnumerationItemImpl implements FieldEnumerationItem {
 
     private static final long serialVersionUID = 1L;
@@ -49,23 +50,23 @@ public class FieldEnumerationItemImpl implements FieldEnumerationItem {
     @Id
     @GeneratedValue(generator = "FieldEnumerationItemId")
     @GenericGenerator(
-        name="FieldEnumerationItemId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="FieldEnumerationItemImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.field.domain.FieldEnumerationItemImpl")
-        }
+            name = "FieldEnumerationItemId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FieldEnumerationItemImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldEnumerationItemImpl")
+            }
     )
     @Column(name = "FLD_ENUM_ITEM_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     protected String name;
 
-    @Column (name = "FRIENDLY_NAME")
+    @Column(name = "FRIENDLY_NAME")
     protected String friendlyName;
 
-    @Column(name="FLD_ORDER")
+    @Column(name = "FLD_ORDER")
     protected int fieldOrder;
 
     @ManyToOne(targetEntity = FieldEnumerationImpl.class)

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.cms.field.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXref;
 import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -47,6 +37,17 @@ import org.hibernate.annotations.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -55,7 +56,8 @@ import java.util.List;
 @Table(name = "BLC_FLD_GROUP")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true)
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true)
 })
 public class FieldGroupImpl implements FieldGroup, ProfileEntity {
 
@@ -68,7 +70,8 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "FieldGroupImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldGroupImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.field.domain.FieldGroupImpl")
             }
     )
     @Column(name = "FLD_GROUP_ID")
@@ -80,7 +83,8 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Column(name = "INIT_COLLAPSED_FLAG")
     protected Boolean initCollapsedFlag = false;
 
-    @OneToMany(mappedBy = "fieldGroup", targetEntity = FieldDefinitionImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "fieldGroup", targetEntity = FieldDefinitionImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("fieldOrder")
     @BatchSize(size = 20)
@@ -91,12 +95,14 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Column(name = "IS_MASTER_FIELD_GROUP")
     protected Boolean isMasterFieldGroup = false;
 
-    @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "fieldGroup", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "fieldGroup",
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
     @ClonePolicyCollectionOverride
-    protected List<StructuredContentFieldGroupXref> fieldGroupXrefs = new ArrayList<StructuredContentFieldGroupXref>();
+    protected List<StructuredContentFieldGroupXref> fieldGroupXrefs =
+            new ArrayList<StructuredContentFieldGroupXref>();
 
     @Override
     public List<StructuredContentFieldGroupXref> getFieldGroupXrefs() {
@@ -149,7 +155,8 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     }
 
     @Override
-    public <G extends FieldGroup> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+    public <G extends FieldGroup> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context)
             throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -162,11 +169,13 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
         cloned.setInitCollapsedFlag(initCollapsedFlag);
 
         for (FieldDefinition fieldDefinition : fieldDefinitions) {
-            FieldDefinition clonedDef = fieldDefinition.createOrRetrieveCopyInstance(context).getClone();
+            FieldDefinition clonedDef =
+                    fieldDefinition.createOrRetrieveCopyInstance(context).getClone();
             cloned.getFieldDefinitions().add(clonedDef);
         }
         for (StructuredContentFieldGroupXref entry : fieldGroupXrefs) {
-            CreateResponse<StructuredContentFieldGroupXref> clonedDef = entry.createOrRetrieveCopyInstance(context);
+            CreateResponse<StructuredContentFieldGroupXref> clonedDef =
+                    entry.createOrRetrieveCopyInstance(context);
             clonedDef.getClone().setFieldGroup(cloned);
             cloned.getFieldGroupXrefs().add(clonedDef.getClone());
         }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/domain/FieldGroupImpl.java
@@ -10,31 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.field.domain;
-
-import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXref;
-import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyArchive;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyCollectionOverride;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -46,6 +27,25 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXref;
+import org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyArchive;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyCollectionOverride;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by bpolster.
@@ -53,7 +53,7 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_FLD_GROUP")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true)
 })
@@ -64,35 +64,35 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
     @Id
     @GeneratedValue(generator = "FieldGroupId")
     @GenericGenerator(
-        name="FieldGroupId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="FieldGroupImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.field.domain.FieldGroupImpl")
-        }
+            name = "FieldGroupId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FieldGroupImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.field.domain.FieldGroupImpl")
+            }
     )
     @Column(name = "FLD_GROUP_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     protected String name;
 
-    @Column (name = "INIT_COLLAPSED_FLAG")
+    @Column(name = "INIT_COLLAPSED_FLAG")
     protected Boolean initCollapsedFlag = false;
 
-    @OneToMany(mappedBy = "fieldGroup", targetEntity = FieldDefinitionImpl.class, cascade = { CascadeType.ALL })
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @OneToMany(mappedBy = "fieldGroup", targetEntity = FieldDefinitionImpl.class, cascade = {CascadeType.ALL})
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("fieldOrder")
     @BatchSize(size = 20)
     @ClonePolicyCollectionOverride
     @ClonePolicyArchive
     protected List<FieldDefinition> fieldDefinitions = new ArrayList<FieldDefinition>();
 
-    @Column (name = "IS_MASTER_FIELD_GROUP")
+    @Column(name = "IS_MASTER_FIELD_GROUP")
     protected Boolean isMasterFieldGroup = false;
 
     @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "fieldGroup", cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
     @ClonePolicyCollectionOverride
@@ -166,7 +166,7 @@ public class FieldGroupImpl implements FieldGroup, ProfileEntity {
             cloned.getFieldDefinitions().add(clonedDef);
         }
         for (StructuredContentFieldGroupXref entry : fieldGroupXrefs) {
-            CreateResponse<StructuredContentFieldGroupXref>  clonedDef = entry.createOrRetrieveCopyInstance(context);
+            CreateResponse<StructuredContentFieldGroupXref> clonedDef = entry.createOrRetrieveCopyInstance(context);
             clonedDef.getClone().setFieldGroup(cloned);
             cloned.getFieldGroupXrefs().add(clonedDef.getClone());
         }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/type/FieldType.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/type/FieldType.java
@@ -94,10 +94,8 @@ public class FieldType implements Serializable {
             return false;
         FieldType other = (FieldType) obj;
         if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/type/StorageType.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/field/type/StorageType.java
@@ -88,10 +88,8 @@ public class StorageType implements Serializable {
             return false;
         StorageType other = (StorageType) obj;
         if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/dao/StaticAssetDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/dao/StaticAssetDaoImpl.java
@@ -45,7 +45,7 @@ import jakarta.persistence.criteria.Root;
 @Repository("blStaticAssetDao")
 public class StaticAssetDaoImpl implements StaticAssetDao {
 
-    private static SandBox DUMMY_SANDBOX = new SandBoxImpl();
+    private static final SandBox DUMMY_SANDBOX = new SandBoxImpl();
     {
         DUMMY_SANDBOX.setId(-1l);
     }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/ImageStaticAssetImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/ImageStaticAssetImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -32,18 +32,18 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@EntityListeners(value = { AdminAuditableListener.class })
+@EntityListeners(value = {AdminAuditableListener.class})
 @Table(name = "BLC_IMG_STATIC_ASSET")
 public class ImageStaticAssetImpl extends StaticAssetImpl implements ImageStaticAsset {
 
-    @Column(name ="WIDTH")
+    @Column(name = "WIDTH")
     @AdminPresentation(friendlyName = "ImageStaticAssetImpl_Width",
             order = FieldOrder.LAST + 1000,
             group = GroupName.File_Details,
             readOnly = true)
     protected Integer width;
 
-    @Column(name ="HEIGHT")
+    @Column(name = "HEIGHT")
     @AdminPresentation(friendlyName = "ImageStaticAssetImpl_Height",
             order = FieldOrder.LAST + 2000,
             group = GroupName.File_Details,

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetDescriptionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetDescriptionImpl.java
@@ -10,25 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.file.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,6 +25,19 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by bpolster.
@@ -45,8 +45,8 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_STATIC_ASSET_DESC")
-@EntityListeners(value = { AdminAuditableListener.class })
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@EntityListeners(value = {AdminAuditableListener.class})
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
 })
@@ -57,21 +57,21 @@ public class StaticAssetDescriptionImpl implements StaticAssetDescription {
     @Id
     @GeneratedValue(generator = "StaticAssetDescriptionId")
     @GenericGenerator(
-        name="StaticAssetDescriptionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StaticAssetDescriptionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.file.domain.StaticAssetDescriptionImpl")
-        }
+            name = "StaticAssetDescriptionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StaticAssetDescriptionImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetDescriptionImpl")
+            }
     )
     @Column(name = "STATIC_ASSET_DESC_ID")
     protected Long id;
 
-    @Column (name = "DESCRIPTION")
+    @Column(name = "DESCRIPTION")
     @AdminPresentation(friendlyName = "StaticAssetDescriptionImpl_Description", prominent = true)
     protected String description;
 
-    @Column (name = "LONG_DESCRIPTION")
+    @Column(name = "LONG_DESCRIPTION")
     @AdminPresentation(friendlyName = "StaticAssetDescriptionImpl_Long_Description", largeEntry = true, visibility = VisibilityEnum.GRID_HIDDEN)
     protected String longDescription;
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetDescriptionImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetDescriptionImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.cms.file.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -38,6 +30,15 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 
 /**
  * Created by bpolster.
@@ -61,7 +62,8 @@ public class StaticAssetDescriptionImpl implements StaticAssetDescription {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StaticAssetDescriptionImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetDescriptionImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.file.domain.StaticAssetDescriptionImpl")
             }
     )
     @Column(name = "STATIC_ASSET_DESC_ID")
@@ -72,7 +74,8 @@ public class StaticAssetDescriptionImpl implements StaticAssetDescription {
     protected String description;
 
     @Column(name = "LONG_DESCRIPTION")
-    @AdminPresentation(friendlyName = "StaticAssetDescriptionImpl_Long_Description", largeEntry = true, visibility = VisibilityEnum.GRID_HIDDEN)
+    @AdminPresentation(friendlyName = "StaticAssetDescriptionImpl_Long_Description",
+            largeEntry = true, visibility = VisibilityEnum.GRID_HIDDEN)
     protected String longDescription;
 
     @Override
@@ -115,7 +118,8 @@ public class StaticAssetDescriptionImpl implements StaticAssetDescription {
     }
 
     @Override
-    public <G extends StaticAssetDescription> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StaticAssetDescription> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.cms.file.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.cms.field.type.StorageType;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -60,6 +47,20 @@ import org.hibernate.annotations.Parameter;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -71,45 +72,75 @@ import java.util.Map;
 @AdminPresentationMergeOverrides(value = {
         @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.dateCreated",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL"),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.GROUP,
+                                overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL"),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.GROUP,
+                                overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
                 }
         ),
         @AdminPresentationMergeOverride(name = "sandbox",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)
                 }
         )
 })
@@ -128,7 +159,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StaticAssetImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.file.domain.StaticAssetImpl")
             }
     )
     @Column(name = "STATIC_ASSET_ID")
@@ -194,7 +226,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
     @JoinTable(name = "BLC_ASSET_DESC_MAP", joinColumns = @JoinColumn(name = "STATIC_ASSET_ID"),
             inverseJoinColumns = @JoinColumn(name = "STATIC_ASSET_DESC_ID"))
     @MapKeyColumn(name = "MAP_KEY")
-    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @BatchSize(size = 20)
     @AdminPresentationMap(
@@ -206,7 +239,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
             mapKeyOptionEntityClass = LocaleImpl.class,
             mapKeyOptionEntityDisplayField = "friendlyName",
             mapKeyOptionEntityValueField = "localeCode")
-    protected Map<String, StaticAssetDescription> contentMessageValues = new HashMap<String, StaticAssetDescription>();
+    protected Map<String, StaticAssetDescription> contentMessageValues =
+            new HashMap<String, StaticAssetDescription>();
 
     @Column(name = "STORAGE_TYPE")
     @AdminPresentation(excluded = true)
@@ -318,7 +352,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
     }
 
     @Override
-    public <G extends StaticAsset> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StaticAsset> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -333,7 +368,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
         cloned.setTitle(title);
         cloned.setStorageType(getStorageType());
         for (Map.Entry<String, StaticAssetDescription> entry : contentMessageValues.entrySet()) {
-            CreateResponse<StaticAssetDescription> clonedDescRsp = entry.getValue().createOrRetrieveCopyInstance(context);
+            CreateResponse<StaticAssetDescription> clonedDescRsp =
+                    entry.getValue().createOrRetrieveCopyInstance(context);
             cloned.getContentMessageValues().put(entry.getKey(), clonedDescRsp.getClone());
         }
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetImpl.java
@@ -10,13 +10,26 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.file.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.cms.field.type.StorageType;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -26,6 +39,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.locale.domain.LocaleImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
@@ -46,72 +60,58 @@ import org.hibernate.annotations.Parameter;
 import java.util.HashMap;
 import java.util.Map;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.Table;
-
 /**
  * Created by bpolster.
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@EntityListeners(value = { AdminAuditableListener.class })
+@EntityListeners(value = {AdminAuditableListener.class})
 @Table(name = "BLC_STATIC_ASSET")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
-@AdminPresentationMergeOverrides(value = { 
-    @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.dateCreated",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "sandbox",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
-        }
-    )
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
+@AdminPresentationMergeOverrides(value = {
+        @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.dateCreated",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"),
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = StaticAssetAdminPresentation.GroupName.File_Details)
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "sandbox",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
+                }
+        )
 })
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
@@ -124,12 +124,12 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
     @Id
     @GeneratedValue(generator = "StaticAssetId")
     @GenericGenerator(
-        name="StaticAssetId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StaticAssetImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.file.domain.StaticAssetImpl")
-        }
+            name = "StaticAssetId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StaticAssetImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetImpl")
+            }
     )
     @Column(name = "STATIC_ASSET_ID")
     protected Long id;
@@ -144,7 +144,7 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
             prominent = true)
     protected String name;
 
-    @Column(name ="FULL_URL", nullable = false)
+    @Column(name = "FULL_URL", nullable = false)
     @AdminPresentation(friendlyName = "StaticAssetImpl_Full_URL",
             group = GroupName.Image,
             order = FieldOrder.URL,
@@ -152,7 +152,7 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
             requiredOverride = RequiredOverride.REQUIRED,
             fieldType = SupportedFieldType.ASSET_URL,
             prominent = true)
-    @Index(name="ASST_FULL_URL_INDX", columnNames={"FULL_URL"})
+    @Index(name = "ASST_FULL_URL_INDX", columnNames = {"FULL_URL"})
     protected String fullUrl;
 
     @Column(name = "TITLE", nullable = true)
@@ -194,8 +194,8 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
     @JoinTable(name = "BLC_ASSET_DESC_MAP", joinColumns = @JoinColumn(name = "STATIC_ASSET_ID"),
             inverseJoinColumns = @JoinColumn(name = "STATIC_ASSET_DESC_ID"))
     @MapKeyColumn(name = "MAP_KEY")
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @BatchSize(size = 20)
     @AdminPresentationMap(
             excluded = true,
@@ -206,7 +206,7 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
             mapKeyOptionEntityClass = LocaleImpl.class,
             mapKeyOptionEntityDisplayField = "friendlyName",
             mapKeyOptionEntityValueField = "localeCode")
-    protected Map<String,StaticAssetDescription> contentMessageValues = new HashMap<String,StaticAssetDescription>();
+    protected Map<String, StaticAssetDescription> contentMessageValues = new HashMap<String, StaticAssetDescription>();
 
     @Column(name = "STORAGE_TYPE")
     @AdminPresentation(excluded = true)
@@ -332,9 +332,9 @@ public class StaticAssetImpl implements StaticAsset, AdminMainEntity, StaticAsse
         cloned.setMimeType(mimeType);
         cloned.setTitle(title);
         cloned.setStorageType(getStorageType());
-        for(Map.Entry<String, StaticAssetDescription> entry : contentMessageValues.entrySet()){
+        for (Map.Entry<String, StaticAssetDescription> entry : contentMessageValues.entrySet()) {
             CreateResponse<StaticAssetDescription> clonedDescRsp = entry.getValue().createOrRetrieveCopyInstance(context);
-            cloned.getContentMessageValues().put(entry.getKey(),clonedDescRsp.getClone());
+            cloned.getContentMessageValues().put(entry.getKey(), clonedDescRsp.getClone());
         }
 
         return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetStorageImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetStorageImpl.java
@@ -17,6 +17,14 @@
  */
 package org.broadleafcommerce.cms.file.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
+import java.sql.Blob;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,13 +33,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
-import java.sql.Blob;
 
 /**
  * Created by jfischer
@@ -50,7 +51,8 @@ public class StaticAssetStorageImpl implements StaticAssetStorage {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StaticAssetStorageImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetStorageImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.file.domain.StaticAssetStorageImpl")
             }
     )
     @Column(name = "STATIC_ASSET_STRG_ID")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetStorageImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/domain/StaticAssetStorageImpl.java
@@ -10,19 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.file.domain;
-
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
-import java.sql.Blob;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,6 +25,13 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
+import java.sql.Blob;
 
 /**
  * Created by jfischer
@@ -46,22 +46,22 @@ public class StaticAssetStorageImpl implements StaticAssetStorage {
     @Id
     @GeneratedValue(generator = "StaticAssetStorageId")
     @GenericGenerator(
-        name="StaticAssetStorageId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StaticAssetStorageImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.file.domain.StaticAssetStorageImpl")
-        }
+            name = "StaticAssetStorageId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StaticAssetStorageImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.file.domain.StaticAssetStorageImpl")
+            }
     )
     @Column(name = "STATIC_ASSET_STRG_ID")
     protected Long id;
 
-    @Column(name ="STATIC_ASSET_ID", nullable = false)
-    @Index(name="STATIC_ASSET_ID_INDEX", columnNames={"STATIC_ASSET_ID"})
+    @Column(name = "STATIC_ASSET_ID", nullable = false)
+    @Index(name = "STATIC_ASSET_ID_INDEX", columnNames = {"STATIC_ASSET_ID"})
     protected Long staticAssetId;
 
     @Lob
-    @Column (name = "FILE_DATA", length = Length.LONG32 - 1)
+    @Column(name = "FILE_DATA", length = Length.LONG32 - 1)
     protected Blob fileData;
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
@@ -118,7 +118,7 @@ public class StaticAssetServiceImpl implements StaticAssetService {
     protected String getFileExtension(String fileName) {
         int pos = fileName.lastIndexOf(".");
         if (pos > 0) {
-            return fileName.substring(pos + 1, fileName.length()).toLowerCase();
+            return fileName.substring(pos + 1).toLowerCase();
         } else {
             LOG.warn("No extension provided for asset : " + StringUtil.sanitize(fileName));
             return null;
@@ -184,7 +184,7 @@ public class StaticAssetServiceImpl implements StaticAssetService {
 
     private static String normalizeFileExtension(MultipartFile file) {
         int index = file.getOriginalFilename().lastIndexOf(".");
-        return file.getOriginalFilename().substring(0, index + 1) + file.getOriginalFilename().substring(index + 1, file.getOriginalFilename().length()).toLowerCase();
+        return file.getOriginalFilename().substring(0, index + 1) + file.getOriginalFilename().substring(index + 1).toLowerCase();
     }
 
     private static String getFileExtension(MultipartFile file) {

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetStorageServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetStorageServiceImpl.java
@@ -377,7 +377,7 @@ public class StaticAssetStorageServiceImpl implements StaticAssetStorageService 
         String fileName = staticAsset.getFullUrl();
 
         StringBuilder sb = new StringBuilder(200);
-        sb.append(fileName.substring(0, fileName.lastIndexOf('.')));
+        sb.append(fileName, 0, fileName.lastIndexOf('.'));
         sb.append("---");
 
         StringBuilder sb2 = new StringBuilder(200);

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/dao/PageDaoImpl.java
@@ -58,7 +58,7 @@ import jakarta.persistence.criteria.Root;
 @Repository("blPageDao")
 public class PageDaoImpl implements PageDao {
 
-    private static SandBox DUMMY_SANDBOX = new SandBoxImpl();
+    private static final SandBox DUMMY_SANDBOX = new SandBoxImpl();
 
     {
         DUMMY_SANDBOX.setId(-1l);

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
@@ -10,25 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -41,6 +28,19 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -55,20 +55,20 @@ import jakarta.persistence.Table;
 public class PageAttributeImpl implements PageAttribute, ProfileEntity {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Id
-    @GeneratedValue(generator= "PageAttributeId")
+    @GeneratedValue(generator = "PageAttributeId")
     @GenericGenerator(
-        name="PageAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PageAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageAttributeImpl")
-        }
+            name = "PageAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PageAttributeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageAttributeImpl")
+            }
     )
     @Column(name = "ATTRIBUTE_ID")
     protected Long id;
-    
+
     @Column(name = "FIELD_NAME", nullable = false)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String name;
@@ -79,7 +79,7 @@ public class PageAttributeImpl implements PageAttribute, ProfileEntity {
     @ManyToOne(targetEntity = PageImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PAGE_ID")
     protected Page page;
-    
+
     @Override
     public Long getId() {
         return id;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageAttributeImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -42,6 +31,18 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE_ATTRIBUTES", indexes = {
@@ -49,7 +50,8 @@ import org.hibernate.annotations.Parameter;
         @Index(name = "PAGEATTRIBUTE_INDEX", columnList = "PAGE_ID")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageAttributeImpl implements PageAttribute, ProfileEntity {
@@ -63,7 +65,8 @@ public class PageAttributeImpl implements PageAttribute, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageAttributeImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageAttributeImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageAttributeImpl")
             }
     )
     @Column(name = "ATTRIBUTE_ID")
@@ -160,15 +163,14 @@ public class PageAttributeImpl implements PageAttribute, ProfileEntity {
         } else if (!page.equals(other.page))
             return false;
         if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+            return other.value == null;
+        } else
+            return value.equals(other.value);
     }
 
     @Override
-    public <G extends PageAttribute> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageAttribute> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageFieldImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageFieldImpl.java
@@ -10,25 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -42,6 +29,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by bpolster.
@@ -49,10 +49,10 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE_FLD")
-@EntityListeners(value = { AdminAuditableListener.class })
+@EntityListeners(value = {AdminAuditableListener.class})
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
 
 })
@@ -63,21 +63,21 @@ public class PageFieldImpl implements PageField, ProfileEntity {
     @Id
     @GeneratedValue(generator = "PageFieldId")
     @GenericGenerator(
-        name="PageFieldId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PageFieldImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageFieldImpl")
-        }
+            name = "PageFieldId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PageFieldImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageFieldImpl")
+            }
     )
     @Column(name = "PAGE_FLD_ID")
     protected Long id;
 
-    @Column (name = "FLD_KEY")
+    @Column(name = "FLD_KEY")
     @AdminPresentation
     protected String fieldKey;
 
-    @Column (name = "VALUE")
+    @Column(name = "VALUE")
     @AdminPresentation
     protected String stringValue;
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageFieldImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageFieldImpl.java
@@ -17,18 +17,6 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -43,6 +31,19 @@ import org.hibernate.Length;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -51,8 +52,10 @@ import org.hibernate.annotations.Parameter;
 @Table(name = "BLC_PAGE_FLD")
 @EntityListeners(value = {AdminAuditableListener.class})
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
 
 })
@@ -67,7 +70,8 @@ public class PageFieldImpl implements PageField, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageFieldImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageFieldImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageFieldImpl")
             }
     )
     @Column(name = "PAGE_FLD_ID")
@@ -113,7 +117,8 @@ public class PageFieldImpl implements PageField, ProfileEntity {
     @Override
     public String getValue() {
         if (stringValue != null && stringValue.length() > 0) {
-            return DynamicTranslationProvider.getValue(page, "pageTemplate|" + fieldKey, stringValue);
+            return DynamicTranslationProvider.getValue(page, "pageTemplate|" + fieldKey,
+                    stringValue);
         } else {
             return DynamicTranslationProvider.getValue(page, "pageTemplate|" + fieldKey, lobValue);
         }
@@ -146,7 +151,8 @@ public class PageFieldImpl implements PageField, ProfileEntity {
     }
 
     @Override
-    public <G extends PageField> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageField> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
 
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageImpl.java
@@ -10,30 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -68,73 +51,123 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE")
-@EntityListeners(value = { AdminAuditableListener.class })
-@AdminPresentationMergeOverrides(value = { 
-    @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.dateCreated",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "pageTemplate.templateDescription",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "pageTemplate.templateName",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
-        }
-    ),
-    @AdminPresentationMergeOverride(name = "pageTemplate.locale",
-        mergeEntries = { 
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)
-        }
-    )
+@EntityListeners(value = {AdminAuditableListener.class})
+@AdminPresentationMergeOverrides(value = {
+        @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.dateCreated",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "pageTemplate.templateDescription",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "pageTemplate.templateName",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)
+                }
+        ),
+        @AdminPresentationMergeOverride(name = "pageTemplate.locale",
+                mergeEntries = {
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)
+                }
+        )
 })
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
 })
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
-public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity, PageAdminPresentation {
+public class PageImpl
+        implements Page, AdminMainEntity, Locatable, ProfileEntity, PageAdminPresentation {
 
     private static final long serialVersionUID = 1L;
 
@@ -143,44 +176,49 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
     @Id
     @GeneratedValue(generator = "PageId")
     @GenericGenerator(
-            name="PageId",
+            name = "PageId",
             type = IdOverrideTableGenerator.class,
             parameters = {
-                @Parameter(name="segment_value", value="PageImpl"),
-                @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageImpl")
+                    @Parameter(name = "segment_value", value = "PageImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageImpl")
             }
-        )
+    )
     @Column(name = "PAGE_ID")
     protected Long id;
 
     @ManyToOne(targetEntity = PageTemplateImpl.class)
     @JoinColumn(name = "PAGE_TMPLT_ID")
     @AdminPresentation(friendlyName = "PageImpl_Page_Template", order = 4000,
-        group = PageAdminPresentation.GroupName.Misc, groupOrder = PageAdminPresentation.GroupOrder.Misc, prominent = true,
-        requiredOverride = RequiredOverride.REQUIRED)
+            group = PageAdminPresentation.GroupName.Misc,
+            groupOrder = PageAdminPresentation.GroupOrder.Misc, prominent = true,
+            requiredOverride = RequiredOverride.REQUIRED)
     @AdminPresentationToOneLookup(lookupDisplayProperty = "templateName")
     protected PageTemplate pageTemplate;
 
-    @Column (name = "DESCRIPTION")
+    @Column(name = "DESCRIPTION")
     @AdminPresentation(friendlyName = "PageImpl_Description", order = 1000,
-        group = PageAdminPresentation.GroupName.Basic, groupOrder = PageAdminPresentation.GroupOrder.Basic,
+            group = PageAdminPresentation.GroupName.Basic,
+            groupOrder = PageAdminPresentation.GroupOrder.Basic,
             requiredOverride = RequiredOverride.REQUIRED,
-        prominent = true, gridOrder = 1)
+            prominent = true, gridOrder = 1)
     protected String description;
 
-    @Column (name = "FULL_URL")
-    @Index(name="PAGE_FULL_URL_INDEX", columnNames={"FULL_URL"})
+    @Column(name = "FULL_URL")
+    @Index(name = "PAGE_FULL_URL_INDEX", columnNames = {"FULL_URL"})
     @AdminPresentation(friendlyName = "PageImpl_Full_Url", order = 3000,
-        group = PageAdminPresentation.GroupName.Basic, groupOrder = PageAdminPresentation.GroupOrder.Basic,
-        prominent = true, gridOrder = 2,
-        validationConfigurations = { @ValidationConfiguration(validationImplementation = "blUriPropertyValidator") })
+            group = PageAdminPresentation.GroupName.Basic,
+            groupOrder = PageAdminPresentation.GroupOrder.Basic,
+            prominent = true, gridOrder = 2,
+            validationConfigurations = {
+                    @ValidationConfiguration(validationImplementation = "blUriPropertyValidator")})
     protected String fullUrl;
 
-    @OneToMany(mappedBy = "page", targetEntity = PageFieldImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "page", targetEntity = PageFieldImpl.class, cascade = {CascadeType.ALL})
     @MapKey(name = "fieldKey")
     @BatchSize(size = 20)
     @AdminPresentationMap(forceFreeFormKeys = true, friendlyName = "pageFields")
-    protected Map<String,PageField> pageFields = new HashMap<String,PageField>();
+    protected Map<String, PageField> pageFields = new HashMap<String, PageField>();
 
     @Column(name = "PRIORITY")
     @Deprecated
@@ -188,17 +226,19 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
 
     @Column(name = "OFFLINE_FLAG")
     @AdminPresentation(friendlyName = "PageImpl_Offline", order = 3500,
-        group = GroupName.Misc, defaultValue = "false")
+            group = GroupName.Misc, defaultValue = "false")
     protected Boolean offlineFlag = false;
 
     /*
      * This will not work with Enterprise workflows.  Do not use.
      */
     @ManyToMany(targetEntity = PageRuleImpl.class, cascade = {CascadeType.ALL})
-    @JoinTable(name = "BLC_PAGE_RULE_MAP", 
-               joinColumns = @JoinColumn(name = "BLC_PAGE_PAGE_ID", referencedColumnName = "PAGE_ID"), 
-               inverseJoinColumns = @JoinColumn(name = "PAGE_RULE_ID", referencedColumnName = "PAGE_RULE_ID"))
-    @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
+    @JoinTable(name = "BLC_PAGE_RULE_MAP",
+            joinColumns = @JoinColumn(name = "BLC_PAGE_PAGE_ID", referencedColumnName = "PAGE_ID"),
+            inverseJoinColumns = @JoinColumn(name = "PAGE_RULE_ID",
+                    referencedColumnName = "PAGE_RULE_ID"))
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @MapKeyColumn(name = "MAP_KEY", nullable = false)
     @Deprecated
     protected Map<String, PageRule> pageMatchRules = new HashMap<String, PageRule>();
@@ -206,47 +246,53 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
     /*
      * This will not work with Enterprise workflows. Do not use.
      */
-    @OneToMany(fetch = FetchType.LAZY, targetEntity = PageItemCriteriaImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(fetch = FetchType.LAZY, targetEntity = PageItemCriteriaImpl.class,
+            cascade = {CascadeType.ALL})
     @JoinTable(name = "BLC_QUAL_CRIT_PAGE_XREF",
-        joinColumns = @JoinColumn(name = "PAGE_ID"),
-        inverseJoinColumns = @JoinColumn(name = "PAGE_ITEM_CRITERIA_ID"))
+            joinColumns = @JoinColumn(name = "PAGE_ID"),
+            inverseJoinColumns = @JoinColumn(name = "PAGE_ITEM_CRITERIA_ID"))
     @Deprecated
     @IgnoreEnterpriseBehavior
     protected Set<PageItemCriteria> qualifyingItemCriteria = new HashSet<PageItemCriteria>();
 
     @Column(name = "EXCLUDE_FROM_SITE_MAP")
     @AdminPresentation(friendlyName = "PageImpl_Exclude_From_Site_Map", order = 1800,
-        tab = TabName.Seo, group = GroupName.Sitemap, defaultValue = "false")
+            tab = TabName.Seo, group = GroupName.Sitemap, defaultValue = "false")
     protected Boolean excludeFromSiteMap = false;
 
-    @OneToMany(mappedBy = "page", targetEntity = PageAttributeImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "page", targetEntity = PageAttributeImpl.class,
+            cascade = {CascadeType.ALL})
     @MapKey(name = "name")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "PageImpl_Page_Attributes_Title",
-        deleteEntityUponRemove = true, forceFreeFormKeys = true, keyPropertyFriendlyName = "PageAttributeImpl_Name"
+            deleteEntityUponRemove = true, forceFreeFormKeys = true,
+            keyPropertyFriendlyName = "PageAttributeImpl_Name"
     )
-    protected Map<String, PageAttribute> additionalAttributes = new HashMap<String, PageAttribute>();
+    protected Map<String, PageAttribute> additionalAttributes =
+            new HashMap<String, PageAttribute>();
 
     @Column(name = "ACTIVE_START_DATE")
     @AdminPresentation(friendlyName = "PageImpl_activeStartDate", order = 5000,
-        group = PageAdminPresentation.GroupName.Basic, groupOrder = PageAdminPresentation.GroupOrder.Basic,
-        excluded = true)
+            group = PageAdminPresentation.GroupName.Basic,
+            groupOrder = PageAdminPresentation.GroupOrder.Basic,
+            excluded = true)
     protected Date activeStartDate;
 
     @Column(name = "ACTIVE_END_DATE")
     @AdminPresentation(friendlyName = "PageImpl_activeEndDate", order = 6000,
-        group = PageAdminPresentation.GroupName.Basic, groupOrder = PageAdminPresentation.GroupOrder.Basic,
-        excluded = true)
+            group = PageAdminPresentation.GroupName.Basic,
+            groupOrder = PageAdminPresentation.GroupOrder.Basic,
+            excluded = true)
     protected Date activeEndDate;
 
-    @Column (name = "META_TITLE")
+    @Column(name = "META_TITLE")
     @AdminPresentation(friendlyName = "PageImpl_metaTitle", order = 2000,
-        tab = TabName.Seo, group = GroupName.Tags, largeEntry = true)
+            tab = TabName.Seo, group = GroupName.Tags, largeEntry = true)
     protected String metaTitle;
 
-    @Column (name = "META_DESCRIPTION")
+    @Column(name = "META_DESCRIPTION")
     @AdminPresentation(friendlyName = "PageImpl_metaDescription", order = 3000,
-        tab = TabName.Seo, group = GroupName.Tags, largeEntry = true)
+            tab = TabName.Seo, group = GroupName.Tags, largeEntry = true)
     protected String metaDescription;
 
     @Override
@@ -301,12 +347,12 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
 
     @Override
     public Boolean getOfflineFlag() {
-        return offlineFlag == null ? false : offlineFlag;
+        return offlineFlag != null && offlineFlag;
     }
 
     @Override
     public void setOfflineFlag(Boolean offlineFlag) {
-        this.offlineFlag = offlineFlag == null ? false : offlineFlag;
+        this.offlineFlag = offlineFlag != null && offlineFlag;
     }
 
     @Override
@@ -356,7 +402,8 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
     }
 
     @Override
-    public <G extends Page> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Page> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -372,18 +419,21 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
         cloned.setMetaDescription(metaDescription);
         cloned.setOfflineFlag(offlineFlag);
         cloned.setMetaTitle(metaTitle);
-        for(Map.Entry<String, PageField> entry : pageFields.entrySet()){
-            CreateResponse<PageField> clonedPageField = entry.getValue().createOrRetrieveCopyInstance(context);
+        for (Map.Entry<String, PageField> entry : pageFields.entrySet()) {
+            CreateResponse<PageField> clonedPageField =
+                    entry.getValue().createOrRetrieveCopyInstance(context);
             PageField pageField = clonedPageField.getClone();
-            cloned.getPageFields().put(entry.getKey(),pageField);
+            cloned.getPageFields().put(entry.getKey(), pageField);
         }
-        for(Map.Entry<String,PageRule> entry : pageMatchRules.entrySet()){
-            CreateResponse<PageRule> clonedRsp = entry.getValue().createOrRetrieveCopyInstance(context);
+        for (Map.Entry<String, PageRule> entry : pageMatchRules.entrySet()) {
+            CreateResponse<PageRule> clonedRsp =
+                    entry.getValue().createOrRetrieveCopyInstance(context);
             PageRule clonedRule = clonedRsp.getClone();
-            cloned.getPageMatchRules().put(entry.getKey(),clonedRule);
+            cloned.getPageMatchRules().put(entry.getKey(), clonedRule);
         }
-        if (pageTemplate != null){
-            CreateResponse<PageTemplate> clonedTemplateRsp = pageTemplate.createOrRetrieveCopyInstance(context);
+        if (pageTemplate != null) {
+            CreateResponse<PageTemplate> clonedTemplateRsp =
+                    pageTemplate.createOrRetrieveCopyInstance(context);
             cloned.setPageTemplate(clonedTemplateRsp.getClone());
         }
         return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageImpl.java
@@ -17,6 +17,23 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -25,6 +42,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -49,24 +67,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 /**
  * Created by bpolster.
@@ -144,7 +144,7 @@ public class PageImpl implements Page, AdminMainEntity, Locatable, ProfileEntity
     @GeneratedValue(generator = "PageId")
     @GenericGenerator(
             name="PageId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                 @Parameter(name="segment_value", value="PageImpl"),
                 @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageImpl")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageItemCriteriaImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageItemCriteriaImpl.java
@@ -10,25 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,51 +28,62 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
- * 
  * @author bpolster
- *
  */
 @Entity
 @Table(name = "BLC_PAGE_ITEM_CRITERIA")
-@Inheritance(strategy=InheritanceType.JOINED)
+@Inheritance(strategy = InheritanceType.JOINED)
 @AdminPresentationClass(friendlyName = "PageItemCriteriaImpl_basePageItemCriteria")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
-    
+
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "PageItemCriteriaId")
+    @GeneratedValue(generator = "PageItemCriteriaId")
     @GenericGenerator(
-        name="PageItemCriteriaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PageItemCriteriaImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageItemCriteriaImpl")
-        }
+            name = "PageItemCriteriaId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PageItemCriteriaImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageItemCriteriaImpl")
+            }
     )
     @Column(name = "PAGE_ITEM_CRITERIA_ID")
-    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Item_Criteria_Id", group = "PageItemCriteriaImpl_Description", visibility =VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Item_Criteria_Id", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
-    @Column(name = "QUANTITY", nullable=false)
-    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Quantity", group = "PageItemCriteriaImpl_Description", visibility =VisibilityEnum.HIDDEN_ALL)
+
+    @Column(name = "QUANTITY", nullable = false)
+    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Quantity", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Integer quantity;
-    
+
     @Lob
     @Column(name = "ORDER_ITEM_MATCH_RULE", length = Length.LONG32 - 1)
     @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Order_Item_Match_Rule", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String orderItemMatchRule;
-    
+
     @ManyToOne(targetEntity = PageImpl.class)
     @JoinTable(name = "BLC_QUAL_CRIT_PAGE_XREF", joinColumns = @JoinColumn(name = "PAGE_ITEM_CRITERIA_ID"), inverseJoinColumns = @JoinColumn(name = "PAGE_ID"))
     protected Page page;
-    
+
     @Override
     public Long getId() {
         return id;
@@ -145,11 +143,11 @@ public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
         if (!getClass().isAssignableFrom(obj.getClass()))
             return false;
         PageItemCriteriaImpl other = (PageItemCriteriaImpl) obj;
-        
+
         if (id != null && other.id != null) {
             return id.equals(other.id);
         }
-        
+
         if (orderItemMatchRule == null) {
             if (other.orderItemMatchRule != null)
                 return false;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageItemCriteriaImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageItemCriteriaImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -42,6 +31,18 @@ import org.hibernate.Length;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author bpolster
  */
@@ -50,7 +51,8 @@ import org.hibernate.annotations.Parameter;
 @Inheritance(strategy = InheritanceType.JOINED)
 @AdminPresentationClass(friendlyName = "PageItemCriteriaImpl_basePageItemCriteria")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
@@ -64,24 +66,30 @@ public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageItemCriteriaImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageItemCriteriaImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageItemCriteriaImpl")
             }
     )
     @Column(name = "PAGE_ITEM_CRITERIA_ID")
-    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Item_Criteria_Id", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Item_Criteria_Id",
+            group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "QUANTITY", nullable = false)
-    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Quantity", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Quantity",
+            group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Integer quantity;
 
     @Lob
     @Column(name = "ORDER_ITEM_MATCH_RULE", length = Length.LONG32 - 1)
-    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Order_Item_Match_Rule", group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "PageItemCriteriaImpl_Order_Item_Match_Rule",
+            group = "PageItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String orderItemMatchRule;
 
     @ManyToOne(targetEntity = PageImpl.class)
-    @JoinTable(name = "BLC_QUAL_CRIT_PAGE_XREF", joinColumns = @JoinColumn(name = "PAGE_ITEM_CRITERIA_ID"), inverseJoinColumns = @JoinColumn(name = "PAGE_ID"))
+    @JoinTable(name = "BLC_QUAL_CRIT_PAGE_XREF",
+            joinColumns = @JoinColumn(name = "PAGE_ITEM_CRITERIA_ID"),
+            inverseJoinColumns = @JoinColumn(name = "PAGE_ID"))
     protected Page page;
 
     @Override
@@ -129,7 +137,8 @@ public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((orderItemMatchRule == null) ? 0 : orderItemMatchRule.hashCode());
+        result =
+                prime * result + ((orderItemMatchRule == null) ? 0 : orderItemMatchRule.hashCode());
         result = prime * result + ((quantity == null) ? 0 : quantity.hashCode());
         return result;
     }
@@ -154,11 +163,9 @@ public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
         } else if (!orderItemMatchRule.equals(other.orderItemMatchRule))
             return false;
         if (quantity == null) {
-            if (other.quantity != null)
-                return false;
-        } else if (!quantity.equals(other.quantity))
-            return false;
-        return true;
+            return other.quantity == null;
+        } else
+            return quantity.equals(other.quantity);
     }
 
     @Override
@@ -171,7 +178,8 @@ public class PageItemCriteriaImpl implements PageItemCriteria, ProfileEntity {
     }
 
     @Override
-    public <G extends PageItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageRuleImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageRuleImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -36,6 +28,15 @@ import org.hibernate.Length;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
 /**
  * @author bpolster
  */
@@ -43,7 +44,8 @@ import org.hibernate.annotations.Parameter;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE_RULE")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageRuleImpl implements PageRule, ProfileEntity {
@@ -57,7 +59,8 @@ public class PageRuleImpl implements PageRule, ProfileEntity {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageRuleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageRuleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageRuleImpl")
             }
     )
     @Column(name = "PAGE_RULE_ID")
@@ -111,11 +114,9 @@ public class PageRuleImpl implements PageRule, ProfileEntity {
         }
 
         if (matchRule == null) {
-            if (other.matchRule != null)
-                return false;
-        } else if (!matchRule.equals(other.matchRule))
-            return false;
-        return true;
+            return other.matchRule == null;
+        } else
+            return matchRule.equals(other.matchRule);
     }
 
     @Override
@@ -127,7 +128,8 @@ public class PageRuleImpl implements PageRule, ProfileEntity {
     }
 
     @Override
-    public <G extends PageRule> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageRule> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageRuleImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageRuleImpl.java
@@ -10,22 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,11 +25,19 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
- * 
  * @author bpolster
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -53,18 +51,18 @@ public class PageRuleImpl implements PageRule, ProfileEntity {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "PageRuleId")
+    @GeneratedValue(generator = "PageRuleId")
     @GenericGenerator(
-        name="PageRuleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PageRuleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageRuleImpl")
-        }
+            name = "PageRuleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PageRuleImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageRuleImpl")
+            }
     )
     @Column(name = "PAGE_RULE_ID")
     protected Long id;
-    
+
     @Lob
     @Column(name = "MATCH_RULE", length = Length.LONG32 - 1)
     protected String matchRule;
@@ -107,11 +105,11 @@ public class PageRuleImpl implements PageRule, ProfileEntity {
         if (!getClass().isAssignableFrom(obj.getClass()))
             return false;
         PageRuleImpl other = (PageRuleImpl) obj;
-        
+
         if (id != null && other.id != null) {
             return id.equals(other.id);
         }
-        
+
         if (matchRule == null) {
             if (other.matchRule != null)
                 return false;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateFieldGroupXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateFieldGroupXrefImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -51,7 +51,8 @@ import jakarta.persistence.Table;
 @Table(name = "BLC_PGTMPLT_FLDGRP_XREF")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageTemplateFieldGroupXrefImpl implements PageTemplateFieldGroupXref, ProfileEntity {
@@ -65,7 +66,8 @@ public class PageTemplateFieldGroupXrefImpl implements PageTemplateFieldGroupXre
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "PageTemplateFieldGroupXrefImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageTemplateFieldGroupXrefImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageTemplateFieldGroupXrefImpl")
             })
     @Column(name = "PG_TMPLT_FLD_GRP_ID")
     protected Long id;
@@ -75,7 +77,7 @@ public class PageTemplateFieldGroupXrefImpl implements PageTemplateFieldGroupXre
     @AdminPresentation(excluded = true)
     protected PageTemplate pageTemplate;
 
-    @ManyToOne(targetEntity = FieldGroupImpl.class, cascade = { CascadeType.ALL })
+    @ManyToOne(targetEntity = FieldGroupImpl.class, cascade = {CascadeType.ALL})
     @JoinColumn(name = "FLD_GROUP_ID")
     @ClonePolicy
     protected FieldGroup fieldGroup;
@@ -134,7 +136,8 @@ public class PageTemplateFieldGroupXrefImpl implements PageTemplateFieldGroupXre
     }
 
     @Override
-    public <G extends PageTemplateFieldGroupXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageTemplateFieldGroupXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateImpl.java
@@ -10,39 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.page.domain;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.cms.field.domain.FieldGroup;
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyCollectionOverride;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.locale.domain.Locale;
-import org.broadleafcommerce.common.locale.domain.LocaleImpl;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -57,6 +30,33 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.cms.field.domain.FieldGroup;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicyCollectionOverride;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.locale.domain.Locale;
+import org.broadleafcommerce.common.locale.domain.LocaleImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Created by bpolster.
@@ -64,7 +64,7 @@ import jakarta.persistence.Transient;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE_TMPLT")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "PageTemplateImpl_basePageTemplate")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
@@ -78,31 +78,31 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
     @Id
     @GeneratedValue(generator = "PageTemplateId")
     @GenericGenerator(
-        name="PageTemplateId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PageTemplateImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.PageTemplateImpl")
-        }
+            name = "PageTemplateId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PageTemplateImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageTemplateImpl")
+            }
     )
     @Column(name = "PAGE_TMPLT_ID")
-    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Id", 
-        visibility = VisibilityEnum.HIDDEN_ALL, 
-        readOnly = true)
+    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Id",
+            visibility = VisibilityEnum.HIDDEN_ALL,
+            readOnly = true)
     protected Long id;
 
-    @Column (name = "TMPLT_NAME")
-    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Name", 
-        prominent = true, gridOrder = 1)
+    @Column(name = "TMPLT_NAME")
+    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Name",
+            prominent = true, gridOrder = 1)
     protected String templateName;
 
-    @Column (name = "TMPLT_DESCR")
+    @Column(name = "TMPLT_DESCR")
     protected String templateDescription;
 
-    @Column (name = "TMPLT_PATH")
-    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Path", 
-        visibility = VisibilityEnum.HIDDEN_ALL, 
-        readOnly = true)
+    @Column(name = "TMPLT_PATH")
+    @AdminPresentation(friendlyName = "PageTemplateImpl_Template_Path",
+            visibility = VisibilityEnum.HIDDEN_ALL,
+            readOnly = true)
     protected String templatePath;
 
     @ManyToOne(targetEntity = LocaleImpl.class)
@@ -111,8 +111,8 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
     @Deprecated
     protected Locale locale;
 
-    @OneToMany(targetEntity = PageTemplateFieldGroupXrefImpl.class, cascade = { CascadeType.ALL }, mappedBy = "pageTemplate")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @OneToMany(targetEntity = PageTemplateFieldGroupXrefImpl.class, cascade = {CascadeType.ALL}, mappedBy = "pageTemplate")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
     @ClonePolicyCollectionOverride

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.cms.page.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;
@@ -58,6 +45,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * Created by bpolster.
  */
@@ -65,9 +66,11 @@ import java.util.List;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PAGE_TMPLT")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "PageTemplateImpl_basePageTemplate")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "PageTemplateImpl_basePageTemplate")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileEntity {
@@ -82,7 +85,8 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageTemplateImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.PageTemplateImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.PageTemplateImpl")
             }
     )
     @Column(name = "PAGE_TMPLT_ID")
@@ -111,12 +115,14 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
     @Deprecated
     protected Locale locale;
 
-    @OneToMany(targetEntity = PageTemplateFieldGroupXrefImpl.class, cascade = {CascadeType.ALL}, mappedBy = "pageTemplate")
+    @OneToMany(targetEntity = PageTemplateFieldGroupXrefImpl.class, cascade = {CascadeType.ALL},
+            mappedBy = "pageTemplate")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
     @ClonePolicyCollectionOverride
-    protected List<PageTemplateFieldGroupXref> fieldGroups = new ArrayList<PageTemplateFieldGroupXref>();
+    protected List<PageTemplateFieldGroupXref> fieldGroups =
+            new ArrayList<PageTemplateFieldGroupXref>();
 
     @Transient
     protected List<FieldGroup> legacyFieldGroups = new ArrayList<FieldGroup>();
@@ -208,7 +214,8 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
     }
 
     @Override
-    public <G extends PageTemplate> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PageTemplate> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -219,7 +226,8 @@ public class PageTemplateImpl implements PageTemplate, AdminMainEntity, ProfileE
         cloned.setTemplatePath(templatePath);
         cloned.setLocale(locale);
         for (PageTemplateFieldGroupXref fieldGroup : fieldGroups) {
-            CreateResponse<PageTemplateFieldGroupXref> clonedGroupResponse = fieldGroup.createOrRetrieveCopyInstance(context);
+            CreateResponse<PageTemplateFieldGroupXref> clonedGroupResponse =
+                    fieldGroup.createOrRetrieveCopyInstance(context);
             PageTemplateFieldGroupXref clonedGroup = clonedGroupResponse.getClone();
             cloned.getFieldGroupXrefs().add(clonedGroup);
         }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/type/PageRuleType.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/type/PageRuleType.java
@@ -117,13 +117,9 @@ public class PageRuleType implements Serializable, BroadleafEnumerationType {
         }
         PageRuleType other = (PageRuleType) obj;
         if (type == null) {
-            if (other.type != null) {
-                return false;
-            }
-        } else if (!type.equals(other.type)) {
-            return false;
-        }
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/dao/StructuredContentDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/dao/StructuredContentDaoImpl.java
@@ -47,7 +47,7 @@ import jakarta.persistence.criteria.Root;
 @Repository("blStructuredContentDao")
 public class StructuredContentDaoImpl implements StructuredContentDao {
 
-    private static SandBox DUMMY_SANDBOX = new SandBoxImpl();
+    private static final SandBox DUMMY_SANDBOX = new SandBoxImpl();
     {
         DUMMY_SANDBOX.setId(-1l);
     }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
@@ -10,21 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
-
-import org.broadleafcommerce.cms.field.domain.FieldGroup;
-import org.broadleafcommerce.cms.field.domain.FieldGroupImpl;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,16 +26,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.cms.field.domain.FieldGroup;
+import org.broadleafcommerce.cms.field.domain.FieldGroupImpl;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
- * 
- * 
  * @author Phillip Verheyden (phillipuniverse)
  */
 @Entity
 @Table(name = "BLC_SC_FLDGRP_XREF")
 @Inheritance(strategy = InheritanceType.JOINED)
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 public class StructuredContentFieldGroupXrefImpl implements StructuredContentFieldGroupXref {
 
     private static final long serialVersionUID = 1L;
@@ -52,23 +50,23 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
     @Id
     @GeneratedValue(generator = "StructuredContentFieldGroupXrefId")
     @GenericGenerator(
-        name="StructuredContentFieldGroupXrefId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentFieldGroupXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl")
-        }
+            name = "StructuredContentFieldGroupXrefId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentFieldGroupXrefImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl")
+            }
     )
     @Column(name = "BLC_SC_FLDGRP_XREF_ID")
     protected Long id;
-    
+
     @Column(name = "GROUP_ORDER")
     protected Integer groupOrder;
-    
+
     @ManyToOne(targetEntity = StructuredContentFieldTemplateImpl.class)
     @JoinColumn(name = "SC_FLD_TMPLT_ID")
     protected StructuredContentFieldTemplate template;
-    
+
     @ManyToOne(targetEntity = FieldGroupImpl.class)
     @JoinColumn(name = "FLD_GROUP_ID")
     protected FieldGroup fieldGroup;
@@ -97,19 +95,19 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
     public FieldGroup getFieldGroup() {
         return fieldGroup;
     }
-    
+
     @Override
     public void setFieldGroup(FieldGroup fieldGroup) {
         this.fieldGroup = fieldGroup;
     }
-    
+
     @Override
     public <G extends StructuredContentFieldGroupXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
-        
+
         StructuredContentFieldGroupXref cloned = createResponse.getClone();
         cloned.setGroupOrder(groupOrder);
 
@@ -118,8 +116,8 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
 
         CreateResponse<FieldGroup> clonedFieldGroup = fieldGroup.createOrRetrieveCopyInstance(context);
         cloned.setFieldGroup(clonedFieldGroup.getClone());
-        
+
         return createResponse;
     }
-    
+
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldGroupXrefImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;
 import org.broadleafcommerce.cms.field.domain.FieldGroupImpl;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -35,6 +26,16 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 /**
  * @author Phillip Verheyden (phillipuniverse)
@@ -53,8 +54,10 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
             name = "StructuredContentFieldGroupXrefId",
             type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name = "segment_value", value = "StructuredContentFieldGroupXrefImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl")
+                    @Parameter(name = "segment_value",
+                            value = "StructuredContentFieldGroupXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldGroupXrefImpl")
             }
     )
     @Column(name = "BLC_SC_FLDGRP_XREF_ID")
@@ -102,7 +105,8 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
     }
 
     @Override
-    public <G extends StructuredContentFieldGroupXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentFieldGroupXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -111,10 +115,12 @@ public class StructuredContentFieldGroupXrefImpl implements StructuredContentFie
         StructuredContentFieldGroupXref cloned = createResponse.getClone();
         cloned.setGroupOrder(groupOrder);
 
-        CreateResponse<StructuredContentFieldTemplate> clonedTemplate = template.createOrRetrieveCopyInstance(context);
+        CreateResponse<StructuredContentFieldTemplate> clonedTemplate =
+                template.createOrRetrieveCopyInstance(context);
         cloned.setTemplate(clonedTemplate.getClone());
 
-        CreateResponse<FieldGroup> clonedFieldGroup = fieldGroup.createOrRetrieveCopyInstance(context);
+        CreateResponse<FieldGroup> clonedFieldGroup =
+                fieldGroup.createOrRetrieveCopyInstance(context);
         cloned.setFieldGroup(clonedFieldGroup.getClone());
 
         return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldImpl.java
@@ -10,24 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
-import org.hibernate.Length;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,6 +26,18 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.openadmin.audit.AdminAuditableListener;
+import org.hibernate.Length;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by bpolster.
@@ -45,7 +45,7 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_FLD")
-@EntityListeners(value = { AdminAuditableListener.class })
+@EntityListeners(value = {AdminAuditableListener.class})
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
@@ -57,27 +57,27 @@ public class StructuredContentFieldImpl implements StructuredContentField, Profi
     @Id
     @GeneratedValue(generator = "StructuredContentFieldId")
     @GenericGenerator(
-        name="StructuredContentFieldId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentFieldImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentFieldImpl")
-        }
+            name = "StructuredContentFieldId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentFieldImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldImpl")
+            }
     )
     @Column(name = "SC_FLD_ID")
     protected Long id;
 
     @AdminPresentation
-    @Column (name = "FLD_KEY")
+    @Column(name = "FLD_KEY")
     protected String fieldKey;
 
     @AdminPresentation
-    @Column (name = "VALUE")
+    @Column(name = "VALUE")
     protected String stringValue;
 
     @Lob
     @AdminPresentation
-    @Column (name = "LOB_VALUE", length = Length.LONG32 - 1)
+    @Column(name = "LOB_VALUE", length = Length.LONG32 - 1)
     protected String lobValue;
 
     @Override
@@ -124,7 +124,7 @@ public class StructuredContentFieldImpl implements StructuredContentField, Profi
             stringValue = null;
         }
     }
-    
+
     @Override
     public StructuredContentField clone() {
         StructuredContentField clone = null;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -39,6 +30,16 @@ import org.hibernate.Length;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -47,7 +48,8 @@ import org.hibernate.annotations.Parameter;
 @Table(name = "BLC_SC_FLD")
 @EntityListeners(value = {AdminAuditableListener.class})
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class StructuredContentFieldImpl implements StructuredContentField, ProfileEntity {
@@ -61,7 +63,8 @@ public class StructuredContentFieldImpl implements StructuredContentField, Profi
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentFieldImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldImpl")
             }
     )
     @Column(name = "SC_FLD_ID")
@@ -141,7 +144,8 @@ public class StructuredContentFieldImpl implements StructuredContentField, Profi
     }
 
     @Override
-    public <G extends StructuredContentField> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentField> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Transformer;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;
@@ -47,6 +37,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -54,7 +55,8 @@ import java.util.List;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_FLD_TMPLT")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StructuredContentFieldTemplateImpl_baseStructuredContentFieldTemplate")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "StructuredContentFieldTemplateImpl_baseStructuredContentFieldTemplate")
 public class StructuredContentFieldTemplateImpl implements StructuredContentFieldTemplate {
 
     private static final long serialVersionUID = 1L;
@@ -65,22 +67,28 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
             name = "StructuredContentFieldTemplateId",
             type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name = "segment_value", value = "StructuredContentFieldTemplateImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldTemplateImpl")
+                    @Parameter(name = "segment_value",
+                            value = "StructuredContentFieldTemplateImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldTemplateImpl")
             }
     )
     @Column(name = "SC_FLD_TMPLT_ID")
     protected Long id;
 
     @Column(name = "NAME")
-    @AdminPresentation(friendlyName = "StructuredContentFieldTemplateImpl_Field_Template_Name", order = 1, gridOrder = 2, group = "StructuredContentFieldTemplateImpl_Details", prominent = true)
+    @AdminPresentation(friendlyName = "StructuredContentFieldTemplateImpl_Field_Template_Name",
+            order = 1, gridOrder = 2, group = "StructuredContentFieldTemplateImpl_Details",
+            prominent = true)
     protected String name;
 
-    @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "template", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "template",
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
-    protected List<StructuredContentFieldGroupXref> fieldGroupXrefs = new ArrayList<StructuredContentFieldGroupXref>();
+    protected List<StructuredContentFieldGroupXref> fieldGroupXrefs =
+            new ArrayList<StructuredContentFieldGroupXref>();
 
     @Override
     public Long getId() {
@@ -104,13 +112,14 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
 
     @Override
     public List<FieldGroup> getFieldGroups() {
-        Collection<FieldGroup> transformed = CollectionUtils.collect(fieldGroupXrefs, new Transformer<StructuredContentFieldGroupXref, FieldGroup>() {
+        Collection<FieldGroup> transformed = CollectionUtils.collect(fieldGroupXrefs,
+                new Transformer<StructuredContentFieldGroupXref, FieldGroup>() {
 
-            @Override
-            public FieldGroup transform(StructuredContentFieldGroupXref input) {
-                return input.getFieldGroup();
-            }
-        });
+                    @Override
+                    public FieldGroup transform(StructuredContentFieldGroupXref input) {
+                        return input.getFieldGroup();
+                    }
+                });
 
         return Collections.unmodifiableList(new ArrayList<FieldGroup>(transformed));
     }
@@ -131,7 +140,8 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
     }
 
     @Override
-    public <G extends StructuredContentFieldTemplate> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentFieldTemplate> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -139,7 +149,8 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
         StructuredContentFieldTemplate cloned = createResponse.getClone();
         cloned.setName(name);
         for (StructuredContentFieldGroupXref entry : fieldGroupXrefs) {
-            CreateResponse<StructuredContentFieldGroupXref> clonedGroupRsp = entry.createOrRetrieveCopyInstance(context);
+            CreateResponse<StructuredContentFieldGroupXref> clonedGroupRsp =
+                    entry.createOrRetrieveCopyInstance(context);
             clonedGroupRsp.getClone().setTemplate(cloned);
             cloned.getFieldGroupXrefs().add(clonedGroupRsp.getClone());
         }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldTemplateImpl.java
@@ -10,18 +10,29 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Transformer;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -36,24 +47,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-
 /**
  * Created by bpolster.
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_FLD_TMPLT")
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StructuredContentFieldTemplateImpl_baseStructuredContentFieldTemplate")
 public class StructuredContentFieldTemplateImpl implements StructuredContentFieldTemplate {
 
@@ -62,22 +62,22 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
     @Id
     @GeneratedValue(generator = "StructuredContentFieldTemplateId")
     @GenericGenerator(
-        name="StructuredContentFieldTemplateId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentFieldTemplateImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentFieldTemplateImpl")
-        }
+            name = "StructuredContentFieldTemplateId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentFieldTemplateImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldTemplateImpl")
+            }
     )
     @Column(name = "SC_FLD_TMPLT_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     @AdminPresentation(friendlyName = "StructuredContentFieldTemplateImpl_Field_Template_Name", order = 1, gridOrder = 2, group = "StructuredContentFieldTemplateImpl_Details", prominent = true)
     protected String name;
 
     @OneToMany(targetEntity = StructuredContentFieldGroupXrefImpl.class, mappedBy = "template", cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
     @OrderBy("groupOrder")
     @BatchSize(size = 20)
     protected List<StructuredContentFieldGroupXref> fieldGroupXrefs = new ArrayList<StructuredContentFieldGroupXref>();
@@ -111,7 +111,7 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
                 return input.getFieldGroup();
             }
         });
-        
+
         return Collections.unmodifiableList(new ArrayList<FieldGroup>(transformed));
     }
 
@@ -119,7 +119,7 @@ public class StructuredContentFieldTemplateImpl implements StructuredContentFiel
     public void setFieldGroups(List<FieldGroup> fieldGroups) {
         throw new UnsupportedOperationException("Not Supported - Use setAllFieldGroupXrefs()");
     }
-    
+
     @Override
     public List<StructuredContentFieldGroupXref> getFieldGroupXrefs() {
         return fieldGroupXrefs;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldXrefImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -50,11 +50,13 @@ import jakarta.persistence.Table;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_FLD_MAP")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
-public class StructuredContentFieldXrefImpl implements StructuredContentFieldXref, Serializable, ProfileEntity {
+public class StructuredContentFieldXrefImpl
+        implements StructuredContentFieldXref, Serializable, ProfileEntity {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -66,17 +68,19 @@ public class StructuredContentFieldXrefImpl implements StructuredContentFieldXre
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentFieldXrefImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldXrefImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentFieldXrefImpl")
             })
     @Column(name = "BLC_SC_SC_FIELD_ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = StructuredContentImpl.class, optional = false, cascade = { CascadeType.REFRESH })
+    @ManyToOne(targetEntity = StructuredContentImpl.class, optional = false,
+            cascade = {CascadeType.REFRESH})
     @JoinColumn(name = "SC_ID")
     @AdminPresentation(excluded = true)
     protected StructuredContent structuredContent;
 
-    @ManyToOne(targetEntity = StructuredContentFieldImpl.class, cascade = { CascadeType.ALL })
+    @ManyToOne(targetEntity = StructuredContentFieldImpl.class, cascade = {CascadeType.ALL})
     @JoinColumn(name = "SC_FLD_ID")
     @ClonePolicy
     @AdminPresentation(fieldType = SupportedFieldType.FOREIGN_KEY)
@@ -90,7 +94,9 @@ public class StructuredContentFieldXrefImpl implements StructuredContentFieldXre
         //Default constructor for JPA...
     }
 
-    public StructuredContentFieldXrefImpl(StructuredContent sc, StructuredContentField scField, String key) {
+    public StructuredContentFieldXrefImpl(StructuredContent sc,
+            StructuredContentField scField,
+            String key) {
         this.structuredContent = sc;
         this.structuredContentField = scField;
         this.key = key;
@@ -137,7 +143,8 @@ public class StructuredContentFieldXrefImpl implements StructuredContentFieldXre
     }
 
     @Override
-    public <G extends StructuredContentFieldXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentFieldXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -145,7 +152,8 @@ public class StructuredContentFieldXrefImpl implements StructuredContentFieldXre
         StructuredContentFieldXref cloned = createResponse.getClone();
         cloned.setKey(key);
         if (structuredContent != null) {
-            cloned.setStructuredContent(structuredContent.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setStructuredContent(
+                    structuredContent.createOrRetrieveCopyInstance(context).getClone());
         }
         if (structuredContentField != null) {
             CreateResponse<StructuredContentField> clonedFieldRsp = structuredContentField

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
@@ -17,6 +17,26 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
+import jakarta.annotation.Nullable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -27,6 +47,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
 import org.broadleafcommerce.common.locale.domain.Locale;
 import org.broadleafcommerce.common.locale.domain.LocaleImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
@@ -52,27 +73,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import jakarta.annotation.Nullable;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 /**
  * Created by bpolster.
@@ -151,7 +151,7 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
     @GeneratedValue(generator = "StructuredContentId")
     @GenericGenerator(
         name="StructuredContentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="StructuredContentImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentImpl")

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentImpl.java
@@ -10,33 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.annotation.Nullable;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -74,6 +54,27 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import jakarta.annotation.Nullable;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * Created by bpolster.
  */
@@ -88,133 +89,187 @@ import java.util.Set;
 @AdminPresentationMergeOverrides(value = {
         @AdminPresentationMergeOverride(name = "auditable.createdBy.id",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.updatedBy.id",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.createdBy.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.updatedBy.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.dateCreated",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "auditable.dateUpdated",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
         @AdminPresentationMergeOverride(name = "structuredContentType.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         ),
-        @AdminPresentationMergeOverride(name = "structuredContentType.structuredContentFieldTemplate.name",
+        @AdminPresentationMergeOverride(
+                name = "structuredContentType.structuredContentFieldTemplate.name",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.READONLY,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "HIDDEN_ALL")
                 }
         )
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StructuredContentImpl_baseStructuredContent")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "StructuredContentImpl_baseStructuredContent")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 public class StructuredContentImpl implements StructuredContent, AdminMainEntity, ProfileEntity {
 
     private static final long serialVersionUID = 1L;
-    
+
     public static final String SC_DONT_DUPLICATE_SC_TYPE_HINT = "dont-duplicate-sc-type";
 
     @Id
     @GeneratedValue(generator = "StructuredContentId")
     @GenericGenerator(
-        name="StructuredContentId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentImpl")
-        }
+            name = "StructuredContentId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentImpl")
+            }
     )
     @Column(name = "SC_ID")
     protected Long id;
 
     @AdminPresentation(friendlyName = "StructuredContentImpl_Content_Name", order = 1,
-        group = Presentation.Group.Name.Description, groupOrder = Presentation.Group.Order.Description,
-        prominent = true, gridOrder = 1)
+            group = Presentation.Group.Name.Description,
+            groupOrder = Presentation.Group.Order.Description,
+            prominent = true, gridOrder = 1)
     @Column(name = "CONTENT_NAME", nullable = false)
     protected String contentName;
 
     @ManyToOne(targetEntity = LocaleImpl.class, optional = false)
     @JoinColumn(name = "LOCALE_CODE")
     @AdminPresentation(friendlyName = "StructuredContentImpl_Locale", order = 2,
-        group = Presentation.Group.Name.Description, groupOrder = Presentation.Group.Order.Description,
-        prominent = true, gridOrder = 2)
-    @AdminPresentationToOneLookup(lookupDisplayProperty = "friendlyName", lookupType = LookupType.DROPDOWN)
+            group = Presentation.Group.Name.Description,
+            groupOrder = Presentation.Group.Order.Description,
+            prominent = true, gridOrder = 2)
+    @AdminPresentationToOneLookup(lookupDisplayProperty = "friendlyName",
+            lookupType = LookupType.DROPDOWN)
     protected Locale locale;
 
     @Column(name = "PRIORITY", nullable = false)
     @AdminPresentation(friendlyName = "StructuredContentImpl_Priority", order = 3,
-        group = Presentation.Group.Name.Description, groupOrder = Presentation.Group.Order.Description)
+            group = Presentation.Group.Name.Description,
+            groupOrder = Presentation.Group.Order.Description)
     protected Integer priority;
 
     @ManyToMany(targetEntity = StructuredContentRuleImpl.class, cascade = {CascadeType.ALL})
-    @JoinTable(name = "BLC_SC_RULE_MAP", 
-               joinColumns = @JoinColumn(name = "BLC_SC_SC_ID", referencedColumnName = "SC_ID"),
-               inverseJoinColumns = @JoinColumn(name = "SC_RULE_ID", referencedColumnName = "SC_RULE_ID"))
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @JoinTable(name = "BLC_SC_RULE_MAP",
+            joinColumns = @JoinColumn(name = "BLC_SC_SC_ID", referencedColumnName = "SC_ID"),
+            inverseJoinColumns = @JoinColumn(name = "SC_RULE_ID",
+                    referencedColumnName = "SC_RULE_ID"))
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @MapKeyColumn(name = "MAP_KEY", nullable = false)
-    @Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
     @IgnoreEnterpriseBehavior
-    Map<String, StructuredContentRule> structuredContentMatchRules = new HashMap<String, StructuredContentRule>();
+    Map<String, StructuredContentRule> structuredContentMatchRules =
+            new HashMap<String, StructuredContentRule>();
 
-    @OneToMany(fetch = FetchType.LAZY, targetEntity = StructuredContentItemCriteriaImpl.class, cascade={CascadeType.ALL})
-    @JoinTable(name = "BLC_QUAL_CRIT_SC_XREF", joinColumns = @JoinColumn(name = "SC_ID"), inverseJoinColumns = @JoinColumn(name = "SC_ITEM_CRITERIA_ID"))
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
-    @Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+    @OneToMany(fetch = FetchType.LAZY, targetEntity = StructuredContentItemCriteriaImpl.class,
+            cascade = {CascadeType.ALL})
+    @JoinTable(name = "BLC_QUAL_CRIT_SC_XREF", joinColumns = @JoinColumn(name = "SC_ID"),
+            inverseJoinColumns = @JoinColumn(name = "SC_ITEM_CRITERIA_ID"))
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
     @IgnoreEnterpriseBehavior
-    protected Set<StructuredContentItemCriteria> qualifyingItemCriteria = new HashSet<StructuredContentItemCriteria>();
+    protected Set<StructuredContentItemCriteria> qualifyingItemCriteria =
+            new HashSet<StructuredContentItemCriteria>();
 
     @ManyToOne(targetEntity = StructuredContentTypeImpl.class)
-    @JoinColumn(name="SC_TYPE_ID")
-    @AdminPresentation(friendlyName = "StructuredContentImpl_Content_Type", order = 2, prominent = true,
-        group = Presentation.Group.Name.Description, groupOrder = Presentation.Group.Order.Description,
-        requiredOverride = RequiredOverride.REQUIRED)
-    @AdminPresentationToOneLookup(lookupDisplayProperty = "name", forcePopulateChildProperties = true)
+    @JoinColumn(name = "SC_TYPE_ID")
+    @AdminPresentation(friendlyName = "StructuredContentImpl_Content_Type", order = 2,
+            prominent = true,
+            group = Presentation.Group.Name.Description,
+            groupOrder = Presentation.Group.Order.Description,
+            requiredOverride = RequiredOverride.REQUIRED)
+    @AdminPresentationToOneLookup(lookupDisplayProperty = "name",
+            forcePopulateChildProperties = true)
     protected StructuredContentType structuredContentType;
 
-    @OneToMany(mappedBy = "structuredContent", targetEntity = StructuredContentFieldXrefImpl.class, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "structuredContent", targetEntity = StructuredContentFieldXrefImpl.class,
+            cascade = CascadeType.ALL)
     @MapKey(name = "key")
     @BatchSize(size = 20)
     @AdminPresentationMap(forceFreeFormKeys = true, friendlyName = "structuredContentFields")
-    protected Map<String, StructuredContentFieldXref> structuredContentFields = new HashMap<String, StructuredContentFieldXref>();
+    protected Map<String, StructuredContentFieldXref> structuredContentFields =
+            new HashMap<String, StructuredContentFieldXref>();
 
     @Transient
-    protected Map<String, StructuredContentField> legacyStructuredContentFields = new HashMap<String, StructuredContentField>();
+    protected Map<String, StructuredContentField> legacyStructuredContentFields =
+            new HashMap<String, StructuredContentField>();
 
     @AdminPresentation(friendlyName = "StructuredContentImpl_Offline", order = 4,
-        group = Presentation.Group.Name.Description, groupOrder = Presentation.Group.Order.Description)
+            group = Presentation.Group.Name.Description,
+            groupOrder = Presentation.Group.Order.Description)
     @Column(name = "OFFLINE_FLAG")
     protected Boolean offlineFlag = false;
 
@@ -266,7 +321,8 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
     public Map<String, StructuredContentField> getStructuredContentFields() {
         if (legacyStructuredContentFields.isEmpty()) {
             for (Map.Entry<String, StructuredContentFieldXref> entry : getStructuredContentFieldXrefs().entrySet()) {
-                legacyStructuredContentFields.put(entry.getKey(), entry.getValue().getStructuredContentField());
+                legacyStructuredContentFields.put(entry.getKey(),
+                        entry.getValue().getStructuredContentField());
             }
         }
         return Collections.unmodifiableMap(legacyStructuredContentFields);
@@ -277,7 +333,8 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
         this.structuredContentFields.clear();
         this.legacyStructuredContentFields.clear();
         for (Map.Entry<String, StructuredContentField> entry : structuredContentFields.entrySet()) {
-            this.structuredContentFields.put(entry.getKey(), new StructuredContentFieldXrefImpl(this, entry.getValue(), entry.getKey()));
+            this.structuredContentFields.put(entry.getKey(),
+                    new StructuredContentFieldXrefImpl(this, entry.getValue(), entry.getKey()));
         }
     }
 
@@ -294,7 +351,8 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
     @Override
     public String getFieldValue(String fieldName) {
         if (structuredContentFields.containsKey(fieldName)) {
-            return getStructuredContentFieldXrefs().get(fieldName).getStructuredContentField().getValue();
+            return getStructuredContentFieldXrefs().get(fieldName).getStructuredContentField()
+                    .getValue();
         }
         return null;
     }
@@ -309,7 +367,8 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
         if (fieldValuesMap == null) {
             fieldValuesMap = new HashMap<String, String>();
             for (Entry<String, StructuredContentFieldXref> entry : getStructuredContentFieldXrefs().entrySet()) {
-                fieldValuesMap.put(entry.getKey(), entry.getValue().getStructuredContentField().getValue());
+                fieldValuesMap.put(entry.getKey(),
+                        entry.getValue().getStructuredContentField().getValue());
             }
         }
         return fieldValuesMap;
@@ -365,7 +424,8 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
     }
 
     @Override
-    public <G extends StructuredContent> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContent> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -375,34 +435,37 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
         cloned.setLocale(locale);
         cloned.setOfflineFlag(offlineFlag);
         cloned.setPriority(priority);
-        
+
         if (structuredContentType != null) {
             if (Boolean.valueOf(context.getCopyHints().get(SC_DONT_DUPLICATE_SC_TYPE_HINT))) {
                 cloned.setStructuredContentType(structuredContentType);
             } else {
-                CreateResponse<StructuredContentType> clonedType = 
+                CreateResponse<StructuredContentType> clonedType =
                         structuredContentType.createOrRetrieveCopyInstance(context);
                 cloned.setStructuredContentType(clonedType.getClone());
             }
         }
-        
-        for(StructuredContentItemCriteria itemCriteria : qualifyingItemCriteria){
-            CreateResponse<StructuredContentItemCriteria> clonedItem = itemCriteria.createOrRetrieveCopyInstance(context);
+
+        for (StructuredContentItemCriteria itemCriteria : qualifyingItemCriteria) {
+            CreateResponse<StructuredContentItemCriteria> clonedItem =
+                    itemCriteria.createOrRetrieveCopyInstance(context);
             StructuredContentItemCriteria clonedCritera = clonedItem.getClone();
             cloned.getQualifyingItemCriteria().add(clonedCritera);
         }
-        
-        for(Entry<String, StructuredContentRule> entry : structuredContentMatchRules.entrySet()){
-            CreateResponse<StructuredContentRule> clonedItem = entry.getValue().createOrRetrieveCopyInstance(context);
+
+        for (Entry<String, StructuredContentRule> entry : structuredContentMatchRules.entrySet()) {
+            CreateResponse<StructuredContentRule> clonedItem =
+                    entry.getValue().createOrRetrieveCopyInstance(context);
             StructuredContentRule clonedRule = clonedItem.getClone();
-            cloned.getStructuredContentMatchRules().put(entry.getKey(),clonedRule);
+            cloned.getStructuredContentMatchRules().put(entry.getKey(), clonedRule);
 
         }
-        
-        for(Entry<String, StructuredContentFieldXref> entry : structuredContentFields.entrySet() ){
-            CreateResponse<StructuredContentFieldXref> clonedItem = entry.getValue().createOrRetrieveCopyInstance(context);
+
+        for (Entry<String, StructuredContentFieldXref> entry : structuredContentFields.entrySet()) {
+            CreateResponse<StructuredContentFieldXref> clonedItem =
+                    entry.getValue().createOrRetrieveCopyInstance(context);
             StructuredContentFieldXref clonedContentFieldXref = clonedItem.getClone();
-            cloned.getStructuredContentFieldXrefs().put(entry.getKey(),clonedContentFieldXref);
+            cloned.getStructuredContentFieldXrefs().put(entry.getKey(), clonedContentFieldXref);
         }
 
         return createResponse;
@@ -414,10 +477,12 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
                 public static final String Rules = "StructuredContentImpl_Rules_Tab";
             }
 
+
             public static class Order {
                 public static final int Rules = 1000;
             }
         }
+
 
         public static class Group {
             public static class Name {
@@ -425,6 +490,7 @@ public class StructuredContentImpl implements StructuredContent, AdminMainEntity
                 public static final String Internal = "StructuredContentImpl_Internal";
                 public static final String Rules = "StructuredContentImpl_Rules";
             }
+
 
             public static class Order {
                 public static final int Description = 1000;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentItemCriteriaImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentItemCriteriaImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -43,19 +33,33 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author jfischer
  */
 @Entity
 @Table(name = "BLC_SC_ITEM_CRITERIA")
 @Inheritance(strategy = InheritanceType.JOINED)
-@AdminPresentationClass(friendlyName = "StructuredContentItemCriteriaImpl_baseStructuredContentItemCriteria")
+@AdminPresentationClass(
+        friendlyName = "StructuredContentItemCriteriaImpl_baseStructuredContentItemCriteria")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
-public class StructuredContentItemCriteriaImpl implements StructuredContentItemCriteria, ProfileEntity {
+public class StructuredContentItemCriteriaImpl
+        implements StructuredContentItemCriteria, ProfileEntity {
 
     public static final long serialVersionUID = 1L;
 
@@ -66,20 +70,27 @@ public class StructuredContentItemCriteriaImpl implements StructuredContentItemC
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentItemCriteriaImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.StructuredContentItemCriteriaImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.page.domain.StructuredContentItemCriteriaImpl")
             }
     )
     @Column(name = "SC_ITEM_CRITERIA_ID")
-    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Item_Criteria_Id", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Item_Criteria_Id",
+            group = "StructuredContentItemCriteriaImpl_Description",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "QUANTITY", nullable = false)
-    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Quantity", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Quantity",
+            group = "StructuredContentItemCriteriaImpl_Description",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Integer quantity;
 
     @Lob
     @Column(name = "ORDER_ITEM_MATCH_RULE", length = Length.LONG32 - 1)
-    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Order_Item_Match_Rule", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Order_Item_Match_Rule",
+            group = "StructuredContentItemCriteriaImpl_Description",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected String orderItemMatchRule;
 
     @ManyToOne(targetEntity = StructuredContentImpl.class)
@@ -131,7 +142,8 @@ public class StructuredContentItemCriteriaImpl implements StructuredContentItemC
         final int prime = 31;
         int result = 1;
         result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((orderItemMatchRule == null) ? 0 : orderItemMatchRule.hashCode());
+        result =
+                prime * result + ((orderItemMatchRule == null) ? 0 : orderItemMatchRule.hashCode());
         result = prime * result + ((quantity == null) ? 0 : quantity.hashCode());
         return result;
     }
@@ -156,11 +168,9 @@ public class StructuredContentItemCriteriaImpl implements StructuredContentItemC
         } else if (!orderItemMatchRule.equals(other.orderItemMatchRule))
             return false;
         if (quantity == null) {
-            if (other.quantity != null)
-                return false;
-        } else if (!quantity.equals(other.quantity))
-            return false;
-        return true;
+            return other.quantity == null;
+        } else
+            return quantity.equals(other.quantity);
     }
 
     @Override
@@ -173,14 +183,16 @@ public class StructuredContentItemCriteriaImpl implements StructuredContentItemC
     }
 
     @Override
-    public <G extends StructuredContentItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
         StructuredContentItemCriteria cloned = createResponse.getClone();
         if (structuredContent != null) {
-            cloned.setStructuredContent(structuredContent.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setStructuredContent(
+                    structuredContent.createOrRetrieveCopyInstance(context).getClone());
         }
         cloned.setMatchRule(orderItemMatchRule);
         cloned.setQuantity(quantity);

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentItemCriteriaImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentItemCriteriaImpl.java
@@ -10,27 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.Length;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,48 +27,61 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.Length;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Table(name = "BLC_SC_ITEM_CRITERIA")
-@Inheritance(strategy=InheritanceType.JOINED)
+@Inheritance(strategy = InheritanceType.JOINED)
 @AdminPresentationClass(friendlyName = "StructuredContentItemCriteriaImpl_baseStructuredContentItemCriteria")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 public class StructuredContentItemCriteriaImpl implements StructuredContentItemCriteria, ProfileEntity {
-    
+
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "SCItemCriteriaId")
+    @GeneratedValue(generator = "SCItemCriteriaId")
     @GenericGenerator(
-        name="SCItemCriteriaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentItemCriteriaImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.page.domain.StructuredContentItemCriteriaImpl")
-        }
+            name = "SCItemCriteriaId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentItemCriteriaImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.page.domain.StructuredContentItemCriteriaImpl")
+            }
     )
     @Column(name = "SC_ITEM_CRITERIA_ID")
-    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Item_Criteria_Id", group = "StructuredContentItemCriteriaImpl_Description", visibility =VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Item_Criteria_Id", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
-    @Column(name = "QUANTITY", nullable=false)
-    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Quantity", group = "StructuredContentItemCriteriaImpl_Description", visibility =VisibilityEnum.HIDDEN_ALL)
+
+    @Column(name = "QUANTITY", nullable = false)
+    @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Quantity", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Integer quantity;
-    
+
     @Lob
     @Column(name = "ORDER_ITEM_MATCH_RULE", length = Length.LONG32 - 1)
     @AdminPresentation(friendlyName = "StructuredContentItemCriteriaImpl_Order_Item_Match_Rule", group = "StructuredContentItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String orderItemMatchRule;
-    
+
     @ManyToOne(targetEntity = StructuredContentImpl.class)
     @JoinColumn(name = "SC_ID")
     protected StructuredContent structuredContent;
@@ -147,11 +145,11 @@ public class StructuredContentItemCriteriaImpl implements StructuredContentItemC
         if (!getClass().isAssignableFrom(obj.getClass()))
             return false;
         StructuredContentItemCriteriaImpl other = (StructuredContentItemCriteriaImpl) obj;
-        
+
         if (id != null && other.id != null) {
             return id.equals(other.id);
         }
-        
+
         if (orderItemMatchRule == null) {
             if (other.orderItemMatchRule != null)
                 return false;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentRuleImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentRuleImpl.java
@@ -10,24 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.hibernate.Length;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,12 +25,22 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.Length;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -51,24 +49,24 @@ import jakarta.persistence.Table;
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
-@Cache(usage= CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region="blCMSElements")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
 public class StructuredContentRuleImpl implements StructuredContentRule, ProfileEntity {
 
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "SCRuleId")
+    @GeneratedValue(generator = "SCRuleId")
     @GenericGenerator(
-        name="SCRuleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentRuleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.StructuredContentRuleImpl")
-        }
+            name = "SCRuleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentRuleImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.StructuredContentRuleImpl")
+            }
     )
     @Column(name = "SC_RULE_ID")
     protected Long id;
-    
+
     @Lob
     @Column(name = "MATCH_RULE", length = Length.LONG32 - 1)
     protected String matchRule;
@@ -111,11 +109,11 @@ public class StructuredContentRuleImpl implements StructuredContentRule, Profile
         if (!getClass().isAssignableFrom(obj.getClass()))
             return false;
         StructuredContentRuleImpl other = (StructuredContentRuleImpl) obj;
-        
+
         if (id != null && other.id != null) {
             return id.equals(other.id);
         }
-        
+
         if (matchRule == null) {
             if (other.matchRule != null)
                 return false;
@@ -140,6 +138,6 @@ public class StructuredContentRuleImpl implements StructuredContentRule, Profile
         }
         StructuredContentRule cloned = createResponse.getClone();
         cloned.setMatchRule(matchRule);
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentRuleImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentRuleImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -38,6 +30,15 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
 
 /**
  * @author jfischer
@@ -46,7 +47,8 @@ import org.hibernate.annotations.Parameter;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_RULE")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
@@ -61,7 +63,8 @@ public class StructuredContentRuleImpl implements StructuredContentRule, Profile
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentRuleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.StructuredContentRuleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.StructuredContentRuleImpl")
             }
     )
     @Column(name = "SC_RULE_ID")
@@ -115,11 +118,9 @@ public class StructuredContentRuleImpl implements StructuredContentRule, Profile
         }
 
         if (matchRule == null) {
-            if (other.matchRule != null)
-                return false;
-        } else if (!matchRule.equals(other.matchRule))
-            return false;
-        return true;
+            return other.matchRule == null;
+        } else
+            return matchRule.equals(other.matchRule);
     }
 
     @Override
@@ -131,7 +132,8 @@ public class StructuredContentRuleImpl implements StructuredContentRule, Profile
     }
 
     @Override
-    public <G extends StructuredContentRule> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentRule> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentTypeImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentTypeImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.cms.structure.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -43,6 +33,17 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * Created by bpolster.
  */
@@ -50,12 +51,15 @@ import org.hibernate.annotations.Parameter;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_TYPE", indexes = {@Index(name = "SC_TYPE_NAME_INDEX", columnList = "NAME")})
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCMSElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StructuredContentTypeImpl_baseStructuredContentType")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "StructuredContentTypeImpl_baseStructuredContentType")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
-public class StructuredContentTypeImpl implements StructuredContentType, AdminMainEntity, ProfileEntity {
+public class StructuredContentTypeImpl
+        implements StructuredContentType, AdminMainEntity, ProfileEntity {
 
     private static final long serialVersionUID = 1L;
 
@@ -66,14 +70,16 @@ public class StructuredContentTypeImpl implements StructuredContentType, AdminMa
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentTypeImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentTypeImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.cms.structure.domain.StructuredContentTypeImpl")
             }
     )
     @Column(name = "SC_TYPE_ID")
     protected Long id;
 
     @Column(name = "NAME")
-    @AdminPresentation(friendlyName = "StructuredContentTypeImpl_Name", order = 1, gridOrder = 1, group = "StructuredContentTypeImpl_Details", prominent = true)
+    @AdminPresentation(friendlyName = "StructuredContentTypeImpl_Name", order = 1, gridOrder = 1,
+            group = "StructuredContentTypeImpl_Details", prominent = true)
     protected String name;
 
     @Column(name = "DESCRIPTION")
@@ -129,7 +135,8 @@ public class StructuredContentTypeImpl implements StructuredContentType, AdminMa
     }
 
     @Override
-    public <G extends StructuredContentType> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends StructuredContentType> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -138,8 +145,9 @@ public class StructuredContentTypeImpl implements StructuredContentType, AdminMa
         cloned.setDescription(description);
         cloned.setName(name);
         if (structuredContentFieldTemplate != null) {
-            CreateResponse<StructuredContentFieldTemplate> clonedTemplate = structuredContentFieldTemplate
-                    .createOrRetrieveCopyInstance(context);
+            CreateResponse<StructuredContentFieldTemplate> clonedTemplate =
+                    structuredContentFieldTemplate
+                            .createOrRetrieveCopyInstance(context);
             cloned.setStructuredContentFieldTemplate(clonedTemplate.getClone());
         }
         return createResponse;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentTypeImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentTypeImpl.java
@@ -10,27 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.cms.structure.domain;
-
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +27,21 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Created by bpolster.
@@ -62,25 +62,25 @@ public class StructuredContentTypeImpl implements StructuredContentType, AdminMa
     @Id
     @GeneratedValue(generator = "StructuredContentTypeId")
     @GenericGenerator(
-        name="StructuredContentTypeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="StructuredContentTypeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.cms.structure.domain.StructuredContentTypeImpl")
-        }
+            name = "StructuredContentTypeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "StructuredContentTypeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.structure.domain.StructuredContentTypeImpl")
+            }
     )
     @Column(name = "SC_TYPE_ID")
     protected Long id;
 
-    @Column (name = "NAME")
+    @Column(name = "NAME")
     @AdminPresentation(friendlyName = "StructuredContentTypeImpl_Name", order = 1, gridOrder = 1, group = "StructuredContentTypeImpl_Details", prominent = true)
     protected String name;
 
-    @Column (name = "DESCRIPTION")
+    @Column(name = "DESCRIPTION")
     protected String description;
 
     @ManyToOne(targetEntity = StructuredContentFieldTemplateImpl.class)
-    @JoinColumn(name="SC_FLD_TMPLT_ID")
+    @JoinColumn(name = "SC_FLD_TMPLT_ID")
     protected StructuredContentFieldTemplate structuredContentFieldTemplate;
 
     @Override

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/service/type/StructuredContentRuleType.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/service/type/StructuredContentRuleType.java
@@ -112,11 +112,9 @@ public class StructuredContentRuleType implements Serializable, BroadleafEnumera
             return false;
         StructuredContentRuleType other = (StructuredContentRuleType) obj;
         if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
@@ -146,10 +146,7 @@ public class URLHandlerImpl implements URLHandler, Locatable, AdminMainEntity, P
     @Override
     public boolean isRegexHandler() {
         if (isRegex == null) {
-            if (hasRegExCharacters(getIncomingURL())) {
-                return true;
-            }
-            return false;
+            return hasRegExCharacters(getIncomingURL());
         }
         return isRegex;
     }
@@ -215,7 +212,7 @@ public class URLHandlerImpl implements URLHandler, Locatable, AdminMainEntity, P
         cloned.setIncomingURL(incomingURL);
         cloned.setNewURL(newURL);
         cloned.setUrlRedirectType(URLRedirectType.getInstance(urlRedirectType));
-        cloned.setRegexHandler(isRegex==null?false:isRegex);
+        cloned.setRegexHandler(isRegex != null && isRegex);
         return createResponse;
     }
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/type/URLRedirectType.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/type/URLRedirectType.java
@@ -82,11 +82,9 @@ public class URLRedirectType implements Serializable, BroadleafEnumerationType {
             return false;
         URLRedirectType other = (URLRedirectType) obj;
         if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 
 }

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/BroadleafProcessURLFilter.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/BroadleafProcessURLFilter.java
@@ -131,14 +131,14 @@ public class BroadleafProcessURLFilter extends OncePerRequestFilter {
     private HashSet<String> ignoreSuffixes;
 
     // Request Parameters and Attributes for Sandbox Mode properties - mostly date values.
-    private static String SANDBOX_ID_VAR = "blSandboxId";
-    private static String SANDBOX_DATE_TIME_VAR = "blSandboxDateTime";
+    private static final String SANDBOX_ID_VAR = "blSandboxId";
+    private static final String SANDBOX_DATE_TIME_VAR = "blSandboxDateTime";
     private static final SimpleDateFormat CONTENT_DATE_FORMATTER = new SimpleDateFormat("yyyyMMddHHmm");
     private static final SimpleDateFormat CONTENT_DATE_DISPLAY_FORMATTER = new SimpleDateFormat("MM/dd/yyyy");
     private static final SimpleDateFormat CONTENT_DATE_DISPLAY_HOURS_FORMATTER = new SimpleDateFormat("h");
     private static final SimpleDateFormat CONTENT_DATE_DISPLAY_MINUTES_FORMATTER = new SimpleDateFormat("mm");
     private static final SimpleDateFormat CONTENT_DATE_PARSE_FORMAT = new SimpleDateFormat("MM/dd/yyyy hh:mm aa");
-    private static String SANDBOX_DATE_TIME_RIBBON_OVERRIDE_PARAM = "blSandboxDateTimeRibbonOverride";
+    private static final String SANDBOX_DATE_TIME_RIBBON_OVERRIDE_PARAM = "blSandboxDateTimeRibbonOverride";
     private static final String SANDBOX_DISPLAY_DATE_TIME_DATE_PARAM = "blSandboxDisplayDateTimeDate";
     private static final String SANDBOX_DISPLAY_DATE_TIME_HOURS_PARAM = "blSandboxDisplayDateTimeHours";
     private static final String SANDBOX_DISPLAY_DATE_TIME_MINUTES_PARAM = "blSandboxDisplayDateTimeMinutes";

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/NullURLProcessor.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/NullURLProcessor.java
@@ -28,7 +28,7 @@ package org.broadleafcommerce.cms.web;
  * Created by bpolster.
  */
 public class NullURLProcessor implements URLProcessor {
-    private static NullURLProcessor _instance = new NullURLProcessor();
+    private static final NullURLProcessor _instance = new NullURLProcessor();
 
 
     public static NullURLProcessor getInstance() {

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PreviewTemplateController.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/PreviewTemplateController.java
@@ -25,7 +25,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @Controller
 @RequestMapping(PreviewTemplateController.REQUEST_MAPPING_PREFIX + "**")
 public class PreviewTemplateController {
-    private String templatePathPrefix = "templates";
+    private final String templatePathPrefix = "templates";
     public static final String REQUEST_MAPPING_PREFIX = "/preview/";
     
     @RequestMapping

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/UrlRewriteProcessor.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/web/processor/UrlRewriteProcessor.java
@@ -114,7 +114,7 @@ public class UrlRewriteProcessor extends AbstractBroadleafAttributeModifierProce
         if (newAttributeValue.startsWith("/")) {
             newAttributeValue = "@{ " + newAttributeValue + " }";
         }
-        return (String) context.parseExpression(newAttributeValue);
+        return context.parseExpression(newAttributeValue);
     }
 
     protected String getFileExtension(String assetPath) {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminMenu.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminMenu.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -22,7 +22,8 @@ import java.util.List;
 
 /**
  * Class to hold the admin menus and sections for which the passed in user has permissions to view.
- * @author bpolster 
+ *
+ * @author bpolster
  */
 public class AdminMenu {
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleDTO.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleDTO.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -21,9 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author bpolster
- *
  */
 public class AdminModuleDTO implements AdminModule {
 

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleImpl.java
@@ -10,13 +10,22 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
@@ -30,24 +39,13 @@ import org.hibernate.annotations.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
 /**
- *
  * @author elbertbautista
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_MODULE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
 @AdminPresentationClass(friendlyName = "AdminModuleImpl_baseAdminModule")
 public class AdminModuleImpl implements AdminModule {
 
@@ -56,37 +54,37 @@ public class AdminModuleImpl implements AdminModule {
     @Id
     @GeneratedValue(generator = "AdminModuleId")
     @GenericGenerator(
-        name="AdminModuleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminModuleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminModuleImpl")
-        }
+            name = "AdminModuleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminModuleImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminModuleImpl")
+            }
     )
     @Column(name = "ADMIN_MODULE_ID")
     @AdminPresentation(friendlyName = "AdminModuleImpl_Admin_Module_ID", group = "AdminModuleImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
-    @Index(name="ADMINMODULE_NAME_INDEX", columnNames={"NAME"})
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Name", order=1, group = "AdminModuleImpl_Module", prominent=true)
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "ADMINMODULE_NAME_INDEX", columnNames = {"NAME"})
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Name", order = 1, group = "AdminModuleImpl_Module", prominent = true)
     protected String name;
 
-    @Column(name = "MODULE_KEY", nullable=false)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Module_Key", order=2, group = "AdminModuleImpl_Module", prominent=true)
+    @Column(name = "MODULE_KEY", nullable = false)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Module_Key", order = 2, group = "AdminModuleImpl_Module", prominent = true)
     protected String moduleKey;
 
-    @Column(name = "ICON", nullable=true)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Icon", order=3, group = "AdminModuleImpl_Module", prominent=true)
+    @Column(name = "ICON", nullable = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Icon", order = 3, group = "AdminModuleImpl_Module", prominent = true)
     protected String icon;
 
     @OneToMany(mappedBy = "module", targetEntity = AdminSectionImpl.class)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     protected List<AdminSection> sections = new ArrayList<AdminSection>();
 
-    @Column(name = "DISPLAY_ORDER", nullable=true)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Display_Order", order=4, group = "AdminModuleImpl_Module", prominent=true)
+    @Column(name = "DISPLAY_ORDER", nullable = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Display_Order", order = 4, group = "AdminModuleImpl_Module", prominent = true)
     protected Integer displayOrder;
 
     @Override
@@ -150,6 +148,7 @@ public class AdminModuleImpl implements AdminModule {
 
     /**
      * Set all properties except the sections.
+     *
      * @return
      */
     public AdminModuleDTO getAdminModuleDTO() {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminModuleImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -38,6 +30,15 @@ import org.hibernate.annotations.Parameter;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 
 /**
  * @author elbertbautista
@@ -58,24 +59,29 @@ public class AdminModuleImpl implements AdminModule {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminModuleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminModuleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminModuleImpl")
             }
     )
     @Column(name = "ADMIN_MODULE_ID")
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Admin_Module_ID", group = "AdminModuleImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Admin_Module_ID",
+            group = "AdminModuleImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "NAME", nullable = false)
     @Index(name = "ADMINMODULE_NAME_INDEX", columnNames = {"NAME"})
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Name", order = 1, group = "AdminModuleImpl_Module", prominent = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Name", order = 1,
+            group = "AdminModuleImpl_Module", prominent = true)
     protected String name;
 
     @Column(name = "MODULE_KEY", nullable = false)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Module_Key", order = 2, group = "AdminModuleImpl_Module", prominent = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Module_Key", order = 2,
+            group = "AdminModuleImpl_Module", prominent = true)
     protected String moduleKey;
 
     @Column(name = "ICON", nullable = true)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Icon", order = 3, group = "AdminModuleImpl_Module", prominent = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Icon", order = 3,
+            group = "AdminModuleImpl_Module", prominent = true)
     protected String icon;
 
     @OneToMany(mappedBy = "module", targetEntity = AdminSectionImpl.class)
@@ -84,7 +90,8 @@ public class AdminModuleImpl implements AdminModule {
     protected List<AdminSection> sections = new ArrayList<AdminSection>();
 
     @Column(name = "DISPLAY_ORDER", nullable = true)
-    @AdminPresentation(friendlyName = "AdminModuleImpl_Display_Order", order = 4, group = "AdminModuleImpl_Module", prominent = true)
+    @AdminPresentation(friendlyName = "AdminModuleImpl_Display_Order", order = 4,
+            group = "AdminModuleImpl_Module", prominent = true)
     protected Integer displayOrder;
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -58,6 +45,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 /**
  * @author jfischer
  */
@@ -67,7 +68,8 @@ import java.util.Set;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
 @AdminPresentationClass(friendlyName = "AdminPermissionImpl_baseAdminPermission")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_ADMINPERMISSION)
+        @DirectCopyTransformMember(
+                templateTokens = DirectCopyTransformTypes.MULTITENANT_ADMINPERMISSION)
 })
 public class AdminPermissionImpl implements AdminPermission {
 
@@ -81,15 +83,18 @@ public class AdminPermissionImpl implements AdminPermission {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminPermissionImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionImpl")
             }
     )
     @Column(name = "ADMIN_PERMISSION_ID")
-    @AdminPresentation(friendlyName = "AdminPermissionImpl_Admin_Permission_ID", group = "AdminPermissionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AdminPermissionImpl_Admin_Permission_ID",
+            group = "AdminPermissionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "NAME", nullable = false)
-    @AdminPresentation(friendlyName = "AdminPermissionImpl_Name", order = 3000, group = "AdminPermissionImpl_Permission")
+    @AdminPresentation(friendlyName = "AdminPermissionImpl_Name", order = 3000,
+            group = "AdminPermissionImpl_Permission")
     protected String name;
 
     @Column(name = "PERMISSION_TYPE", nullable = false)
@@ -100,44 +105,67 @@ public class AdminPermissionImpl implements AdminPermission {
     protected String type;
 
     @Column(name = "DESCRIPTION", nullable = false)
-    @AdminPresentation(friendlyName = "AdminPermissionImpl_Description", order = 1000, group = "AdminPermissionImpl_Permission",
+    @AdminPresentation(friendlyName = "AdminPermissionImpl_Description", order = 1000,
+            group = "AdminPermissionImpl_Permission",
             prominent = true, gridOrder = 2000)
     protected String description;
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminRoleImpl.class)
-    @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"))
+    @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID",
+                    referencedColumnName = "ADMIN_ROLE_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentation(excluded = true)
     protected Set<AdminRole> allRoles = new HashSet<AdminRole>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminUserImpl.class)
-    @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"))
+    @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID",
+                    referencedColumnName = "ADMIN_USER_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentation(excluded = true)
     protected Set<AdminUser> allUsers = new HashSet<AdminUser>();
 
-    @OneToMany(mappedBy = "adminPermission", targetEntity = AdminPermissionQualifiedEntityImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToMany(mappedBy = "adminPermission",
+            targetEntity = AdminPermissionQualifiedEntityImpl.class, cascade = {CascadeType.ALL},
+            orphanRemoval = true)
     @Cascade(value = {org.hibernate.annotations.CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
-    @AdminPresentationCollection(addType = AddMethodType.LOOKUP, friendlyName = "entityPermissionsTitle",
+    @AdminPresentationCollection(addType = AddMethodType.LOOKUP,
+            friendlyName = "entityPermissionsTitle",
             order = 2000)
-    protected List<AdminPermissionQualifiedEntity> qualifiedEntities = new ArrayList<AdminPermissionQualifiedEntity>();
+    protected List<AdminPermissionQualifiedEntity> qualifiedEntities =
+            new ArrayList<AdminPermissionQualifiedEntity>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
-    @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
+    @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"),
+            inverseJoinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
-    @AdminPresentationCollection(addType = AddMethodType.LOOKUP, friendlyName = "childPermissionsTitle",
+    @AdminPresentationCollection(addType = AddMethodType.LOOKUP,
+            friendlyName = "childPermissionsTitle",
             order = 1000,
             manyToField = "allParentPermissions",
-            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            operationTypes = @AdminPresentationOperationTypes(
+                    removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected List<AdminPermission> allChildPermissions = new ArrayList<AdminPermission>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
-    @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF", joinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
+    @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     protected List<AdminPermission> allParentPermissions = new ArrayList<AdminPermission>();
@@ -219,11 +247,14 @@ public class AdminPermissionImpl implements AdminPermission {
         this.allUsers = allUsers;
     }
 
-    public void checkCloneable(AdminPermission adminPermission) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = adminPermission.getClass().getMethod("clone", new Class[]{});
-        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !adminPermission.getClass().getName().startsWith("org.broadleafcommerce")) {
+    public void checkCloneable(AdminPermission adminPermission)
+            throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
+        Method cloneMethod = adminPermission.getClass().getMethod("clone", new Class[] {});
+        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce")
+                && !adminPermission.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
-            throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");
+            throw new CloneNotSupportedException(
+                    "Custom extensions and implementations should implement clone.");
         }
     }
 
@@ -235,7 +266,9 @@ public class AdminPermissionImpl implements AdminPermission {
             try {
                 checkCloneable(clone);
             } catch (CloneNotSupportedException e) {
-                LOG.warn("Clone implementation missing in inheritance hierarchy outside of Broadleaf: " + clone.getClass().getName(), e);
+                LOG.warn(
+                        "Clone implementation missing in inheritance hierarchy outside of Broadleaf: "
+                                + clone.getClass().getName(), e);
             }
             clone.setId(id);
             clone.setName(name);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionImpl.java
@@ -10,18 +10,32 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -44,29 +58,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_PERMISSION")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
 @AdminPresentationClass(friendlyName = "AdminPermissionImpl_baseAdminPermission")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_ADMINPERMISSION)
@@ -79,50 +77,50 @@ public class AdminPermissionImpl implements AdminPermission {
     @Id
     @GeneratedValue(generator = "AdminPermissionId")
     @GenericGenerator(
-        name="AdminPermissionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminPermissionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionImpl")
-        }
+            name = "AdminPermissionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminPermissionImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionImpl")
+            }
     )
     @Column(name = "ADMIN_PERMISSION_ID")
     @AdminPresentation(friendlyName = "AdminPermissionImpl_Admin_Permission_ID", group = "AdminPermissionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
+    @Column(name = "NAME", nullable = false)
     @AdminPresentation(friendlyName = "AdminPermissionImpl_Name", order = 3000, group = "AdminPermissionImpl_Permission")
     protected String name;
 
-    @Column(name = "PERMISSION_TYPE", nullable=false)
+    @Column(name = "PERMISSION_TYPE", nullable = false)
     @AdminPresentation(friendlyName = "AdminPermissionImpl_Permission_Type", order = 3000,
             group = "AdminPermissionImpl_Permission", gridOrder = 2000,
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
             broadleafEnumeration = "org.broadleafcommerce.openadmin.server.security.service.type.PermissionType")
     protected String type;
 
-    @Column(name = "DESCRIPTION", nullable=false)
+    @Column(name = "DESCRIPTION", nullable = false)
     @AdminPresentation(friendlyName = "AdminPermissionImpl_Description", order = 1000, group = "AdminPermissionImpl_Permission",
             prominent = true, gridOrder = 2000)
     protected String description;
-    
+
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminRoleImpl.class)
     @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentation(excluded = true)
-    protected Set<AdminRole> allRoles= new HashSet<AdminRole>();
+    protected Set<AdminRole> allRoles = new HashSet<AdminRole>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminUserImpl.class)
     @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentation(excluded = true)
-    protected Set<AdminUser> allUsers= new HashSet<AdminUser>();
+    protected Set<AdminUser> allUsers = new HashSet<AdminUser>();
 
-    @OneToMany(mappedBy = "adminPermission", targetEntity = AdminPermissionQualifiedEntityImpl.class, cascade = {CascadeType.ALL}, orphanRemoval=true)
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+    @OneToMany(mappedBy = "adminPermission", targetEntity = AdminPermissionQualifiedEntityImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL})
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     @AdminPresentationCollection(addType = AddMethodType.LOOKUP, friendlyName = "entityPermissionsTitle",
             order = 2000)
@@ -130,14 +128,14 @@ public class AdminPermissionImpl implements AdminPermission {
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
     @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     @AdminPresentationCollection(addType = AddMethodType.LOOKUP, friendlyName = "childPermissionsTitle",
             order = 1000,
             manyToField = "allParentPermissions",
             operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected List<AdminPermission> allChildPermissions = new ArrayList<AdminPermission>();
-    
+
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
     @JoinTable(name = "BLC_ADMIN_PERMISSION_XREF", joinColumns = @JoinColumn(name = "CHILD_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
@@ -281,7 +279,7 @@ public class AdminPermissionImpl implements AdminPermission {
 
     @Override
     public Boolean isFriendly() {
-        if(isFriendly == null) {
+        if (isFriendly == null) {
             return false;
         }
         return isFriendly;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionQualifiedEntityImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionQualifiedEntityImpl.java
@@ -10,22 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
@@ -38,18 +29,26 @@ import org.hibernate.annotations.Parameter;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
- * Created by IntelliJ IDEA.
- * User: jfischer
- * Date: 9/24/11
- * Time: 4:34 PM
- * To change this template use File | Settings | File Templates.
+ * Created by IntelliJ IDEA. User: jfischer Date: 9/24/11 Time: 4:34 PM To change this template use
+ * File | Settings | File Templates.
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_PERMISSION_ENTITY")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
-public class AdminPermissionQualifiedEntityImpl implements AdminPermissionQualifiedEntity, Serializable {
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
+public class AdminPermissionQualifiedEntityImpl
+        implements AdminPermissionQualifiedEntity, Serializable {
 
     private static final Log LOG = LogFactory.getLog(AdminPermissionQualifiedEntityImpl.class);
     private static final long serialVersionUID = 1L;
@@ -57,18 +56,20 @@ public class AdminPermissionQualifiedEntityImpl implements AdminPermissionQualif
     @Id
     @GeneratedValue(generator = "AdminPermissionEntityId")
     @GenericGenerator(
-        name="AdminPermissionEntityId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="AdminPermissionEntityImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionQualifiedEntityImpl")
-        }
+            name = "AdminPermissionEntityId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminPermissionEntityImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionQualifiedEntityImpl")
+            }
     )
     @Column(name = "ADMIN_PERMISSION_ENTITY_ID")
     protected Long id;
 
-    @Column(name = "CEILING_ENTITY", nullable=false)
-    @AdminPresentation(friendlyName = "AdminPermissionQualifiedEntityImpl_Ceiling_Entity_Name", order=1, group = "AdminPermissionQualifiedEntityImpl_Permission", prominent=true)
+    @Column(name = "CEILING_ENTITY", nullable = false)
+    @AdminPresentation(friendlyName = "AdminPermissionQualifiedEntityImpl_Ceiling_Entity_Name",
+            order = 1, group = "AdminPermissionQualifiedEntityImpl_Permission", prominent = true)
     protected String ceilingEntityFullyQualifiedName;
 
     @ManyToOne(targetEntity = AdminPermissionImpl.class)
@@ -105,11 +106,14 @@ public class AdminPermissionQualifiedEntityImpl implements AdminPermissionQualif
         this.adminPermission = adminPermission;
     }
 
-    public void checkCloneable(AdminPermissionQualifiedEntity qualifiedEntity) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = qualifiedEntity.getClass().getMethod("clone", new Class[]{});
-        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !qualifiedEntity.getClass().getName().startsWith("org.broadleafcommerce")) {
+    public void checkCloneable(AdminPermissionQualifiedEntity qualifiedEntity)
+            throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
+        Method cloneMethod = qualifiedEntity.getClass().getMethod("clone", new Class[] {});
+        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce")
+                && !qualifiedEntity.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
-            throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");
+            throw new CloneNotSupportedException(
+                    "Custom extensions and implementations should implement clone.");
         }
     }
 
@@ -117,11 +121,14 @@ public class AdminPermissionQualifiedEntityImpl implements AdminPermissionQualif
     public AdminPermissionQualifiedEntity clone() {
         AdminPermissionQualifiedEntity clone;
         try {
-            clone = (AdminPermissionQualifiedEntity) Class.forName(this.getClass().getName()).newInstance();
+            clone = (AdminPermissionQualifiedEntity) Class.forName(this.getClass().getName())
+                    .newInstance();
             try {
                 checkCloneable(clone);
             } catch (CloneNotSupportedException e) {
-                LOG.warn("Clone implementation missing in inheritance hierarchy outside of Broadleaf: " + clone.getClass().getName(), e);
+                LOG.warn(
+                        "Clone implementation missing in inheritance hierarchy outside of Broadleaf: "
+                                + clone.getClass().getName(), e);
             }
             clone.setId(id);
             clone.setCeilingEntityFullyQualifiedName(ceilingEntityFullyQualifiedName);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionQualifiedEntityImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminPermissionQualifiedEntityImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -37,6 +26,17 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
 
 /**
  * Created by IntelliJ IDEA.
@@ -58,7 +58,7 @@ public class AdminPermissionQualifiedEntityImpl implements AdminPermissionQualif
     @GeneratedValue(generator = "AdminPermissionEntityId")
     @GenericGenerator(
         name="AdminPermissionEntityId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="AdminPermissionEntityImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminPermissionQualifiedEntityImpl")

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminRoleImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminRoleImpl.java
@@ -10,19 +10,31 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationOperationTypes;
@@ -39,27 +51,13 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
-
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_ROLE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_ADMINROLE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY),
@@ -73,38 +71,40 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
     @Id
     @GeneratedValue(generator = "AdminRoleId")
     @GenericGenerator(
-        name="AdminRoleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminRoleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminRoleImpl")
-        }
+            name = "AdminRoleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminRoleImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminRoleImpl")
+            }
     )
     @Column(name = "ADMIN_ROLE_ID")
     @AdminPresentation(friendlyName = "AdminRoleImpl_Admin_Role_ID", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
+    @Column(name = "NAME", nullable = false)
     @AdminPresentation(friendlyName = "AdminRoleImpl_Name",
             group = GroupName.RoleDetails, order = FieldOrder.NAME)
     protected String name;
 
-    @Column(name = "DESCRIPTION", nullable=false)
+    @Column(name = "DESCRIPTION", nullable = false)
     @AdminPresentation(friendlyName = "AdminRoleImpl_Description",
             group = GroupName.RoleDetails, order = FieldOrder.DESCRIPTION,
             prominent = true)
     protected String description;
 
-    /** All users that have this role */
+    /**
+     * All users that have this role
+     */
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminUserImpl.class)
     @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     protected Set<AdminUser> allUsers = new HashSet<AdminUser>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
     @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "permissionListTitle",
             group = GroupName.Permissions, order = FieldOrder.PERMISSIONS,
@@ -112,7 +112,7 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
             manyToField = "allRoles",
             customCriteria = "includeFriendlyOnly",
             operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
-    protected Set<AdminPermission> allPermissions= new HashSet<AdminPermission>();
+    protected Set<AdminPermission> allPermissions = new HashSet<AdminPermission>();
 
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminRoleImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminRoleImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -50,6 +39,18 @@ import org.hibernate.annotations.Parameter;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 
 /**
  * @author jfischer
@@ -75,11 +76,13 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminRoleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminRoleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminRoleImpl")
             }
     )
     @Column(name = "ADMIN_ROLE_ID")
-    @AdminPresentation(friendlyName = "AdminRoleImpl_Admin_Role_ID", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AdminRoleImpl_Admin_Role_ID",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "NAME", nullable = false)
@@ -97,13 +100,20 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
      * All users that have this role
      */
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminUserImpl.class)
-    @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"))
+    @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID",
+            referencedColumnName = "ADMIN_ROLE_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_USER_ID",
+                    referencedColumnName = "ADMIN_USER_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     protected Set<AdminUser> allUsers = new HashSet<AdminUser>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
-    @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
+    @JoinTable(name = "BLC_ADMIN_ROLE_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_ROLE_ID",
+                    referencedColumnName = "ADMIN_ROLE_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "permissionListTitle",
@@ -111,7 +121,8 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
             addType = AddMethodType.LOOKUP,
             manyToField = "allRoles",
             customCriteria = "includeFriendlyOnly",
-            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            operationTypes = @AdminPresentationOperationTypes(
+                    removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected Set<AdminPermission> allPermissions = new HashSet<AdminPermission>();
 
 
@@ -158,11 +169,14 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
         this.allPermissions = allPermissions;
     }
 
-    public void checkCloneable(AdminRole adminRole) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = adminRole.getClass().getMethod("clone", new Class[]{});
-        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !adminRole.getClass().getName().startsWith("org.broadleafcommerce")) {
+    public void checkCloneable(AdminRole adminRole)
+            throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
+        Method cloneMethod = adminRole.getClass().getMethod("clone", new Class[] {});
+        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce")
+                && !adminRole.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
-            throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");
+            throw new CloneNotSupportedException(
+                    "Custom extensions and implementations should implement clone.");
         }
     }
 
@@ -174,7 +188,9 @@ public class AdminRoleImpl implements AdminRole, AdminRoleAdminPresentation, Adm
             try {
                 checkCloneable(clone);
             } catch (CloneNotSupportedException e) {
-                LOG.warn("Clone implementation missing in inheritance hierarchy outside of Broadleaf: " + clone.getClass().getName(), e);
+                LOG.warn(
+                        "Clone implementation missing in inheritance hierarchy outside of Broadleaf: "
+                                + clone.getClass().getName(), e);
             }
             clone.setId(id);
             clone.setName(name);

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
@@ -17,18 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
@@ -47,6 +35,19 @@ import org.hibernate.annotations.Parameter;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 /**
  * @author elbertbautista
@@ -70,24 +71,29 @@ public class AdminSectionImpl implements AdminSection {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminSectionImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminSectionImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminSectionImpl")
             }
     )
     @Column(name = "ADMIN_SECTION_ID")
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Admin_Section_ID", group = "AdminSectionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Admin_Section_ID",
+            group = "AdminSectionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "NAME", nullable = false)
     @Index(name = "ADMINSECTION_NAME_INDEX", columnNames = {"NAME"})
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Name", order = 1, group = "AdminSectionImpl_Section", prominent = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Name", order = 1,
+            group = "AdminSectionImpl_Section", prominent = true)
     protected String name;
 
     @Column(name = "SECTION_KEY", nullable = false, unique = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Section_Key", order = 2, group = "AdminSectionImpl_Section", prominent = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Section_Key", order = 2,
+            group = "AdminSectionImpl_Section", prominent = true)
     protected String sectionKey;
 
     @Column(name = "URL", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Url", order = 3, group = "AdminSectionImpl_Section", prominent = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Url", order = 3,
+            group = "AdminSectionImpl_Section", prominent = true)
     protected String url;
 
     @ManyToOne(optional = false, targetEntity = AdminModuleImpl.class)
@@ -97,7 +103,11 @@ public class AdminSectionImpl implements AdminSection {
     protected AdminModule module;
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
-    @JoinTable(name = "BLC_ADMIN_SEC_PERM_XREF", joinColumns = @JoinColumn(name = "ADMIN_SECTION_ID", referencedColumnName = "ADMIN_SECTION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
+    @JoinTable(name = "BLC_ADMIN_SEC_PERM_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_SECTION_ID",
+                    referencedColumnName = "ADMIN_SECTION_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     protected List<AdminPermission> permissions = new ArrayList<AdminPermission>();
@@ -109,7 +119,8 @@ public class AdminSectionImpl implements AdminSection {
      */
     @Deprecated
     @Column(name = "DISPLAY_CONTROLLER", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Controller", order = 4, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Controller", order = 4,
+            group = "AdminSectionImpl_Section")
     protected String displayController;
 
     /**
@@ -119,24 +130,29 @@ public class AdminSectionImpl implements AdminSection {
      */
     @Deprecated
     @Column(name = "USE_DEFAULT_HANDLER", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Use_Default_Handler", order = 5, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Use_Default_Handler", order = 5,
+            group = "AdminSectionImpl_Section")
     protected Boolean useDefaultHandler = Boolean.TRUE;
 
     @Column(name = "CEILING_ENTITY", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Ceiling_Entity", order = 6, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Ceiling_Entity", order = 6,
+            group = "AdminSectionImpl_Section")
     protected String ceilingEntity;
 
     @Column(name = "DISPLAY_ORDER", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Order", order = 7, group = "AdminSectionImpl_Section",
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Order", order = 7,
+            group = "AdminSectionImpl_Section",
             prominent = true)
     protected Integer displayOrder;
 
     @Column(name = "FOLDERABLE")
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Folderable", order = 8, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Folderable", order = 8,
+            group = "AdminSectionImpl_Section")
     protected Boolean folderable;
 
     @Column(name = "FOLDERED_BY_DEFAULT")
-    @AdminPresentation(friendlyName = "AdminSectionImpl_FolderedByDefault", order = 9, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_FolderedByDefault", order = 9,
+            group = "AdminSectionImpl_Section")
     protected Boolean folderedByDefault;
 
     @Override

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminSectionImpl.java
@@ -10,16 +10,29 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
@@ -35,28 +48,13 @@ import org.hibernate.annotations.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-
 /**
- *
  * @author elbertbautista
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_SECTION")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
 @AdminPresentationClass(friendlyName = "AdminSectionImpl_baseAdminSection")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
@@ -68,31 +66,31 @@ public class AdminSectionImpl implements AdminSection {
     @Id
     @GeneratedValue(generator = "AdminSectionId")
     @GenericGenerator(
-        name="AdminSectionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminSectionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminSectionImpl")
-        }
+            name = "AdminSectionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminSectionImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminSectionImpl")
+            }
     )
     @Column(name = "ADMIN_SECTION_ID")
     @AdminPresentation(friendlyName = "AdminSectionImpl_Admin_Section_ID", group = "AdminSectionImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
-    @Index(name="ADMINSECTION_NAME_INDEX", columnNames={"NAME"})
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Name", order=1, group = "AdminSectionImpl_Section", prominent=true)
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "ADMINSECTION_NAME_INDEX", columnNames = {"NAME"})
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Name", order = 1, group = "AdminSectionImpl_Section", prominent = true)
     protected String name;
 
-    @Column(name = "SECTION_KEY", nullable=false, unique = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Section_Key", order=2, group = "AdminSectionImpl_Section", prominent=true)
+    @Column(name = "SECTION_KEY", nullable = false, unique = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Section_Key", order = 2, group = "AdminSectionImpl_Section", prominent = true)
     protected String sectionKey;
 
-    @Column(name = "URL", nullable=true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Url", order=3, group = "AdminSectionImpl_Section", prominent=true)
+    @Column(name = "URL", nullable = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Url", order = 3, group = "AdminSectionImpl_Section", prominent = true)
     protected String url;
 
-    @ManyToOne(optional=false, targetEntity = AdminModuleImpl.class)
+    @ManyToOne(optional = false, targetEntity = AdminModuleImpl.class)
     @Fetch(FetchMode.JOIN)
     @JoinColumn(name = "ADMIN_MODULE_ID")
     @Index(name = "ADMINSECTION_MODULE_INDEX", columnNames = {"ADMIN_MODULE_ID"})
@@ -100,26 +98,28 @@ public class AdminSectionImpl implements AdminSection {
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
     @JoinTable(name = "BLC_ADMIN_SEC_PERM_XREF", joinColumns = @JoinColumn(name = "ADMIN_SECTION_ID", referencedColumnName = "ADMIN_SECTION_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurity")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurity")
     @BatchSize(size = 50)
     protected List<AdminPermission> permissions = new ArrayList<AdminPermission>();
 
     /**
      * No longer needed after GWT removal
+     *
      * @param displayController
      */
     @Deprecated
-    @Column(name = "DISPLAY_CONTROLLER", nullable=true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Controller", order=4, group = "AdminSectionImpl_Section")
+    @Column(name = "DISPLAY_CONTROLLER", nullable = true)
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Display_Controller", order = 4, group = "AdminSectionImpl_Section")
     protected String displayController;
 
     /**
      * No longer needed after GWT removal
+     *
      * @param displayController
      */
     @Deprecated
     @Column(name = "USE_DEFAULT_HANDLER", nullable = true)
-    @AdminPresentation(friendlyName = "AdminSectionImpl_Use_Default_Handler", order=5, group = "AdminSectionImpl_Section")
+    @AdminPresentation(friendlyName = "AdminSectionImpl_Use_Default_Handler", order = 5, group = "AdminSectionImpl_Section")
     protected Boolean useDefaultHandler = Boolean.TRUE;
 
     @Column(name = "CEILING_ENTITY", nullable = true)

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserAttributeImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserAttributeImpl.java
@@ -17,6 +17,15 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -26,14 +35,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -50,7 +51,8 @@ public class AdminUserAttributeImpl implements AdminUserAttribute {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminUserAttributeImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserAttributeImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserAttributeImpl")
             }
     )
     @Column(name = "ATTRIBUTE_ID")

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserAttributeImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserAttributeImpl.java
@@ -10,20 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
-
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,30 +26,38 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_ADMIN_USER_ADDTL_FIELDS")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+@Table(name = "BLC_ADMIN_USER_ADDTL_FIELDS")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
 public class AdminUserAttributeImpl implements AdminUserAttribute {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Id
-    @GeneratedValue(generator= "AdminUserAttributeId")
+    @GeneratedValue(generator = "AdminUserAttributeId")
     @GenericGenerator(
-        name="AdminUserAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminUserAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminUserAttributeImpl")
-        }
+            name = "AdminUserAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminUserAttributeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserAttributeImpl")
+            }
     )
     @Column(name = "ATTRIBUTE_ID")
     protected Long id;
-    
+
     @Column(name = "FIELD_NAME", nullable = false)
-    @Index(name="ADMINUSERATTRIBUTE_NAME_INDEX", columnNames = { "NAME" })
+    @Index(name = "ADMINUSERATTRIBUTE_NAME_INDEX", columnNames = {"NAME"})
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String name;
 
@@ -66,9 +66,9 @@ public class AdminUserAttributeImpl implements AdminUserAttribute {
 
     @ManyToOne(targetEntity = AdminUserImpl.class, optional = false)
     @JoinColumn(name = "ADMIN_USER_ID")
-    @Index(name="ADMINUSERATTRIBUTE_INDEX", columnNames = { "ADMIN_USER_ID" })
+    @Index(name = "ADMINUSERATTRIBUTE_INDEX", columnNames = {"ADMIN_USER_ID"})
     protected AdminUser adminUser;
-    
+
     @Override
     public Long getId() {
         return id;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
@@ -17,22 +17,6 @@
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -68,6 +52,23 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * @author jfischer
  */
@@ -94,11 +95,13 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "AdminUserImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserImpl")
             }
     )
     @Column(name = "ADMIN_USER_ID")
-    @AdminPresentation(friendlyName = "AdminUserImpl_Admin_User_ID", group = "AdminUserImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AdminUserImpl_Admin_User_ID",
+            group = "AdminUserImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     private Long id;
 
     @Column(name = "NAME", nullable = false)
@@ -122,8 +125,10 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
             validationConfigurations = {@ValidationConfiguration(
                     validationImplementation = "org.broadleafcommerce.openadmin.server.service.persistence.validation.MatchesFieldValidator",
                     configurationItems = {
-                            @ConfigurationItem(itemName = ConfigurationItem.ERROR_MESSAGE, itemValue = "passwordNotMatchError"),
-                            @ConfigurationItem(itemName = "otherField", itemValue = "passwordConfirm")
+                            @ConfigurationItem(itemName = ConfigurationItem.ERROR_MESSAGE,
+                                    itemValue = "passwordNotMatchError"),
+                            @ConfigurationItem(itemName = "otherField",
+                                    itemValue = "passwordConfirm")
                     }
             )
             })
@@ -132,7 +137,8 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     @Column(name = "EMAIL", nullable = false)
     @Index(name = "ADMINPERM_EMAIL_INDEX", columnNames = {"EMAIL"})
     @AdminPresentation(friendlyName = "AdminUserImpl_Admin_Email_Address",
-            group = GroupName.User, order = FieldOrder.EMAIL, requiredOverride = RequiredOverride.REQUIRED,
+            group = GroupName.User, order = FieldOrder.EMAIL,
+            requiredOverride = RequiredOverride.REQUIRED,
             fieldType = SupportedFieldType.STRING)
     protected String email;
 
@@ -151,18 +157,26 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
      * All roles that this user has
      */
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminRoleImpl.class)
-    @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"))
+    @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_USER_ID",
+            referencedColumnName = "ADMIN_USER_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID",
+                    referencedColumnName = "ADMIN_ROLE_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "roleListTitle",
             group = GroupName.RolesAndPermissions, order = FieldOrder.ROLES,
             addType = AddMethodType.LOOKUP,
             manyToField = "allUsers",
-            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            operationTypes = @AdminPresentationOperationTypes(
+                    removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected Set<AdminRole> allRoles = new HashSet<AdminRole>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
-    @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
+    @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF",
+            joinColumns = @JoinColumn(name = "ADMIN_USER_ID",
+                    referencedColumnName = "ADMIN_USER_ID"),
+            inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID",
+                    referencedColumnName = "ADMIN_PERMISSION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "permissionListTitle",
@@ -170,7 +184,8 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
             addType = AddMethodType.LOOKUP,
             customCriteria = "includeFriendlyOnly",
             manyToField = "allUsers",
-            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            operationTypes = @AdminPresentationOperationTypes(
+                    removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected Set<AdminPermission> allPermissions = new HashSet<AdminPermission>();
 
     @Transient
@@ -182,18 +197,24 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     }
 
     @ManyToOne(targetEntity = SandBoxImpl.class, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-    @JoinTable(name = "BLC_ADMIN_USER_SANDBOX", joinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"), inverseJoinColumns = @JoinColumn(name = "SANDBOX_ID", referencedColumnName = "SANDBOX_ID"))
+    @JoinTable(name = "BLC_ADMIN_USER_SANDBOX", joinColumns = @JoinColumn(name = "ADMIN_USER_ID",
+            referencedColumnName = "ADMIN_USER_ID"),
+            inverseJoinColumns = @JoinColumn(name = "SANDBOX_ID",
+                    referencedColumnName = "SANDBOX_ID"))
     @AdminPresentation(excluded = true)
     protected SandBox overrideSandBox;
 
-    @OneToMany(mappedBy = "adminUser", targetEntity = AdminUserAttributeImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToMany(mappedBy = "adminUser", targetEntity = AdminUserAttributeImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @MapKey(name = "name")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "AdminUserImpl_additional_fields",
             group = GroupName.AdditionalFields,
-            deleteEntityUponRemove = true, forceFreeFormKeys = true, keyPropertyFriendlyName = "AdminUserAttributeImpl_Key")
-    protected Map<String, AdminUserAttribute> additionalFields = new HashMap<String, AdminUserAttribute>();
+            deleteEntityUponRemove = true, forceFreeFormKeys = true,
+            keyPropertyFriendlyName = "AdminUserAttributeImpl_Key")
+    protected Map<String, AdminUserAttribute> additionalFields =
+            new HashMap<String, AdminUserAttribute>();
 
     @Override
     public void setUnencodedPassword(String unencodedPassword) {

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
@@ -10,13 +10,29 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.openadmin.server.security.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -24,6 +40,7 @@ import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
@@ -51,32 +68,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ADMIN_USER")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_ADMINUSER),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY),
@@ -92,25 +90,25 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     @Id
     @GeneratedValue(generator = "AdminUserId")
     @GenericGenerator(
-        name="AdminUserId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="AdminUserImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.openadmin.server.security.domain.AdminUserImpl")
-        }
+            name = "AdminUserId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AdminUserImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.openadmin.server.security.domain.AdminUserImpl")
+            }
     )
     @Column(name = "ADMIN_USER_ID")
     @AdminPresentation(friendlyName = "AdminUserImpl_Admin_User_ID", group = "AdminUserImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     private Long id;
 
-    @Column(name = "NAME", nullable=false)
-    @Index(name="ADMINUSER_NAME_INDEX", columnNames={"NAME"})
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "ADMINUSER_NAME_INDEX", columnNames = {"NAME"})
     @AdminPresentation(friendlyName = "AdminUserImpl_Admin_Name",
             group = GroupName.User, order = FieldOrder.NAME,
             prominent = true, gridOrder = 1000)
     protected String name;
 
-    @Column(name = "LOGIN", nullable=false)
+    @Column(name = "LOGIN", nullable = false)
     @AdminPresentation(friendlyName = "AdminUserImpl_Admin_Login",
             group = GroupName.User, order = FieldOrder.LOGIN,
             prominent = true, gridOrder = 2000)
@@ -121,18 +119,18 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
             friendlyName = "AdminUserImpl_Admin_Password",
             group = GroupName.User, order = FieldOrder.PASSWORD,
             fieldType = SupportedFieldType.PASSWORD,
-            validationConfigurations = { @ValidationConfiguration(
+            validationConfigurations = {@ValidationConfiguration(
                     validationImplementation = "org.broadleafcommerce.openadmin.server.service.persistence.validation.MatchesFieldValidator",
                     configurationItems = {
                             @ConfigurationItem(itemName = ConfigurationItem.ERROR_MESSAGE, itemValue = "passwordNotMatchError"),
                             @ConfigurationItem(itemName = "otherField", itemValue = "passwordConfirm")
                     }
-                    )
+            )
             })
     protected String password;
 
-    @Column(name = "EMAIL", nullable=false)
-    @Index(name="ADMINPERM_EMAIL_INDEX", columnNames={"EMAIL"})
+    @Column(name = "EMAIL", nullable = false)
+    @Index(name = "ADMINPERM_EMAIL_INDEX", columnNames = {"EMAIL"})
     @AdminPresentation(friendlyName = "AdminUserImpl_Admin_Email_Address",
             group = GroupName.User, order = FieldOrder.EMAIL, requiredOverride = RequiredOverride.REQUIRED,
             fieldType = SupportedFieldType.STRING)
@@ -149,33 +147,35 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
             defaultValue = "true")
     protected Boolean activeStatusFlag;
 
-    /** All roles that this user has */
+    /**
+     * All roles that this user has
+     */
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminRoleImpl.class)
     @JoinTable(name = "BLC_ADMIN_USER_ROLE_XREF", joinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_ROLE_ID", referencedColumnName = "ADMIN_ROLE_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "roleListTitle",
-        group = GroupName.RolesAndPermissions, order = FieldOrder.ROLES,
-        addType = AddMethodType.LOOKUP,
-        manyToField = "allUsers",
-        operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            group = GroupName.RolesAndPermissions, order = FieldOrder.ROLES,
+            addType = AddMethodType.LOOKUP,
+            manyToField = "allUsers",
+            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected Set<AdminRole> allRoles = new HashSet<AdminRole>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = AdminPermissionImpl.class)
     @JoinTable(name = "BLC_ADMIN_USER_PERMISSION_XREF", joinColumns = @JoinColumn(name = "ADMIN_USER_ID", referencedColumnName = "ADMIN_USER_ID"), inverseJoinColumns = @JoinColumn(name = "ADMIN_PERMISSION_ID", referencedColumnName = "ADMIN_PERMISSION_ID"))
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "permissionListTitle",
-        group = GroupName.RolesAndPermissions, order = FieldOrder.PERMISSIONS,
-        addType = AddMethodType.LOOKUP,
-        customCriteria = "includeFriendlyOnly",
-        manyToField = "allUsers",
-        operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
+            group = GroupName.RolesAndPermissions, order = FieldOrder.PERMISSIONS,
+            addType = AddMethodType.LOOKUP,
+            customCriteria = "includeFriendlyOnly",
+            manyToField = "allUsers",
+            operationTypes = @AdminPresentationOperationTypes(removeType = OperationType.NONDESTRUCTIVEREMOVE))
     protected Set<AdminPermission> allPermissions = new HashSet<AdminPermission>();
 
     @Transient
     protected String unencodedPassword;
-    
+
     @Override
     public String getUnencodedPassword() {
         return unencodedPassword;
@@ -186,8 +186,8 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     @AdminPresentation(excluded = true)
     protected SandBox overrideSandBox;
 
-    @OneToMany(mappedBy = "adminUser", targetEntity = AdminUserAttributeImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
-    @Cache(usage=CacheConcurrencyStrategy.READ_WRITE, region="blAdminSecurityVolatile")
+    @OneToMany(mappedBy = "adminUser", targetEntity = AdminUserAttributeImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blAdminSecurityVolatile")
     @MapKey(name = "name")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "AdminUserImpl_additional_fields",
@@ -319,7 +319,7 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     public void setContextKey(String contextKey) {
         //do nothing
     }
-    
+
     @Override
     public Map<String, String> getFlatAdditionalFields() {
         Map<String, String> map = new HashMap<String, String>();
@@ -328,7 +328,7 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
         }
         return map;
     }
-    
+
     @Override
     public Map<String, AdminUserAttribute> getAdditionalFields() {
         return additionalFields;
@@ -338,7 +338,7 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     public void setAdditionalFields(Map<String, AdminUserAttribute> additionalFields) {
         this.additionalFields = additionalFields;
     }
-    
+
     @Override
     public Long getLastUsedSandBoxId() {
         AdminUserAttribute attr = getAdditionalFields().get(LAST_USED_SANDBOX);
@@ -347,7 +347,7 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
         }
         return null;
     }
-    
+
     @Override
     public void setLastUsedSandBoxId(Long sandBoxId) {
         AdminUserAttribute attr = getAdditionalFields().get(LAST_USED_SANDBOX);

--- a/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
@@ -10,30 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.config.domain;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.config.service.type.SystemPropertyFieldType;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.RequiredOverride;
-import org.broadleafcommerce.common.presentation.ValidationConfiguration;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -43,6 +25,24 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.config.service.type.SystemPropertyFieldType;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
+import org.broadleafcommerce.common.presentation.ValidationConfiguration;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * Allows the storage and retrieval of System Properties in the database
@@ -51,9 +51,9 @@ import jakarta.persistence.Table;
  * Date: 6/20/12
  */
 @Entity
-@Table(name="BLC_SYSTEM_PROPERTY", indexes = { 
+@Table(name = "BLC_SYSTEM_PROPERTY", indexes = {
         @Index(name = "IDX_BLSYPR_PROPERTY_NAME", columnList = "PROPERTY_NAME")
-    })
+})
 @Inheritance(strategy = InheritanceType.JOINED)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSystemProperties")
 @DirectCopyTransform({
@@ -67,12 +67,12 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
     @Id
     @GeneratedValue(generator = "SystemPropertyId")
     @GenericGenerator(
-        name="SystemPropertyId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="SystemPropertyImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.config.domain.SystemPropertyImpl")
-        }
+            name = "SystemPropertyId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SystemPropertyImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.config.domain.SystemPropertyImpl")
+            }
     )
     @Column(name = "BLC_SYSTEM_PROPERTY_ID")
     protected Long id;
@@ -82,7 +82,7 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
             group = GroupName.General, order = FieldOrder.ATTRIBUTE_NAME,
             prominent = true, gridOrder = 1000,
             requiredOverride = RequiredOverride.REQUIRED,
-            validationConfigurations=@ValidationConfiguration(validationImplementation="blSystemPropertyAttributeNameValidator"))
+            validationConfigurations = @ValidationConfiguration(validationImplementation = "blSystemPropertyAttributeNameValidator"))
     protected String name;
 
     @Column(name = "OVERRIDE_GENERATED_PROP_NAME")
@@ -90,35 +90,35 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
             group = GroupName.General)
     protected Boolean overrideGeneratedPropertyName = false;
 
-    @Column(name= "PROPERTY_VALUE")
+    @Column(name = "PROPERTY_VALUE")
     @AdminPresentation(friendlyName = "SystemPropertyImpl_value",
-        group = GroupName.General, order = FieldOrder.VALUE,
-        prominent = true, gridOrder = 3000,
-        requiredOverride = RequiredOverride.REQUIRED)
+            group = GroupName.General, order = FieldOrder.VALUE,
+            prominent = true, gridOrder = 3000,
+            requiredOverride = RequiredOverride.REQUIRED)
     protected String value;
 
     @Column(name = "PROPERTY_TYPE")
     @AdminPresentation(friendlyName = "SystemPropertyImpl_propertyType",
-        group = GroupName.General, order = FieldOrder.PROPERTY_TYPE,
-        prominent = true, gridOrder = 2000,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.common.config.service.type.SystemPropertyFieldType",
-        requiredOverride = RequiredOverride.REQUIRED)
+            group = GroupName.General, order = FieldOrder.PROPERTY_TYPE,
+            prominent = true, gridOrder = 2000,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.config.service.type.SystemPropertyFieldType",
+            requiredOverride = RequiredOverride.REQUIRED)
     protected String propertyType;
 
     @Column(name = "FRIENDLY_NAME")
     @AdminPresentation(friendlyName = "SystemPropertyImpl_friendlyName",
-        group = GroupName.General, order = FieldOrder.FRIENDLY_NAME)
+            group = GroupName.General, order = FieldOrder.FRIENDLY_NAME)
     protected String friendlyName;
 
     @Column(name = "FRIENDLY_GROUP")
     @AdminPresentation(friendlyName = "SystemPropertyImpl_friendlyGroup",
-        group = GroupName.Placement, order = FieldOrder.GROUP_NAME)
+            group = GroupName.Placement, order = FieldOrder.GROUP_NAME)
     protected String friendlyGroup;
 
     @Column(name = "FRIENDLY_TAB")
     @AdminPresentation(friendlyName = "SystemPropertyImpl_friendlyTab",
-        group = GroupName.Placement, order = FieldOrder.TAB_NAME)
+            group = GroupName.Placement, order = FieldOrder.TAB_NAME)
     protected String friendlyTab;
 
     @Override
@@ -160,7 +160,7 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
     public void setValue(String value) {
         this.value = value;
     }
-    
+
     @Override
     public String getFriendlyName() {
         return friendlyName;
@@ -180,7 +180,7 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
     public void setFriendlyGroup(String friendlyGroup) {
         this.friendlyGroup = friendlyGroup;
     }
-    
+
     @Override
     public String getFriendlyTab() {
         return friendlyTab;

--- a/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/domain/SystemPropertyImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.common.config.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -44,11 +36,19 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
 /**
  * Allows the storage and retrieval of System Properties in the database
  * <p/>
- * User: Kelly Tisdell
- * Date: 6/20/12
+ * User: Kelly Tisdell Date: 6/20/12
  */
 @Entity
 @Table(name = "BLC_SYSTEM_PROPERTY", indexes = {
@@ -60,7 +60,8 @@ import org.hibernate.annotations.Parameter;
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX)
 })
-public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, SystemPropertyAdminPresentation {
+public class SystemPropertyImpl
+        implements SystemProperty, AdminMainEntity, SystemPropertyAdminPresentation {
 
     private static final long serialVersionUID = 1L;
 
@@ -71,7 +72,8 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "SystemPropertyImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.config.domain.SystemPropertyImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.config.domain.SystemPropertyImpl")
             }
     )
     @Column(name = "BLC_SYSTEM_PROPERTY_ID")
@@ -82,7 +84,8 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
             group = GroupName.General, order = FieldOrder.ATTRIBUTE_NAME,
             prominent = true, gridOrder = 1000,
             requiredOverride = RequiredOverride.REQUIRED,
-            validationConfigurations = @ValidationConfiguration(validationImplementation = "blSystemPropertyAttributeNameValidator"))
+            validationConfigurations = @ValidationConfiguration(
+                    validationImplementation = "blSystemPropertyAttributeNameValidator"))
     protected String name;
 
     @Column(name = "OVERRIDE_GENERATED_PROP_NAME")
@@ -213,7 +216,8 @@ public class SystemPropertyImpl implements SystemProperty, AdminMainEntity, Syst
     }
 
     @Override
-    public <G extends SystemProperty> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SystemProperty> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingClicksImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingClicksImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.common.email.domain;
 
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,6 +25,11 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.Date;
 
 /**
  * @author jfischer
@@ -48,7 +48,7 @@ public class EmailTrackingClicksImpl implements EmailTrackingClicks {
     @GeneratedValue(generator = "ClickId")
     @GenericGenerator(
         name="ClickId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="EmailTrackingClicksImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.email.domain.EmailTrackingClicksImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingClicksImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingClicksImpl.java
@@ -210,11 +210,9 @@ public class EmailTrackingClicksImpl implements EmailTrackingClicks {
         } else if (!destinationUri.equals(other.destinationUri))
             return false;
         if (emailTracking == null) {
-            if (other.emailTracking != null)
-                return false;
-        } else if (!emailTracking.equals(other.emailTracking))
-            return false;
-        return true;
+            return other.emailTracking == null;
+        } else
+            return emailTracking.equals(other.emailTracking);
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingImpl.java
@@ -211,11 +211,9 @@ public class EmailTrackingImpl implements EmailTracking {
         } else if (!emailTrackingOpens.equals(other.emailTrackingOpens))
             return false;
         if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
-            return false;
-        return true;
+            return other.type == null;
+        } else
+            return type.equals(other.type);
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingImpl.java
@@ -17,13 +17,6 @@
  */
 package org.broadleafcommerce.common.email.domain;
 
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +24,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author jfischer
@@ -49,7 +49,7 @@ public class EmailTrackingImpl implements EmailTracking {
     @GeneratedValue(generator = "EmailTrackingId")
     @GenericGenerator(
         name="EmailTrackingId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="EmailTrackingImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.email.domain.EmailTrackingImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingOpensImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingOpensImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.common.email.domain;
 
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,6 +25,11 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.Date;
 
 /**
  * @author jfischer
@@ -48,7 +48,7 @@ public class EmailTrackingOpensImpl implements EmailTrackingOpens {
     @GeneratedValue(generator = "OpenId")
     @GenericGenerator(
         name="OpenId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="EmailTrackingOpensImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.email.domain.EmailTrackingOpensImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingOpensImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/domain/EmailTrackingOpensImpl.java
@@ -10,12 +10,18 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.email.domain;
+
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.Date;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,15 +31,9 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.Date;
 
 /**
  * @author jfischer
- *
  */
 @Entity
 @Table(name = "BLC_EMAIL_TRACKING_OPENS", indexes = {
@@ -47,12 +47,13 @@ public class EmailTrackingOpensImpl implements EmailTrackingOpens {
     @Id
     @GeneratedValue(generator = "OpenId")
     @GenericGenerator(
-        name="OpenId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="EmailTrackingOpensImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.email.domain.EmailTrackingOpensImpl")
-        }
+            name = "OpenId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "EmailTrackingOpensImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.email.domain.EmailTrackingOpensImpl")
+            }
     )
     @Column(name = "OPEN_ID")
     protected Long id;
@@ -113,7 +114,7 @@ public class EmailTrackingOpensImpl implements EmailTrackingOpens {
     @Override
     public void setUserAgent(String userAgent) {
         if (userAgent.length() > 255) {
-            userAgent = userAgent.substring(0,254);
+            userAgent = userAgent.substring(0, 254);
         }
         this.userAgent = userAgent;
     }
@@ -170,11 +171,9 @@ public class EmailTrackingOpensImpl implements EmailTrackingOpens {
         } else if (!emailTracking.equals(other.emailTracking))
             return false;
         if (userAgent == null) {
-            if (other.userAgent != null)
-                return false;
-        } else if (!userAgent.equals(other.userAgent))
-            return false;
-        return true;
+            return other.userAgent == null;
+        } else
+            return userAgent.equals(other.userAgent);
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
@@ -17,11 +17,22 @@
  */
 package org.broadleafcommerce.common.enumeration.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -35,17 +46,6 @@ import org.hibernate.annotations.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -64,7 +64,7 @@ public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
     @GeneratedValue(generator = "DataDrivenEnumerationId")
     @GenericGenerator(
         name="DataDrivenEnumerationId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="DataDrivenEnumerationImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.enumeration.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -47,13 +37,27 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_DATA_DRVN_ENUM", indexes = {@Index(name = "ENUM_KEY_INDEX", columnList = "ENUM_KEY")})
+@Table(name = "BLC_DATA_DRVN_ENUM",
+        indexes = {@Index(name = "ENUM_KEY_INDEX", columnList = "ENUM_KEY")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "DataDrivenEnumerationImpl_friendyName")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "DataDrivenEnumerationImpl_friendyName")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
@@ -63,29 +67,35 @@ public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
     @Id
     @GeneratedValue(generator = "DataDrivenEnumerationId")
     @GenericGenerator(
-        name="DataDrivenEnumerationId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="DataDrivenEnumerationImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl")
-        }
+            name = "DataDrivenEnumerationId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "DataDrivenEnumerationImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationImpl")
+            }
     )
     @Column(name = "ENUM_ID")
     protected Long id;
-    
+
     @Column(name = "ENUM_KEY")
-    @AdminPresentation(friendlyName = "DataDrivenEnumerationImpl_Key", order = 1, gridOrder = 1, prominent = true)
+    @AdminPresentation(friendlyName = "DataDrivenEnumerationImpl_Key", order = 1, gridOrder = 1,
+            prominent = true)
     protected String key;
-    
+
     @Column(name = "MODIFIABLE")
-    @AdminPresentation(friendlyName = "DataDrivenEnumerationImpl_Modifiable", order = 2, gridOrder = 2, prominent = true)
+    @AdminPresentation(friendlyName = "DataDrivenEnumerationImpl_Modifiable", order = 2,
+            gridOrder = 2, prominent = true)
     protected Boolean modifiable = false;
 
-    @OneToMany(mappedBy = "type", targetEntity = DataDrivenEnumerationValueImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "type", targetEntity = DataDrivenEnumerationValueImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
-    @AdminPresentationCollection(addType = AddMethodType.PERSIST, friendlyName = "DataDrivenEnumerationImpl_Enum_Values", order = 3)
-    protected List<DataDrivenEnumerationValue> enumValues = new ArrayList<DataDrivenEnumerationValue>();
-    
+    @AdminPresentationCollection(addType = AddMethodType.PERSIST,
+            friendlyName = "DataDrivenEnumerationImpl_Enum_Values", order = 3)
+    protected List<DataDrivenEnumerationValue> enumValues =
+            new ArrayList<DataDrivenEnumerationValue>();
+
     @Override
     public Long getId() {
         return id;
@@ -145,7 +155,8 @@ public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
     }
 
     @Override
-    public <G extends DataDrivenEnumeration> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+    public <G extends DataDrivenEnumeration> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context)
             throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -155,7 +166,8 @@ public class DataDrivenEnumerationImpl implements DataDrivenEnumeration {
         cloned.setKey(key);
         cloned.setModifiable(modifiable);
         for (DataDrivenEnumerationValue value : enumValues) {
-            DataDrivenEnumerationValue clonedValue = value.createOrRetrieveCopyInstance(context).getClone();
+            DataDrivenEnumerationValue clonedValue =
+                    value.createOrRetrieveCopyInstance(context).getClone();
             cloned.getEnumValues().add(clonedValue);
         }
         return createResponse;

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
@@ -17,18 +17,6 @@
  */
 package org.broadleafcommerce.common.enumeration.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,6 +28,18 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * @author Jeff Fischer
@@ -63,7 +63,7 @@ public class DataDrivenEnumerationValueImpl implements DataDrivenEnumerationValu
     @GeneratedValue(generator = "DataDrivenEnumerationValueId")
     @GenericGenerator(
         name="DataDrivenEnumerationValueId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="DataDrivenEnumerationValueImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/enumeration/domain/DataDrivenEnumerationValueImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.enumeration.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -41,6 +30,18 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author Jeff Fischer
  */
@@ -52,7 +53,8 @@ import org.hibernate.annotations.Parameter;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blDataDrivenEnumeration")
 @AdminPresentationClass(friendlyName = "DataDrivenEnumerationValueImpl_friendyName")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
 })
 public class DataDrivenEnumerationValueImpl implements DataDrivenEnumerationValue {
@@ -62,12 +64,13 @@ public class DataDrivenEnumerationValueImpl implements DataDrivenEnumerationValu
     @Id
     @GeneratedValue(generator = "DataDrivenEnumerationValueId")
     @GenericGenerator(
-        name="DataDrivenEnumerationValueId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="DataDrivenEnumerationValueImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl")
-        }
+            name = "DataDrivenEnumerationValueId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "DataDrivenEnumerationValueImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.enumeration.domain.DataDrivenEnumerationValueImpl")
+            }
     )
     @Column(name = "ENUM_VAL_ID")
     protected Long id;
@@ -77,15 +80,18 @@ public class DataDrivenEnumerationValueImpl implements DataDrivenEnumerationValu
     protected DataDrivenEnumeration type;
 
     @Column(name = "ENUM_KEY")
-    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Key", order = 1, gridOrder = 1, prominent = true)
+    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Key", order = 1,
+            gridOrder = 1, prominent = true)
     protected String key;
 
     @Column(name = "DISPLAY")
-    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Display", order = 2, gridOrder = 2, prominent = true)
+    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Display", order = 2,
+            gridOrder = 2, prominent = true)
     protected String display;
 
     @Column(name = "HIDDEN")
-    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Hidden", order = 3, gridOrder = 3, prominent = true)
+    @AdminPresentation(friendlyName = "DataDrivenEnumerationValueImpl_Hidden", order = 3,
+            gridOrder = 3, prominent = true)
     protected Boolean hidden = false;
 
     @Override
@@ -143,7 +149,8 @@ public class DataDrivenEnumerationValueImpl implements DataDrivenEnumerationValu
     }
 
     @Override
-    public <G extends DataDrivenEnumerationValue> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends DataDrivenEnumerationValue> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
@@ -17,22 +17,6 @@
  */
 package org.broadleafcommerce.common.media.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCloneable;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,6 +25,22 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.domain.TranslatedEntity;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -60,7 +60,7 @@ public class MediaImpl implements Media, MultiTenantCloneable<MediaImpl> {
     @GeneratedValue(generator= "MediaId")
     @GenericGenerator(
         name="MediaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="MediaImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.media.domain.MediaImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/media/domain/MediaImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.common.media.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -41,6 +33,15 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -195,11 +196,9 @@ public class MediaImpl implements Media, MultiTenantCloneable<MediaImpl> {
         } else if (!tags.equals(other.tags))
             return false;
         if (url == null) {
-            if (other.url != null)
-                return false;
-        } else if (!url.equals(other.url))
-            return false;
-        return true;
+            return other.url == null;
+        } else
+            return url.equals(other.url);
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxImpl.java
@@ -10,25 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.sandbox.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -55,9 +43,23 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_SANDBOX", indexes = {@Index(name = "SANDBOX_NAME_INDEX", columnList = "SANDBOX_NAME")})
+@Table(name = "BLC_SANDBOX",
+        indexes = {@Index(name = "SANDBOX_NAME_INDEX", columnList = "SANDBOX_NAME")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSandBoxElements")
 @SQLDelete(sql = "UPDATE BLC_SANDBOX SET ARCHIVED = 'Y' WHERE SANDBOX_ID = ?")
 @DirectCopyTransform({
@@ -71,61 +73,68 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
     @Id
     @GeneratedValue(generator = "SandBoxId")
     @GenericGenerator(
-        name="SandBoxId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SandBoxImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.sandbox.domain.SandBoxImpl")
-        }
+            name = "SandBoxId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SandBoxImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.sandbox.domain.SandBoxImpl")
+            }
     )
     @Column(name = "SANDBOX_ID")
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
+
     @Column(name = "SANDBOX_NAME")
-    @AdminPresentation(friendlyName = "SandBoxImpl_Name", group = SandboxAdminPresentation.GroupName.Description, prominent = true, 
+    @AdminPresentation(friendlyName = "SandBoxImpl_Name",
+            group = SandboxAdminPresentation.GroupName.Description, prominent = true,
             gridOrder = 2000, order = 1000,
-            validationConfigurations = { @ValidationConfiguration(validationImplementation = "blSandBoxNameValidator") })
+            validationConfigurations = {
+                    @ValidationConfiguration(validationImplementation = "blSandBoxNameValidator")})
     protected String name;
-    
-    @Column(name="AUTHOR")
-    @AdminPresentation(friendlyName = "SandBoxImpl_Author", group = SandboxAdminPresentation.GroupName.Description,
-        gridOrder = 3000, order = 3000, visibility = VisibilityEnum.FORM_HIDDEN)
+
+    @Column(name = "AUTHOR")
+    @AdminPresentation(friendlyName = "SandBoxImpl_Author",
+            group = SandboxAdminPresentation.GroupName.Description,
+            gridOrder = 3000, order = 3000, visibility = VisibilityEnum.FORM_HIDDEN)
     protected Long author;
 
     @Column(name = "SANDBOX_TYPE")
-    @AdminPresentation(friendlyName = "SandBoxImpl_SandBox_Type", group = SandboxAdminPresentation.GroupName.Description,
-        visibility = VisibilityEnum.HIDDEN_ALL, readOnly = true,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration="org.broadleafcommerce.common.sandbox.domain.SandBoxType")
+    @AdminPresentation(friendlyName = "SandBoxImpl_SandBox_Type",
+            group = SandboxAdminPresentation.GroupName.Description,
+            visibility = VisibilityEnum.HIDDEN_ALL, readOnly = true,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.sandbox.domain.SandBoxType")
     //need to set a default value so that add sandbox works correctly in the admin
     protected String sandboxType = SandBoxType.APPROVAL.getType();
 
     @ManyToOne(targetEntity = SandBoxImpl.class)
     @JoinColumn(name = "PARENT_SANDBOX_ID")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blSandBoxElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSandBoxElements")
     protected SandBox parentSandBox;
 
     @OneToMany(mappedBy = "parentSandBox", targetEntity = SandBoxImpl.class)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blSandBoxElements")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSandBoxElements")
     protected List<SandBox> childSandBoxes;
 
     @Column(name = "COLOR")
-    @AdminPresentation(friendlyName = "SandBoxImpl_Color", group = SandboxAdminPresentation.GroupName.Description, 
-        prominent = true, gridOrder = 1000, fieldType = SupportedFieldType.COLOR, order = 2000)
+    @AdminPresentation(friendlyName = "SandBoxImpl_Color",
+            group = SandboxAdminPresentation.GroupName.Description,
+            prominent = true, gridOrder = 1000, fieldType = SupportedFieldType.COLOR, order = 2000)
     protected String color;
 
     @Column(name = "DESCRIPTION")
-    @AdminPresentation(friendlyName = SandboxAdminPresentation.GroupName.Description, group = SandboxAdminPresentation.GroupName.Description,
-        prominent = true, gridOrder = 4000, order = 4000)
+    @AdminPresentation(friendlyName = SandboxAdminPresentation.GroupName.Description,
+            group = SandboxAdminPresentation.GroupName.Description,
+            prominent = true, gridOrder = 4000, order = 4000)
     protected String description;
 
     /*
      * This field should not be used until logic for it is implemented.
-     * 
+     *
      * @AdminPresentation(friendlyName = "SandBoxImpl_Go_Live_Date", group = SandboxAdminPresentation.GroupName.Description,
      *   prominent = true, gridOrder = 5000, order = 3000)
-    */
+     */
     @Column(name = "GO_LIVE_DATE")
     protected Date goLiveDate;
 
@@ -226,7 +235,8 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
     }
 
     @Override
-    public List<Long> getSandBoxIdsForUpwardHierarchy(boolean includeInherited, boolean includeCurrent) {
+    public List<Long> getSandBoxIdsForUpwardHierarchy(boolean includeInherited,
+            boolean includeCurrent) {
         List<Long> ids = new ArrayList<Long>();
         if (includeCurrent) {
             ids.add(this.getId());
@@ -245,12 +255,12 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
     @Override
     public int hashCode() {
         return new HashCodeBuilder(1, 31)
-            .append(author)
-            .append(id)
-            .append(name)
-            .append(color)
-            .append(goLiveDate)
-            .toHashCode();
+                .append(author)
+                .append(id)
+                .append(name)
+                .append(color)
+                .append(goLiveDate)
+                .toHashCode();
     }
 
     @Override
@@ -258,12 +268,12 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
         if (obj != null && getClass().isAssignableFrom(obj.getClass())) {
             SandBoxImpl other = (SandBoxImpl) obj;
             return new EqualsBuilder()
-                .append(author, other.author)
-                .append(id, other.id)
-                .append(name, other.name)
-                .append(color, other.color)
-                .append(goLiveDate, other.goLiveDate)
-                .build();
+                    .append(author, other.author)
+                    .append(id, other.id)
+                    .append(name, other.name)
+                    .append(color, other.color)
+                    .append(goLiveDate, other.goLiveDate)
+                    .build();
         }
         return false;
     }
@@ -272,7 +282,7 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
     public String getMainEntityName() {
         return getName();
     }
-    
+
     @Override
     public boolean getIsInDefaultHierarchy() {
         if (SandBoxType.DEFAULT.equals(getSandBoxType())) {
@@ -282,7 +292,7 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
         if (getParentSandBox() != null) {
             return getParentSandBox().getIsInDefaultHierarchy();
         }
-        
+
         return false;
     }
 
@@ -307,6 +317,6 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
 
     @Override
     public boolean isActive() {
-        return 'Y'!=getArchived();
+        return 'Y' != getArchived();
     }
 }

--- a/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.common.sandbox.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -27,6 +39,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.ValidationConfiguration;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -41,19 +54,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -72,7 +72,7 @@ public class SandBoxImpl implements SandBox, AdminMainEntity {
     @GeneratedValue(generator = "SandBoxId")
     @GenericGenerator(
         name="SandBoxId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SandBoxImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.sandbox.domain.SandBoxImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxManagementImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxManagementImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.sandbox.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -42,25 +32,38 @@ import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
 /**
- * This class is required mostly as a workaround for an issue in Hibernate. It's obscure, but I'll try to explain.
- * SandBox ids are used as discriminators in workflow. SandBoxes themselves are also able to be managed in the
- * admin (add new sandbox, etc...) Site ids are used as discriminators in multitenant. When workflow and multitenant
- * are used together, both discriminators are in effect. Because sandboxes can be managed in the admin, it is required
- * that they have a site discriminator to be managed in the multitenant admin. This intermingling of references
- * ends up causing this exception at runtime during, for example, a product save:
+ * This class is required mostly as a workaround for an issue in Hibernate. It's obscure, but I'll
+ * try to explain. SandBox ids are used as discriminators in workflow. SandBoxes themselves are also
+ * able to be managed in the admin (add new sandbox, etc...) Site ids are used as discriminators in
+ * multitenant. When workflow and multitenant are used together, both discriminators are in effect.
+ * Because sandboxes can be managed in the admin, it is required that they have a site discriminator
+ * to be managed in the multitenant admin. This intermingling of references ends up causing this
+ * exception at runtime during, for example, a product save:
  *
  * HibernateException: Found two representations of same collection
  *
- * To workaround, we use this management entity that exposes the properties seamlessly of SandBox to the admin, but
- * holds the site discriminator on its own table (rather than BLC_SANDBOX), which fixes the issue.
+ * To workaround, we use this management entity that exposes the properties seamlessly of SandBox to
+ * the admin, but holds the site discriminator on its own table (rather than BLC_SANDBOX), which
+ * fixes the issue.
  *
  * @author Jeff Fischer
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_SANDBOX_MGMT")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blSandBoxElements")
+@Table(name = "BLC_SANDBOX_MGMT")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSandBoxElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
@@ -75,19 +78,20 @@ public class SandBoxManagementImpl implements AdminMainEntity, SandBoxManagement
     @Id
     @GeneratedValue(generator = "SandBoxMgmtId")
     @GenericGenerator(
-        name="SandBoxMgmtId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SandBoxManagementImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.sandbox.domain.SandBoxManagementImpl")
-        }
+            name = "SandBoxMgmtId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SandBoxManagementImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.sandbox.domain.SandBoxManagementImpl")
+            }
     )
     @Column(name = "SANDBOX_MGMT_ID")
     protected Long id;
 
-    @OneToOne(targetEntity = SandBoxImpl.class, cascade={CascadeType.ALL}, optional = false)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blSandBoxElements")
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
+    @OneToOne(targetEntity = SandBoxImpl.class, cascade = {CascadeType.ALL}, optional = false)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSandBoxElements")
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL})
     @JoinColumn(name = "SANDBOX_ID")
     protected SandBox sandBox;
 

--- a/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxManagementImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sandbox/domain/SandBoxManagementImpl.java
@@ -17,20 +17,6 @@
  */
 package org.broadleafcommerce.common.sandbox.domain;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,6 +27,20 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * This class is required mostly as a workaround for an issue in Hibernate. It's obscure, but I'll try to explain.
@@ -76,7 +76,7 @@ public class SandBoxManagementImpl implements AdminMainEntity, SandBoxManagement
     @GeneratedValue(generator = "SandBoxMgmtId")
     @GenericGenerator(
         name="SandBoxMgmtId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SandBoxManagementImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.sandbox.domain.SandBoxManagementImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
@@ -145,7 +145,7 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
     }
 
     public void checkCloneable(Catalog catalog) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = catalog.getClass().getMethod("clone", new Class[] {});
+        Method cloneMethod = catalog.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !catalog.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteCatalogXrefImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteCatalogXrefImpl.java
@@ -17,13 +17,6 @@
  */
 package org.broadleafcommerce.common.site.domain;
 
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -33,6 +26,13 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 
 @Entity
@@ -52,7 +52,7 @@ public class SiteCatalogXrefImpl implements SiteCatalogXref, AdminMainEntity {
     @GeneratedValue(generator = "SiteCatalogXrefId")
     @GenericGenerator(
         name="SiteCatalogXrefId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SiteCatalogXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.site.domain.SiteCatalogXrefImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteCatalogXrefImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteCatalogXrefImpl.java
@@ -10,12 +10,20 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.common.site.domain;
+
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,19 +34,12 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 
 @Entity
 @Table(name = "BLC_SITE_CATALOG")
 @Inheritance(strategy = InheritanceType.JOINED)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blSiteElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSiteElements")
 @AdminPresentationClass(friendlyName = "SiteCatalogXrefImpl")
 public class SiteCatalogXrefImpl implements SiteCatalogXref, AdminMainEntity {
 
@@ -51,12 +52,13 @@ public class SiteCatalogXrefImpl implements SiteCatalogXref, AdminMainEntity {
     @Id
     @GeneratedValue(generator = "SiteCatalogXrefId")
     @GenericGenerator(
-        name="SiteCatalogXrefId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SiteCatalogXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.common.site.domain.SiteCatalogXrefImpl")
-        }
+            name = "SiteCatalogXrefId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SiteCatalogXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.common.site.domain.SiteCatalogXrefImpl")
+            }
     )
     @Column(name = "SITE_CATALOG_XREF_ID")
     protected Long id;

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
@@ -260,7 +260,7 @@ public class SiteImpl implements Site, SiteAdminPresentation, AdminMainEntity {
     }
 
     public void checkCloneable(Site site) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = site.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = site.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !site.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone.");
@@ -283,7 +283,7 @@ public class SiteImpl implements Site, SiteAdminPresentation, AdminMainEntity {
             clone.setSiteResolutionType(getSiteResolutionType());
             clone.setSiteIdentifierValue(getSiteIdentifierValue());
             clone.setDefaultLocale(getDefaultLocale());
-            ((Status) clone).setArchived(getArchived());
+            clone.setArchived(getArchived());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -303,9 +303,7 @@ public class SiteImpl implements Site, SiteAdminPresentation, AdminMainEntity {
 
         SiteImpl site = (SiteImpl) o;
 
-        if (id != null && site.id != null && id.equals(site.id)) return true;
-
-        return false;
+        return id != null && site.id != null && id.equals(site.id);
     }
 
     @Override

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/SiteImpl.java
@@ -17,31 +17,6 @@
  */
 package org.broadleafcommerce.common.site.domain;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.locale.domain.Locale;
-import org.broadleafcommerce.common.locale.domain.LocaleImpl;
-import org.broadleafcommerce.common.persistence.ArchiveStatus;
-import org.broadleafcommerce.common.persistence.Status;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.RequiredOverride;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.broadleafcommerce.common.site.service.type.SiteResolutionType;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -56,6 +31,31 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.locale.domain.Locale;
+import org.broadleafcommerce.common.locale.domain.LocaleImpl;
+import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.persistence.Status;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.RequiredOverride;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.common.site.service.type.SiteResolutionType;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by bpolster.
@@ -78,7 +78,7 @@ public class SiteImpl implements Site, SiteAdminPresentation, AdminMainEntity {
     @GeneratedValue(generator = "SiteId")
     @GenericGenerator(
         name="SiteId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SiteImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.common.site.domain.SiteImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -42,48 +32,62 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
- * 
  * @author Phillip Verheyden
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_CATEGORY_ATTRIBUTE")
+@Table(name = "BLC_CATEGORY_ATTRIBUTE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @AdminPresentationClass(friendlyName = "baseCategoryAttribute")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class CategoryAttributeImpl implements CategoryAttribute {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Id
-    @GeneratedValue(generator= "CategoryAttributeId")
+    @GeneratedValue(generator = "CategoryAttributeId")
     @GenericGenerator(
-        name="CategoryAttributeId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategoryAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryAttributeImpl")
-        }
+            name = "CategoryAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategoryAttributeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CategoryAttributeImpl")
+            }
     )
     @Column(name = "CATEGORY_ATTRIBUTE_ID")
     protected Long id;
-    
-    @Column(name = "NAME", nullable=false)
-    @Index(name="CATEGORYATTRIBUTE_NAME_INDEX", columnNames={"NAME"})
-    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Name", order=-1, group = "ProductAttributeImpl_Description", prominent=true, gridOrder = 1)
+
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "CATEGORYATTRIBUTE_NAME_INDEX", columnNames = {"NAME"})
+    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Name", order = -1,
+            group = "ProductAttributeImpl_Description", prominent = true, gridOrder = 1)
     protected String name;
 
     @Column(name = "VALUE")
-    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Value", order=2, group = "ProductAttributeImpl_Description", prominent=true)
+    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Value", order = 2,
+            group = "ProductAttributeImpl_Description", prominent = true)
     protected String value;
-    
-    @ManyToOne(targetEntity = CategoryImpl.class, optional=false, cascade = CascadeType.REFRESH)
+
+    @ManyToOne(targetEntity = CategoryImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
-    @Index(name="CATEGORYATTRIBUTE_INDEX", columnNames={"CATEGORY_ID"})
+    @Index(name = "CATEGORYATTRIBUTE_INDEX", columnNames = {"CATEGORY_ID"})
     protected Category category;
 
     @Override
@@ -174,7 +178,8 @@ public class CategoryAttributeImpl implements CategoryAttribute {
     }
 
     @Override
-    public <G extends CategoryAttribute> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CategoryAttribute> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -185,6 +190,6 @@ public class CategoryAttributeImpl implements CategoryAttribute {
         }
         cloned.setName(name);
         cloned.setValue(value);
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryAttributeImpl.java
@@ -17,20 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,6 +27,20 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -63,7 +63,7 @@ public class CategoryAttributeImpl implements CategoryAttribute {
     @GeneratedValue(generator= "CategoryAttributeId")
     @GenericGenerator(
         name="CategoryAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryAttributeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryAttributeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
@@ -17,6 +17,22 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
@@ -36,6 +52,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.media.domain.Media;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationAdornedTargetCollection;
@@ -84,23 +101,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 /**
  * @author bTaylor
@@ -164,7 +164,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @GeneratedValue(generator= "CategoryId")
     @GenericGenerator(
         name="CategoryId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
@@ -10,29 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
@@ -102,20 +86,40 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * @author bTaylor
  * @author Jeff Fischer
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_CATEGORY")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCategories")
-@SQLDelete(sql="UPDATE BLC_CATEGORY SET ARCHIVED = 'Y' WHERE CATEGORY_ID = ?")
+@Table(name = "BLC_CATEGORY")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategories")
+@SQLDelete(sql = "UPDATE BLC_CATEGORY SET ARCHIVED = 'Y' WHERE CATEGORY_ID = ?")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class CategoryImpl implements Category, Status, AdminMainEntity, Locatable, TemplatePathContainer, CategoryAdminPresentation {
+public class CategoryImpl
+        implements Category, Status, AdminMainEntity, Locatable, TemplatePathContainer,
+        CategoryAdminPresentation {
 
     private static final long serialVersionUID = 1L;
     private static final Log LOG = LogFactory.getLog(CategoryImpl.class);
@@ -130,7 +134,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             if (!ignoreTopLevel || myCategory.getParentCategory() != null) {
                 if (linkBuffer.length() == 0) {
                     linkBuffer.append(myCategory.getUrlKey());
-                } else if(myCategory.getUrlKey() != null && !"/".equals(myCategory.getUrlKey())){
+                } else if (myCategory.getUrlKey() != null && !"/".equals(myCategory.getUrlKey())) {
                     linkBuffer.insert(0, myCategory.getUrlKey() + '/');
                 }
             }
@@ -140,14 +144,19 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         return linkBuffer.toString();
     }
 
-    private static void fillInURLMapForCategory(Map<String, List<Long>> categoryUrlMap, Category category, String startingPath, List<Long> startingCategoryList) throws CacheFactoryException {
+    private static void fillInURLMapForCategory(Map<String, List<Long>> categoryUrlMap,
+            Category category,
+            String startingPath,
+            List<Long> startingCategoryList) throws CacheFactoryException {
         String urlKey = category.getUrlKey();
         if (urlKey == null) {
-            throw new CacheFactoryException("Cannot create childCategoryURLMap - the urlKey for a category("+category.getId()+") was null");
+            throw new CacheFactoryException(
+                    "Cannot create childCategoryURLMap - the urlKey for a category("
+                            + category.getId() + ") was null");
         }
 
         String currentPath = "";
-        if (! "/".equals(category.getUrlKey())) {
+        if (!"/".equals(category.getUrlKey())) {
             currentPath = startingPath + "/" + category.getUrlKey();
         }
 
@@ -156,26 +165,29 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
         categoryUrlMap.put(currentPath, newCategoryList);
         for (CategoryXref currentCategory : category.getChildCategoryXrefs()) {
-            fillInURLMapForCategory(categoryUrlMap, currentCategory.getSubCategory(), currentPath, newCategoryList);
+            fillInURLMapForCategory(categoryUrlMap, currentCategory.getSubCategory(), currentPath,
+                    newCategoryList);
         }
     }
 
     @Id
-    @GeneratedValue(generator= "CategoryId")
+    @GeneratedValue(generator = "CategoryId")
     @GenericGenerator(
-        name="CategoryId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategoryImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryImpl")
-        }
+            name = "CategoryId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategoryImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CategoryImpl")
+            }
     )
     @Column(name = "CATEGORY_ID")
-    @AdminPresentation(friendlyName = "CategoryImpl_Category_ID", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "CategoryImpl_Category_ID",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
-    @Index(name="CATEGORY_NAME_INDEX", columnNames={"NAME"})
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "CATEGORY_NAME_INDEX", columnNames = {"NAME"})
     @AdminPresentation(friendlyName = "CategoryImpl_Category_Name", order = 1000,
             group = GroupName.General,
             prominent = true, gridOrder = 1000,
@@ -186,24 +198,26 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @AdminPresentation(friendlyName = "CategoryImpl_Category_Url", order = 4000,
             group = GroupName.General,
             prominent = true, gridOrder = 2000,
-            validationConfigurations = { @ValidationConfiguration(validationImplementation = "blUriPropertyValidator") })
-    @Index(name="CATEGORY_URL_INDEX", columnNames={"URL"})
+            validationConfigurations = {
+                    @ValidationConfiguration(validationImplementation = "blUriPropertyValidator")})
+    @Index(name = "CATEGORY_URL_INDEX", columnNames = {"URL"})
     protected String url;
 
     @Column(name = "OVERRIDE_GENERATED_URL")
-    @AdminPresentation(friendlyName = "CategoryImpl_Override_Generated_Url", group = GroupName.General,
+    @AdminPresentation(friendlyName = "CategoryImpl_Override_Generated_Url",
+            group = GroupName.General,
             order = 2010, defaultValue = "false")
     protected Boolean overrideGeneratedUrl = false;
 
     @Column(name = "EXTERNAL_ID")
-    @Index(name="CATEGORY_E_ID_INDEX", columnNames={"EXTERNAL_ID"})
+    @Index(name = "CATEGORY_E_ID_INDEX", columnNames = {"EXTERNAL_ID"})
     @AdminPresentation(friendlyName = "CategoryImpl_Category_ExternalID",
             group = GroupName.Miscellaneous, order = 2000,
             tooltip = "CategoryImpl_Category_ExternalID_Tooltip")
     protected String externalId;
 
     @Column(name = "URL_KEY")
-    @Index(name="CATEGORY_URLKEY_INDEX", columnNames={"URL_KEY"})
+    @Index(name = "CATEGORY_URLKEY_INDEX", columnNames = {"URL_KEY"})
     @AdminPresentation(friendlyName = "CategoryImpl_Category_Url_Key",
             group = GroupName.ProductDefaults, excluded = true)
     protected String urlKey;
@@ -221,8 +235,10 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @AdminPresentation(friendlyName = "CategoryImpl_Category_TaxCode", order = 4000,
             tooltip = "categoryTaxCodeHelpText",
             group = GroupName.ProductDefaults)
-    @AdminPresentationDataDrivenEnumeration(optionCanEditValues = true, optionHideIfEmpty = true, optionFilterParams = { @OptionFilterParam(
-            param = "type.key", value = "TAX_CODE", paramType = OptionFilterParamType.STRING) })
+    @AdminPresentationDataDrivenEnumeration(optionCanEditValues = true, optionHideIfEmpty = true,
+            optionFilterParams = {@OptionFilterParam(
+                    param = "type.key", value = "TAX_CODE",
+                    paramType = OptionFilterParamType.STRING)})
     protected String taxCode;
 
     @Column(name = "ACTIVE_START_DATE")
@@ -233,13 +249,14 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @Column(name = "ACTIVE_END_DATE")
     @AdminPresentation(friendlyName = "CategoryImpl_Category_Active_End_Date", order = 2000,
-        group = GroupName.ActiveDateRange,
-        validationConfigurations = {
-            @ValidationConfiguration(validationImplementation = "blAfterStartDateValidator",
-                configurationItems = {
-                    @ConfigurationItem(itemName = "otherField", itemValue = "activeStartDate")
+            group = GroupName.ActiveDateRange,
+            validationConfigurations = {
+                    @ValidationConfiguration(validationImplementation = "blAfterStartDateValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "activeStartDate")
+                            })
             })
-        })
     protected Date activeEndDate;
 
     @Column(name = "DISPLAY_TEMPLATE")
@@ -286,7 +303,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @ManyToOne(targetEntity = CategoryImpl.class)
     @JoinColumn(name = "DEFAULT_PARENT_CATEGORY_ID")
-    @Index(name="CATEGORY_PARENT_INDEX", columnNames={"DEFAULT_PARENT_CATEGORY_ID"})
+    @Index(name = "CATEGORY_PARENT_INDEX", columnNames = {"DEFAULT_PARENT_CATEGORY_ID"})
     @AdminPresentation(friendlyName = "CategoryImpl_defaultParentCategory", order = 3000,
             group = GroupName.General)
     @AdminPresentationToOneLookup()
@@ -295,7 +312,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @OneToMany(targetEntity = CategoryXrefImpl.class, mappedBy = "category", orphanRemoval = true,
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
-    @OrderBy(value="displayOrder")
+    @OrderBy(value = "displayOrder")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
@@ -304,12 +321,13 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             friendlyName = "allChildCategoriesTitle",
             sortProperty = "displayOrder",
             tab = TabName.Subcategories,
-            gridVisibleFields = { "name" })
+            gridVisibleFields = {"name"})
     protected List<CategoryXref> allChildCategoryXrefs = new ArrayList<CategoryXref>(10);
 
-    @OneToMany(targetEntity = CategoryXrefImpl.class, mappedBy = "subCategory", orphanRemoval = true,
+    @OneToMany(targetEntity = CategoryXrefImpl.class, mappedBy = "subCategory",
+            orphanRemoval = true,
             cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
-    @OrderBy(value="displayOrder")
+    @OrderBy(value = "displayOrder")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
@@ -318,12 +336,13 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             friendlyName = "allParentCategoriesTitle",
             sortProperty = "displayOrder",
             tab = TabName.Subcategories,
-            gridVisibleFields = { "name" })
+            gridVisibleFields = {"name"})
     protected List<CategoryXref> allParentCategoryXrefs = new ArrayList<CategoryXref>(10);
 
-    @OneToMany(targetEntity = CategoryProductXrefImpl.class, mappedBy = "category", orphanRemoval = true,
+    @OneToMany(targetEntity = CategoryProductXrefImpl.class, mappedBy = "category",
+            orphanRemoval = true,
             cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
-    @OrderBy(value="displayOrder")
+    @OrderBy(value = "displayOrder")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryProduct")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(
@@ -331,96 +350,106 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             parentObjectProperty = "category",
             friendlyName = "allProductsTitle",
             tab = TabName.Products,
-            gridVisibleFields = { "defaultSku.name", "displayOrder" },
-            maintainedAdornedTargetFields = { "displayOrder" })
+            gridVisibleFields = {"defaultSku.name", "displayOrder"},
+            maintainedAdornedTargetFields = {"displayOrder"})
     protected List<CategoryProductXref> allProductXrefs = new ArrayList<CategoryProductXref>(10);
 
-    @OneToMany(mappedBy = "category", targetEntity = CategoryMediaXrefImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
+    @OneToMany(mappedBy = "category", targetEntity = CategoryMediaXrefImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @MapKey(name = "key")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationMap(friendlyName = "CategoryImpl_Category_Media",
-        tab = TabName.Media,
-        keyPropertyFriendlyName = "CategoryImpl_Category_Media_Key",
-        deleteEntityUponRemove = true,
-        mediaField = "media.url",
-        toOneTargetProperty = "media",
-        toOneParentProperty = "category",
-        keys = {
-            @AdminPresentationMapKey(keyName = "primary", friendlyKeyName = "mediaPrimary"),
-            @AdminPresentationMapKey(keyName = "alt1", friendlyKeyName = "mediaAlternate1"),
-            @AdminPresentationMapKey(keyName = "alt2", friendlyKeyName = "mediaAlternate2"),
-            @AdminPresentationMapKey(keyName = "alt3", friendlyKeyName = "mediaAlternate3"),
-            @AdminPresentationMapKey(keyName = "alt4", friendlyKeyName = "mediaAlternate4"),
-            @AdminPresentationMapKey(keyName = "alt5", friendlyKeyName = "mediaAlternate5"),
-            @AdminPresentationMapKey(keyName = "alt6", friendlyKeyName = "mediaAlternate6")
-        }
+            tab = TabName.Media,
+            keyPropertyFriendlyName = "CategoryImpl_Category_Media_Key",
+            deleteEntityUponRemove = true,
+            mediaField = "media.url",
+            toOneTargetProperty = "media",
+            toOneParentProperty = "category",
+            keys = {
+                    @AdminPresentationMapKey(keyName = "primary", friendlyKeyName = "mediaPrimary"),
+                    @AdminPresentationMapKey(keyName = "alt1", friendlyKeyName = "mediaAlternate1"),
+                    @AdminPresentationMapKey(keyName = "alt2", friendlyKeyName = "mediaAlternate2"),
+                    @AdminPresentationMapKey(keyName = "alt3", friendlyKeyName = "mediaAlternate3"),
+                    @AdminPresentationMapKey(keyName = "alt4", friendlyKeyName = "mediaAlternate4"),
+                    @AdminPresentationMapKey(keyName = "alt5", friendlyKeyName = "mediaAlternate5"),
+                    @AdminPresentationMapKey(keyName = "alt6", friendlyKeyName = "mediaAlternate6")
+            }
     )
-    protected Map<String, CategoryMediaXref> categoryMedia = new HashMap<String, CategoryMediaXref>();
+    protected Map<String, CategoryMediaXref> categoryMedia =
+            new HashMap<String, CategoryMediaXref>();
 
     @Transient
     protected Map<String, Media> legacyCategoryMedia = new HashMap<String, Media>();
 
-    @OneToMany(mappedBy = "category", targetEntity = FeaturedProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
+    @OneToMany(mappedBy = "category", targetEntity = FeaturedProductImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
-    @OrderBy(value="sequence")
+    @OrderBy(value = "sequence")
     @BatchSize(size = 50)
     @AdminPresentationAdornedTargetCollection(friendlyName = "featuredProductsTitle", order = 1000,
             tab = TabName.Marketing,
             targetObjectProperty = "product",
             sortProperty = "sequence",
-            maintainedAdornedTargetFields = { "promotionMessage" },
-            gridVisibleFields = { "defaultSku.name", "promotionMessage" })
+            maintainedAdornedTargetFields = {"promotionMessage"},
+            gridVisibleFields = {"defaultSku.name", "promotionMessage"})
     protected List<FeaturedProduct> featuredProducts = new ArrayList<FeaturedProduct>(10);
 
-    @OneToMany(mappedBy = "category", targetEntity = CrossSaleProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @OneToMany(mappedBy = "category", targetEntity = CrossSaleProductImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
-    @OrderBy(value="sequence")
+    @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "crossSaleProductsTitle", order = 2000,
             tab = TabName.Marketing,
             targetObjectProperty = "relatedSaleProduct",
             sortProperty = "sequence",
-            maintainedAdornedTargetFields = { "promotionMessage" },
-            gridVisibleFields = { "defaultSku.name", "promotionMessage" })
+            maintainedAdornedTargetFields = {"promotionMessage"},
+            gridVisibleFields = {"defaultSku.name", "promotionMessage"})
     protected List<RelatedProduct> crossSaleProducts = new ArrayList<RelatedProduct>();
 
-    @OneToMany(mappedBy = "category", targetEntity = UpSaleProductImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
-    @Cascade(value={org.hibernate.annotations.CascadeType.ALL})
+    @OneToMany(mappedBy = "category", targetEntity = UpSaleProductImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
-    @OrderBy(value="sequence")
+    @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "upsaleProductsTitle", order = 3000,
             tab = TabName.Marketing,
             targetObjectProperty = "relatedSaleProduct",
             sortProperty = "sequence",
-            maintainedAdornedTargetFields = { "promotionMessage" },
-            gridVisibleFields = { "defaultSku.name", "promotionMessage" })
-    protected List<RelatedProduct> upSaleProducts  = new ArrayList<RelatedProduct>();
+            maintainedAdornedTargetFields = {"promotionMessage"},
+            gridVisibleFields = {"defaultSku.name", "promotionMessage"})
+    protected List<RelatedProduct> upSaleProducts = new ArrayList<RelatedProduct>();
 
-    @OneToMany(mappedBy = "category", targetEntity = CategorySearchFacetImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "category", targetEntity = CategorySearchFacetImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
-    @OrderBy(value="sequence")
+    @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "categoryFacetsTitle", order = 1000,
             tab = TabName.Search,
             targetObjectProperty = "searchFacet",
             sortProperty = "sequence",
-            gridVisibleFields = { "name", "label", "fieldType.indexField.field.friendlyName" })
+            gridVisibleFields = {"name", "label", "fieldType.indexField.field.friendlyName"})
     @BatchSize(size = 50)
-    protected List<CategorySearchFacet> searchFacets  = new ArrayList<CategorySearchFacet>();
+    protected List<CategorySearchFacet> searchFacets = new ArrayList<CategorySearchFacet>();
 
-    @OneToMany(mappedBy = "category", targetEntity = CategoryExcludedSearchFacetImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "category", targetEntity = CategoryExcludedSearchFacetImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "excludedFacetsTitle", order = 2000,
             tab = TabName.Search,
             targetObjectProperty = "searchFacet",
             sortProperty = "sequence",
-            gridVisibleFields = { "name", "label", "fieldType.indexField.field.friendlyName" })
+            gridVisibleFields = {"name", "label", "fieldType.indexField.field.friendlyName"})
     @BatchSize(size = 50)
-    protected List<CategoryExcludedSearchFacet> excludedSearchFacets = new ArrayList<CategoryExcludedSearchFacet>(10);
+    protected List<CategoryExcludedSearchFacet> excludedSearchFacets =
+            new ArrayList<CategoryExcludedSearchFacet>(10);
 
-    @OneToMany(mappedBy = "category", targetEntity = CategoryAttributeImpl.class, cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToMany(mappedBy = "category", targetEntity = CategoryAttributeImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "categoryAttributesTitle",
@@ -499,9 +528,10 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         // if startswith "/" return
         // if contains a ":" and no "?" or (contains a ":" before a "?") return
         // else "add a /" at the beginning
-        if(url == null || url.equals("") || url.startsWith("/")) {
+        if (url == null || url.equals("") || url.startsWith("/")) {
             return url;
-        } else if ((url.contains(":") && !url.contains("?")) || url.indexOf('?', url.indexOf(':')) != -1) {
+        } else if ((url.contains(":") && !url.contains("?"))
+                || url.indexOf('?', url.indexOf(':')) != -1) {
             return url;
         } else {
             return "/" + url;
@@ -553,7 +583,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @Override
     public Date getActiveStartDate() {
-        if ('Y'==getArchived()) {
+        if ('Y' == getArchived()) {
             return null;
         }
         return activeStartDate;
@@ -561,7 +591,8 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @Override
     public void setActiveStartDate(Date activeStartDate) {
-        this.activeStartDate = (activeStartDate == null) ? null : new Date(activeStartDate.getTime());
+        this.activeStartDate =
+                (activeStartDate == null) ? null : new Date(activeStartDate.getTime());
     }
 
     @Override
@@ -580,11 +611,11 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             if (!DateUtil.isActive(activeStartDate, activeEndDate, true)) {
                 LOG.debug("category, " + id + ", inactive due to date");
             }
-            if ('Y'==getArchived()) {
+            if ('Y' == getArchived()) {
                 LOG.debug("category, " + id + ", inactive due to archived status");
             }
         }
-        return DateUtil.isActive(activeStartDate, activeEndDate, true) && 'Y'!=getArchived();
+        return DateUtil.isActive(activeStartDate, activeEndDate, true) && 'Y' != getArchived();
     }
 
     @Override
@@ -677,7 +708,8 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         List<CategoryXref> xrefs = getAllParentCategoryXrefs();
         if (!CollectionUtils.isEmpty(xrefs)) {
             for (CategoryXref xref : xrefs) {
-                if (xref.getCategory().isActive() && xref.getDefaultReference() != null && xref.getDefaultReference()) {
+                if (xref.getCategory().isActive() && xref.getDefaultReference() != null
+                        && xref.getDefaultReference()) {
                     response = xref;
                     break;
                 }
@@ -686,7 +718,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         if (response == null) {
             if (!CollectionUtils.isEmpty(xrefs)) {
                 for (CategoryXref xref : xrefs) {
-                   if (xref.getCategory().isActive()) {
+                    if (xref.getCategory().isActive()) {
                         response = xref;
                         break;
                     }
@@ -718,7 +750,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     }
 
     @Override
-    public List<CategoryXref> getAllChildCategoryXrefs(){
+    public List<CategoryXref> getAllChildCategoryXrefs() {
         return allChildCategoryXrefs;
     }
 
@@ -737,22 +769,22 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @Override
     public void setChildCategoryXrefs(List<CategoryXref> childCategories) {
         this.childCategoryXrefs.clear();
-        for(CategoryXref category : childCategories){
+        for (CategoryXref category : childCategories) {
             this.childCategoryXrefs.add(category);
         }
     }
 
     @Override
-    public void setAllChildCategoryXrefs(List<CategoryXref> childCategories){
+    public void setAllChildCategoryXrefs(List<CategoryXref> childCategories) {
         allChildCategoryXrefs.clear();
-        for(CategoryXref category : childCategories){
+        for (CategoryXref category : childCategories) {
             allChildCategoryXrefs.add(category);
         }
     }
 
     @Override
     @Deprecated
-    public List<Category> getAllChildCategories(){
+    public List<Category> getAllChildCategories() {
         if (allLegacyChildCategories.isEmpty()) {
             for (CategoryXref category : allChildCategoryXrefs) {
                 allLegacyChildCategories.add(category.getSubCategory());
@@ -762,13 +794,13 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     }
 
     @Override
-    public boolean hasAllChildCategories(){
+    public boolean hasAllChildCategories() {
         return !allChildCategoryXrefs.isEmpty();
     }
 
     @Override
     @Deprecated
-    public void setAllChildCategories(List<Category> childCategories){
+    public void setAllChildCategories(List<Category> childCategories) {
         throw new UnsupportedOperationException("Not Supported - Use setAllChildCategoryXrefs()");
     }
 
@@ -850,7 +882,8 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     }
 
     @Override
-    public List<Category> getParentCategoryHierarchy(List<Category> currentPath, Boolean firstParent) {
+    public List<Category> getParentCategoryHierarchy(List<Category> currentPath,
+            Boolean firstParent) {
         // If firstParent is null, default it to false
         if (firstParent == null) {
             firstParent = false;
@@ -897,7 +930,8 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
             currentPath = new ArrayList<Category>();
             currentPath.add(0, this);
         }
-        if (getDefaultParentCategory() != null && ! currentPath.contains(getDefaultParentCategory())) {
+        if (getDefaultParentCategory() != null && !currentPath.contains(
+                getDefaultParentCategory())) {
             currentPath.add(0, getDefaultParentCategory());
             getDefaultParentCategory().buildDefaultParentCategoryPath(currentPath);
         }
@@ -949,7 +983,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @Override
     public void setFeaturedProducts(List<FeaturedProduct> featuredProducts) {
         this.featuredProducts.clear();
-        for(FeaturedProduct featuredProduct : featuredProducts){
+        for (FeaturedProduct featuredProduct : featuredProducts) {
             this.featuredProducts.add(featuredProduct);
         }
     }
@@ -962,7 +996,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @Override
     public void setCrossSaleProducts(List<RelatedProduct> crossSaleProducts) {
         this.crossSaleProducts.clear();
-        for(RelatedProduct relatedProduct : crossSaleProducts){
+        for (RelatedProduct relatedProduct : crossSaleProducts) {
             this.crossSaleProducts.add(relatedProduct);
         }
     }
@@ -1017,7 +1051,7 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     @Override
     public void setUpSaleProducts(List<RelatedProduct> upSaleProducts) {
         this.upSaleProducts.clear();
-        for(RelatedProduct relatedProduct : upSaleProducts){
+        for (RelatedProduct relatedProduct : upSaleProducts) {
             this.upSaleProducts.add(relatedProduct);
         }
         this.upSaleProducts = upSaleProducts;
@@ -1157,12 +1191,13 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         returnCategoryFacets.addAll(getSearchFacets());
         Collections.sort(returnCategoryFacets, facetPositionComparator);
 
-        final Collection<SearchFacet> facets = CollectionUtils.collect(returnCategoryFacets, new Transformer() {
-                @Override
-                public Object transform(Object input) {
-                    return ((CategorySearchFacet) input).getSearchFacet();
-                }
-            });
+        final Collection<SearchFacet> facets =
+                CollectionUtils.collect(returnCategoryFacets, new Transformer() {
+                    @Override
+                    public Object transform(Object input) {
+                        return ((CategorySearchFacet) input).getSearchFacet();
+                    }
+                });
 
         // Add in parent facets unless they are excluded
         Category parentCategory = getDefaultParentCategory();
@@ -1202,8 +1237,9 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
     public void setCategoryMedia(Map<String, Media> categoryMedia) {
         this.categoryMedia.clear();
         this.legacyCategoryMedia.clear();
-        for(Map.Entry<String, Media> entry : categoryMedia.entrySet()){
-            this.categoryMedia.put(entry.getKey(), new CategoryMediaXrefImpl(this, entry.getValue(), entry.getKey()));
+        for (Map.Entry<String, Media> entry : categoryMedia.entrySet()) {
+            this.categoryMedia.put(entry.getKey(),
+                    new CategoryMediaXrefImpl(this, entry.getValue(), entry.getKey()));
         }
     }
 
@@ -1285,13 +1321,13 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
 
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -1345,28 +1381,32 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         return true;
     }
 
-    protected static Comparator<CategorySearchFacet> facetPositionComparator = new Comparator<CategorySearchFacet>() {
-        @Override
-        public int compare(CategorySearchFacet o1, CategorySearchFacet o2) {
-            return o1.getSequence().compareTo(o2.getSequence());
-        }
-    };
+    protected static Comparator<CategorySearchFacet> facetPositionComparator =
+            new Comparator<CategorySearchFacet>() {
+                @Override
+                public int compare(CategorySearchFacet o1, CategorySearchFacet o2) {
+                    return o1.getSequence().compareTo(o2.getSequence());
+                }
+            };
 
     protected static Comparator sequenceComparator = new Comparator() {
 
         @Override
         public int compare(Object o1, Object o2) {
             try {
-                return ((Comparable) PropertyUtils.getProperty(o1, "sequence")).compareTo(PropertyUtils.getProperty(o2, "sequence"));
+                return ((Comparable) PropertyUtils.getProperty(o1, "sequence")).compareTo(
+                        PropertyUtils.getProperty(o2, "sequence"));
             } catch (Exception e) {
-                LOG.warn("Trying to compare objects that do not have a sequence property, assuming they are the same order");
+                LOG.warn(
+                        "Trying to compare objects that do not have a sequence property, assuming they are the same order");
                 return 0;
             }
         }
     };
 
     @Override
-    public <G extends Category> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Category> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -1385,32 +1425,38 @@ public class CategoryImpl implements Category, Status, AdminMainEntity, Locatabl
         cloned.setExternalId(externalId);
         cloned.setDisplayTemplate(displayTemplate);
         cloned.setDescription(description);
-        for(CategoryXref entry : allParentCategoryXrefs){
+        for (CategoryXref entry : allParentCategoryXrefs) {
             CategoryXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getAllParentCategoryXrefs().add(clonedEntry);
         }
         if (getDefaultParentCategory() != null) {
-            cloned.setParentCategory(getDefaultParentCategory().createOrRetrieveCopyInstance(context).getClone());
+            cloned.setParentCategory(
+                    getDefaultParentCategory().createOrRetrieveCopyInstance(context).getClone());
         }
-        for(CategoryXref entry : allChildCategoryXrefs){
+        for (CategoryXref entry : allChildCategoryXrefs) {
             CategoryXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getAllChildCategoryXrefs().add(clonedEntry);
         }
-        for(Map.Entry<String,CategoryAttribute> entry : getCategoryAttributesMap().entrySet()){
-            CategoryAttribute clonedEntry = entry.getValue().createOrRetrieveCopyInstance(context).getClone();
-            cloned.getCategoryAttributesMap().put(entry.getKey(),clonedEntry);
+        for (Map.Entry<String, CategoryAttribute> entry : getCategoryAttributesMap().entrySet()) {
+            CategoryAttribute clonedEntry =
+                    entry.getValue().createOrRetrieveCopyInstance(context).getClone();
+            cloned.getCategoryAttributesMap().put(entry.getKey(), clonedEntry);
         }
-        for(CategorySearchFacet entry : searchFacets){
-            CategorySearchFacet clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+        for (CategorySearchFacet entry : searchFacets) {
+            CategorySearchFacet clonedEntry =
+                    entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getSearchFacets().add(clonedEntry);
         }
-        for(CategoryExcludedSearchFacet entry : excludedSearchFacets){
-            CategoryExcludedSearchFacet clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+        for (CategoryExcludedSearchFacet entry : excludedSearchFacets) {
+            CategoryExcludedSearchFacet clonedEntry =
+                    entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getExcludedSearchFacets().add(clonedEntry);
         }
-        for(Map.Entry<String, CategoryMediaXref> entry : categoryMedia.entrySet()){
-            CategoryMediaXrefImpl clonedEntry = ((CategoryMediaXrefImpl)entry.getValue()).createOrRetrieveCopyInstance(context).getClone();
-            cloned.getCategoryMediaXref().put(entry.getKey(),clonedEntry);
+        for (Map.Entry<String, CategoryMediaXref> entry : categoryMedia.entrySet()) {
+            CategoryMediaXrefImpl clonedEntry =
+                    ((CategoryMediaXrefImpl) entry.getValue()).createOrRetrieveCopyInstance(context)
+                            .getClone();
+            cloned.getCategoryMediaXref().put(entry.getKey(), clonedEntry);
         }
 
         //Don't clone the references to products - those will be handled by another MultiTenantCopier call

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
@@ -17,25 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCloneable;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.media.domain.Media;
-import org.broadleafcommerce.common.media.domain.MediaImpl;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,6 +27,25 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.media.domain.Media;
+import org.broadleafcommerce.common.media.domain.MediaImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -75,7 +75,7 @@ public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTen
     @GeneratedValue(generator= "CategoryMediaId")
     @GenericGenerator(
         name="CategoryMediaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryMediaXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryMediaXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryMediaXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -47,16 +37,30 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CATEGORY_MEDIA_MAP")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
-@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@AdminPresentationClass(excludeFromPolymorphism = false,
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTenantCloneable<CategoryMediaXrefImpl> {
+public class CategoryMediaXrefImpl
+        implements CategoryMediaXref, Media, MultiTenantCloneable<CategoryMediaXrefImpl> {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -72,20 +76,21 @@ public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTen
     }
 
     @Id
-    @GeneratedValue(generator= "CategoryMediaId")
+    @GeneratedValue(generator = "CategoryMediaId")
     @GenericGenerator(
-        name="CategoryMediaId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategoryMediaXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryMediaXrefImpl")
-        }
+            name = "CategoryMediaId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategoryMediaXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CategoryMediaXrefImpl")
+            }
     )
     @Column(name = "CATEGORY_MEDIA_ID")
     protected Long id;
 
     //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
-    @ManyToOne(targetEntity = CategoryImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = CategoryImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "BLC_CATEGORY_CATEGORY_ID")
     @AdminPresentation(excluded = true)
     protected Category category;
@@ -96,7 +101,7 @@ public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTen
     @ClonePolicy
     protected Media media;
 
-    @Column(name = "MAP_KEY", nullable=false)
+    @Column(name = "MAP_KEY", nullable = false)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String key;
 
@@ -209,15 +214,21 @@ public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTen
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         CategoryMediaXrefImpl that = (CategoryMediaXrefImpl) o;
 
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (media != null ? !media.equals(that.media) : that.media != null) return false;
-        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (media != null ? !media.equals(that.media) : that.media != null)
+            return false;
+        if (key != null ? !key.equals(that.key) : that.key != null)
+            return false;
 
         return true;
     }
@@ -231,7 +242,8 @@ public class CategoryMediaXrefImpl implements CategoryMediaXref, Media, MultiTen
     }
 
     @Override
-    public <G extends CategoryMediaXrefImpl> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CategoryMediaXrefImpl> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,6 +26,21 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
@@ -78,7 +78,7 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     @GeneratedValue(generator= "CategoryProductId")
     @GenericGenerator(
         name="CategoryProductId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryProductXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryProductXrefImpl.java
@@ -10,22 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -42,23 +33,32 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
 /**
- * The Class CategoryProductXrefImpl is the default implmentation of {@link Category}.
- * This entity is only used for executing a named query.
+ * The Class CategoryProductXrefImpl is the default implmentation of {@link Category}. This entity
+ * is only used for executing a named query.
  *
  * If you want to add fields specific to your implementation of BroadLeafCommerce you should extend
  * this class and add your fields.  If you need to make significant changes to the class then you
  * should implement your own version of {@link Category}.
  * <br>
  * <br>
- * This implementation uses a Hibernate implementation of JPA configured through annotations.
- * The Entity references the following tables:
- * BLC_CATEGORY_PRODUCT_XREF,
+ * This implementation uses a Hibernate implementation of JPA configured through annotations. The
+ * Entity references the following tables: BLC_CATEGORY_PRODUCT_XREF,
  *
- * @see {@link Category}, {@link ProductImpl}
  * @author btaylor
+ * @see {@link Category}, {@link ProductImpl}
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -66,7 +66,8 @@ import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DU
 @AdminPresentationClass(excludeFromPolymorphism = false)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryProduct")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class CategoryProductXrefImpl implements CategoryProductXref {
@@ -75,14 +76,15 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CategoryProductId")
+    @GeneratedValue(generator = "CategoryProductId")
     @GenericGenerator(
-        name="CategoryProductId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategoryProductXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl")
-        }
+            name = "CategoryProductId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategoryProductXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl")
+            }
     )
     @Column(name = "CATEGORY_PRODUCT_ID")
     protected Long id;
@@ -90,7 +92,7 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     //todo: 6.3 cascade refresh was deleted due to potential hiberante issue, when after a clone process
     //we refresh original & clone records, and after refresh it will be flushed at some point
     //and during flush there will be exception about shared collection in sku.skuPriceData
-    @ManyToOne(targetEntity = CategoryImpl.class, optional=false)
+    @ManyToOne(targetEntity = CategoryImpl.class, optional = false)
     @JoinColumn(name = "CATEGORY_ID")
     protected Category category = new CategoryImpl();
 
@@ -98,15 +100,16 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     //we refresh original & clone records, and after refresh it will be flushed at some point
     //and during flush there will be exception about shared collection in sku.skuPriceData
     /** The product. */
-    @ManyToOne(targetEntity = ProductImpl.class, optional=false)
+    @ManyToOne(targetEntity = ProductImpl.class, optional = false)
     @JoinColumn(name = "PRODUCT_ID")
     protected Product product = new ProductImpl();
 
     /** The display order. */
     @Column(name = "DISPLAY_ORDER", precision = 10, scale = 6)
-    @AdminPresentation(friendlyName = "CategoryProductXrefImpl_displayOrder", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "CategoryProductXrefImpl_displayOrder",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected BigDecimal displayOrder;
-    
+
     @Column(name = "DEFAULT_REFERENCE")
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected Boolean defaultReference;
@@ -150,12 +153,12 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     @Override
     public Boolean getDefaultReference() {
         return defaultReference;
     }
-    
+
     @Override
     public void setDefaultReference(Boolean defaultReference) {
         this.defaultReference = defaultReference;
@@ -163,14 +166,19 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         CategoryProductXrefImpl that = (CategoryProductXrefImpl) o;
 
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (product != null ? !product.equals(that.product) : that.product != null) return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (product != null ? !product.equals(that.product) : that.product != null)
+            return false;
 
         return true;
     }
@@ -183,7 +191,8 @@ public class CategoryProductXrefImpl implements CategoryProductXref {
     }
 
     @Override
-    public <G extends CategoryProductXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CategoryProductXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategorySiteMapGeneratorConfigurationImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategorySiteMapGeneratorConfigurationImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -32,13 +32,14 @@ import jakarta.persistence.Table;
 
 /**
  * CategorySiteMapGenerator is controlled by this configuration.
- * 
+ *
  * @author Joshua Skorton (jskorton)
  */
 @Entity
 @Table(name = "BLC_CAT_SITE_MAP_GEN_CFG")
 @AdminPresentationClass(friendlyName = "CategorySiteMapGeneratorConfigurationImpl")
-public class CategorySiteMapGeneratorConfigurationImpl extends SiteMapGeneratorConfigurationImpl implements CategorySiteMapGeneratorConfiguration {
+public class CategorySiteMapGeneratorConfigurationImpl extends SiteMapGeneratorConfigurationImpl
+        implements CategorySiteMapGeneratorConfiguration {
 
     private static final long serialVersionUID = 1L;
 
@@ -94,7 +95,8 @@ public class CategorySiteMapGeneratorConfigurationImpl extends SiteMapGeneratorC
         if (obj == null || !getClass().isAssignableFrom(obj.getClass())) {
             return false;
         }
-        CategorySiteMapGeneratorConfigurationImpl rhs = (CategorySiteMapGeneratorConfigurationImpl) obj;
+        CategorySiteMapGeneratorConfigurationImpl rhs =
+                (CategorySiteMapGeneratorConfigurationImpl) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .append(this.rootCategory, rhs.rootCategory)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +27,21 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -61,7 +61,7 @@ public class CategoryXrefImpl implements CategoryXref {
     @GeneratedValue(generator= "CategoryXrefId")
     @GenericGenerator(
         name="CategoryXrefId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -43,13 +33,25 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CATEGORY_XREF")
 @AdminPresentationClass(excludeFromPolymorphism = false)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class CategoryXrefImpl implements CategoryXref {
@@ -58,23 +60,24 @@ public class CategoryXrefImpl implements CategoryXref {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CategoryXrefId")
+    @GeneratedValue(generator = "CategoryXrefId")
     @GenericGenerator(
-        name="CategoryXrefId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategoryXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CategoryXrefImpl")
-        }
+            name = "CategoryXrefId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategoryXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CategoryXrefImpl")
+            }
     )
     @Column(name = "CATEGORY_XREF_ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = CategoryImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = CategoryImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
     protected Category category = new CategoryImpl();
 
-    @ManyToOne(targetEntity = CategoryImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = CategoryImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "SUB_CATEGORY_ID")
     protected Category subCategory = new CategoryImpl();
 
@@ -138,14 +141,19 @@ public class CategoryXrefImpl implements CategoryXref {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         CategoryXrefImpl that = (CategoryXrefImpl) o;
 
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (subCategory != null ? !subCategory.equals(that.subCategory) : that.subCategory != null) return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (subCategory != null ? !subCategory.equals(that.subCategory) : that.subCategory != null)
+            return false;
 
         return true;
     }
@@ -158,7 +166,8 @@ public class CategoryXrefImpl implements CategoryXref {
     }
 
     @Override
-    public <G extends CategoryXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CategoryXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -45,59 +35,74 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_PRODUCT_CROSS_SALE")
+@Table(name = "BLC_PRODUCT_CROSS_SALE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantCloneable<CrossSaleProductImpl> {
+public class CrossSaleProductImpl
+        implements CrossSaleProduct, MultiTenantCloneable<CrossSaleProductImpl> {
 
     protected static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CrossSaleProductId")
+    @GeneratedValue(generator = "CrossSaleProductId")
     @GenericGenerator(
-        name="CrossSaleProductId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CrossSaleProductImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CrossSaleProductImpl")
-        }
+            name = "CrossSaleProductId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CrossSaleProductImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.CrossSaleProductImpl")
+            }
     )
     @Column(name = "CROSS_SALE_PRODUCT_ID")
     protected Long id;
-    
+
     @Column(name = "PROMOTION_MESSAGE")
-    @AdminPresentation(friendlyName = "CrossSaleProductImpl_Cross_Sale_Promotion_Message", translatable=true, largeEntry=true)
+    @AdminPresentation(friendlyName = "CrossSaleProductImpl_Cross_Sale_Promotion_Message",
+            translatable = true, largeEntry = true)
     protected String promotionMessage;
 
     @Column(name = "SEQUENCE", precision = 10, scale = 6)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected BigDecimal sequence;
-    
+
     @ManyToOne(targetEntity = ProductImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_ID")
-    @Index(name="CROSSSALE_INDEX", columnNames={"PRODUCT_ID"})
+    @Index(name = "CROSSSALE_INDEX", columnNames = {"PRODUCT_ID"})
     protected Product product;
-    
+
     @ManyToOne(targetEntity = CategoryImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
-    @Index(name="CROSSSALE_CATEGORY_INDEX", columnNames={"CATEGORY_ID"})
+    @Index(name = "CROSSSALE_CATEGORY_INDEX", columnNames = {"CATEGORY_ID"})
     protected Category category;
 
-    @ManyToOne(targetEntity = ProductImpl.class, optional=false)
+    @ManyToOne(targetEntity = ProductImpl.class, optional = false)
     @JoinColumn(name = "RELATED_SALE_PRODUCT_ID", referencedColumnName = "PRODUCT_ID")
-    @Index(name="CROSSSALE_RELATED_INDEX", columnNames={"RELATED_SALE_PRODUCT_ID"})
+    @Index(name = "CROSSSALE_RELATED_INDEX", columnNames = {"RELATED_SALE_PRODUCT_ID"})
     protected Product relatedSaleProduct = new ProductImpl();
 
     @Override
     public Long getId() {
         return id;
     }
-    
+
     @Override
     public void setId(Long id) {
         this.id = id;
@@ -107,7 +112,7 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
     public String getPromotionMessage() {
         return DynamicTranslationProvider.getValue(this, "promotionMessage", promotionMessage);
     }
-    
+
     @Override
     public void setPromotionMessage(String promotionMessage) {
         this.promotionMessage = promotionMessage;
@@ -117,7 +122,7 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
     public BigDecimal getSequence() {
         return sequence;
     }
-    
+
     @Override
     public void setSequence(BigDecimal sequence) {
         this.sequence = sequence;
@@ -132,7 +137,7 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
     public void setProduct(Product product) {
         this.product = product;
     }
-    
+
     @Override
     public Category getCategory() {
         return category;
@@ -155,17 +160,29 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         CrossSaleProductImpl that = (CrossSaleProductImpl) o;
 
-        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null) return false;
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (product != null ? !product.equals(that.product) : that.product != null) return false;
-        if (relatedSaleProduct != null ? !relatedSaleProduct.equals(that.relatedSaleProduct) : that.relatedSaleProduct != null) return false;
-        if (promotionMessage != null ? !promotionMessage.equals(that.promotionMessage) : that.promotionMessage != null) return false;
+        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null)
+            return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (product != null ? !product.equals(that.product) : that.product != null)
+            return false;
+        if (relatedSaleProduct != null
+                ? !relatedSaleProduct.equals(that.relatedSaleProduct)
+                : that.relatedSaleProduct != null)
+            return false;
+        if (promotionMessage != null
+                ? !promotionMessage.equals(that.promotionMessage)
+                : that.promotionMessage != null)
+            return false;
 
         return true;
     }
@@ -181,7 +198,8 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
     }
 
     @Override
-    public <G extends CrossSaleProductImpl> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CrossSaleProductImpl> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -196,7 +214,8 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
         cloned.setPromotionMessage(promotionMessage);
         cloned.setSequence(sequence);
         if (relatedSaleProduct != null) {
-            cloned.setRelatedProduct(relatedSaleProduct.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setRelatedProduct(
+                    relatedSaleProduct.createOrRetrieveCopyInstance(context).getClone());
         }
         return createResponse;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CrossSaleProductImpl.java
@@ -17,23 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCloneable;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +27,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -61,7 +61,7 @@ public class CrossSaleProductImpl implements CrossSaleProduct, MultiTenantClonea
     @GeneratedValue(generator= "CrossSaleProductId")
     @GenericGenerator(
         name="CrossSaleProductId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CrossSaleProductImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.CrossSaleProductImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Dimension.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Dimension.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -39,46 +39,53 @@ public class Dimension implements Serializable, MultiTenantCloneable<Dimension> 
 
     @Column(name = "WIDTH")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Width",
-            group = SkuAdminPresentation.GroupName.ShippingDimensions, order = SkuAdminPresentation.FieldOrder.WIDTH)
+            group = SkuAdminPresentation.GroupName.ShippingDimensions,
+            order = SkuAdminPresentation.FieldOrder.WIDTH)
     protected BigDecimal width;
 
     @Column(name = "HEIGHT")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Height",
-            group = SkuAdminPresentation.GroupName.ShippingDimensions, order = SkuAdminPresentation.FieldOrder.HEIGHT)
+            group = SkuAdminPresentation.GroupName.ShippingDimensions,
+            order = SkuAdminPresentation.FieldOrder.HEIGHT)
     protected BigDecimal height;
 
     @Column(name = "DEPTH")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Depth",
-        group = SkuAdminPresentation.GroupName.ShippingDimensions, order = SkuAdminPresentation.FieldOrder.DEPTH)
+            group = SkuAdminPresentation.GroupName.ShippingDimensions,
+            order = SkuAdminPresentation.FieldOrder.DEPTH)
     protected BigDecimal depth;
 
     @Column(name = "GIRTH")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Girth",
-        group = SkuAdminPresentation.GroupName.ShippingDimensions, order = SkuAdminPresentation.FieldOrder.GIRTH)
+            group = SkuAdminPresentation.GroupName.ShippingDimensions,
+            order = SkuAdminPresentation.FieldOrder.GIRTH)
     protected BigDecimal girth;
 
     @Column(name = "CONTAINER_SIZE")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Container_Size",
-        group = SkuAdminPresentation.GroupName.ShippingContainer, order = SkuAdminPresentation.FieldOrder.CONTAINER_SIZE,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.common.vendor.service.type.ContainerSizeType",
-        hideEnumerationIfEmpty = true)
+            group = SkuAdminPresentation.GroupName.ShippingContainer,
+            order = SkuAdminPresentation.FieldOrder.CONTAINER_SIZE,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.vendor.service.type.ContainerSizeType",
+            hideEnumerationIfEmpty = true)
     protected String size;
 
     @Column(name = "CONTAINER_SHAPE")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Container_Shape",
-        group = SkuAdminPresentation.GroupName.ShippingContainer, order = SkuAdminPresentation.FieldOrder.CONTAINER_SHAPE,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.common.vendor.service.type.ContainerShapeType",
-        hideEnumerationIfEmpty = true)
+            group = SkuAdminPresentation.GroupName.ShippingContainer,
+            order = SkuAdminPresentation.FieldOrder.CONTAINER_SHAPE,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.vendor.service.type.ContainerShapeType",
+            hideEnumerationIfEmpty = true)
     protected String container;
 
     @Column(name = "DIMENSION_UNIT_OF_MEASURE")
     @AdminPresentation(friendlyName = "ProductDimension_Product_Dimension_Units",
-        group = SkuAdminPresentation.GroupName.ShippingDimensions, order = SkuAdminPresentation.FieldOrder.DIMENSION_UNIT_OF_MEASURE,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.common.util.DimensionUnitOfMeasureType",
-        defaultValue = "CENTIMETERS")
+            group = SkuAdminPresentation.GroupName.ShippingDimensions,
+            order = SkuAdminPresentation.FieldOrder.DIMENSION_UNIT_OF_MEASURE,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.util.DimensionUnitOfMeasureType",
+            defaultValue = "CENTIMETERS")
     protected String dimensionUnitOfMeasure;
 
     public BigDecimal getWidth() {
@@ -106,8 +113,8 @@ public class Dimension implements Serializable, MultiTenantCloneable<Dimension> 
     }
 
     /**
-     * Returns the product dimensions as a String (assumes measurements are in
-     * inches)
+     * Returns the product dimensions as a String (assumes measurements are in inches)
+     *
      * @return a String value of the product dimensions
      */
     public String getDimensionString() {
@@ -153,7 +160,8 @@ public class Dimension implements Serializable, MultiTenantCloneable<Dimension> 
     }
 
     @Override
-    public <G extends Dimension> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Dimension> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         Dimension clone = createResponse.getClone();
         if (container != null) {
@@ -174,21 +182,33 @@ public class Dimension implements Serializable, MultiTenantCloneable<Dimension> 
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         Dimension dimension = (Dimension) o;
 
-        if (container != null ? !container.equals(dimension.container) : dimension.container != null) return false;
-        if (depth != null ? !depth.equals(dimension.depth) : dimension.depth != null) return false;
-        if (dimensionUnitOfMeasure != null ? !dimensionUnitOfMeasure.equals(dimension.dimensionUnitOfMeasure) :
+        if (container != null
+                ? !container.equals(dimension.container)
+                : dimension.container != null)
+            return false;
+        if (depth != null ? !depth.equals(dimension.depth) : dimension.depth != null)
+            return false;
+        if (dimensionUnitOfMeasure != null ? !dimensionUnitOfMeasure.equals(
+                dimension.dimensionUnitOfMeasure) :
                 dimension.dimensionUnitOfMeasure != null)
             return false;
-        if (girth != null ? !girth.equals(dimension.girth) : dimension.girth != null) return false;
-        if (height != null ? !height.equals(dimension.height) : dimension.height != null) return false;
-        if (size != null ? !size.equals(dimension.size) : dimension.size != null) return false;
-        if (width != null ? !width.equals(dimension.width) : dimension.width != null) return false;
+        if (girth != null ? !girth.equals(dimension.girth) : dimension.girth != null)
+            return false;
+        if (height != null ? !height.equals(dimension.height) : dimension.height != null)
+            return false;
+        if (size != null ? !size.equals(dimension.size) : dimension.size != null)
+            return false;
+        if (width != null ? !width.equals(dimension.width) : dimension.width != null)
+            return false;
 
         return true;
     }
@@ -201,7 +221,9 @@ public class Dimension implements Serializable, MultiTenantCloneable<Dimension> 
         result = 31 * result + (girth != null ? girth.hashCode() : 0);
         result = 31 * result + (size != null ? size.hashCode() : 0);
         result = 31 * result + (container != null ? container.hashCode() : 0);
-        result = 31 * result + (dimensionUnitOfMeasure != null ? dimensionUnitOfMeasure.hashCode() : 0);
+        result = 31 * result + (dimensionUnitOfMeasure != null
+                ? dimensionUnitOfMeasure.hashCode()
+                : 0);
         return result;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -43,12 +33,24 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_FEATURED")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCategoryRelationships")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class FeaturedProductImpl implements FeaturedProduct {
@@ -57,34 +59,36 @@ public class FeaturedProductImpl implements FeaturedProduct {
 
     /** The id. */
     @Id
-    @GeneratedValue(generator= "FeaturedProductId")
+    @GeneratedValue(generator = "FeaturedProductId")
     @GenericGenerator(
-        name="FeaturedProductId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="FeaturedProductImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.FeaturedProductImpl")
-        }
+            name = "FeaturedProductId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FeaturedProductImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.FeaturedProductImpl")
+            }
     )
     @Column(name = "FEATURED_PRODUCT_ID")
     protected Long id;
-    
+
     @Column(name = "SEQUENCE", precision = 10, scale = 6)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected BigDecimal sequence;
 
     @Column(name = "PROMOTION_MESSAGE")
-    @AdminPresentation(friendlyName = "FeaturedProductImpl_Featured_Product_Promotion_Message", largeEntry=true)
+    @AdminPresentation(friendlyName = "FeaturedProductImpl_Featured_Product_Promotion_Message",
+            largeEntry = true)
     protected String promotionMessage;
-    
+
     @ManyToOne(targetEntity = CategoryImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
-    @Index(name="PRODFEATURED_CATEGORY_INDEX", columnNames={"CATEGORY_ID"})
+    @Index(name = "PRODFEATURED_CATEGORY_INDEX", columnNames = {"CATEGORY_ID"})
     protected Category category = new CategoryImpl();
 
     @ManyToOne(targetEntity = ProductImpl.class)
     @JoinColumn(name = "PRODUCT_ID")
-    @Index(name="PRODFEATURED_PRODUCT_INDEX", columnNames={"PRODUCT_ID"})
+    @Index(name = "PRODFEATURED_PRODUCT_INDEX", columnNames = {"PRODUCT_ID"})
     protected Product product = new ProductImpl();
 
     @Override
@@ -96,7 +100,7 @@ public class FeaturedProductImpl implements FeaturedProduct {
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     @Override
     public void setSequence(BigDecimal sequence) {
         this.sequence = sequence;
@@ -136,7 +140,7 @@ public class FeaturedProductImpl implements FeaturedProduct {
     public void setProduct(Product product) {
         this.product = product;
     }
-    
+
     @Override
     public Product getRelatedProduct() {
         return product;
@@ -144,16 +148,25 @@ public class FeaturedProductImpl implements FeaturedProduct {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         FeaturedProductImpl that = (FeaturedProductImpl) o;
 
-        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null) return false;
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (product != null ? !product.equals(that.product) : that.product != null) return false;
-        if (promotionMessage != null ? !promotionMessage.equals(that.promotionMessage) : that.promotionMessage != null) return false;
+        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null)
+            return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (product != null ? !product.equals(that.product) : that.product != null)
+            return false;
+        if (promotionMessage != null
+                ? !promotionMessage.equals(that.promotionMessage)
+                : that.promotionMessage != null)
+            return false;
 
         return true;
     }
@@ -168,7 +181,8 @@ public class FeaturedProductImpl implements FeaturedProduct {
     }
 
     @Override
-    public <G extends FeaturedProduct> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends FeaturedProduct> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/FeaturedProductImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +27,21 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -60,7 +60,7 @@ public class FeaturedProductImpl implements FeaturedProduct {
     @GeneratedValue(generator= "FeaturedProductId")
     @GenericGenerator(
         name="FeaturedProductId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FeaturedProductImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.FeaturedProductImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -42,53 +32,69 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 
 /**
  * The Class ProductAttributeImpl.
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_PRODUCT_ATTRIBUTE")
+@Table(name = "BLC_PRODUCT_ATTRIBUTE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
 @AdminPresentationClass(friendlyName = "ProductAttributeImpl_baseProductAttribute")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG, skipOverlaps=true)
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG,
+                skipOverlaps = true)
 })
 public class ProductAttributeImpl implements ProductAttribute {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
-    
+
     /** The id. */
     @Id
-    @GeneratedValue(generator= "ProductAttributeId")
+    @GeneratedValue(generator = "ProductAttributeId")
     @GenericGenerator(
-        name="ProductAttributeId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ProductAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductAttributeImpl")
-        }
+            name = "ProductAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ProductAttributeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.ProductAttributeImpl")
+            }
     )
     @Column(name = "PRODUCT_ATTRIBUTE_ID")
     protected Long id;
-    
+
     /** The name. */
-    @Column(name = "NAME", nullable=false)
-    @Index(name="PRODUCTATTRIBUTE_NAME_INDEX", columnNames={"NAME"})
-    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Name", order=-1, group = "ProductAttributeImpl_Description", prominent=true, gridOrder = 1)
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "PRODUCTATTRIBUTE_NAME_INDEX", columnNames = {"NAME"})
+    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Name", order = -1,
+            group = "ProductAttributeImpl_Description", prominent = true, gridOrder = 1)
     protected String name;
 
     /** The value. */
     @Column(name = "VALUE")
-    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Value", order=2, group = "ProductAttributeImpl_Description", prominent=true, gridOrder = 2)
+    @AdminPresentation(friendlyName = "ProductAttributeImpl_Attribute_Value", order = 2,
+            group = "ProductAttributeImpl_Description", prominent = true, gridOrder = 2)
     protected String value;
-    
+
     /** The product. */
-    @ManyToOne(targetEntity = ProductImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = ProductImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_ID")
-    @Index(name="PRODUCTATTRIBUTE_INDEX", columnNames={"PRODUCT_ID"})
+    @Index(name = "PRODUCTATTRIBUTE_INDEX", columnNames = {"PRODUCT_ID"})
     protected Product product;
 
     @Override
@@ -179,7 +185,8 @@ public class ProductAttributeImpl implements ProductAttribute {
     }
 
     @Override
-    public <G extends ProductAttribute> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends ProductAttribute> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -190,6 +197,6 @@ public class ProductAttributeImpl implements ProductAttribute {
         }
         cloned.setName(name);
         cloned.setValue(value);
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductAttributeImpl.java
@@ -17,20 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,6 +27,20 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 
 /**
@@ -65,7 +65,7 @@ public class ProductAttributeImpl implements ProductAttribute {
     @GeneratedValue(generator= "ProductAttributeId")
     @GenericGenerator(
         name="ProductAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ProductAttributeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductAttributeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductBundleImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductBundleImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -55,19 +55,20 @@ import jakarta.persistence.Table;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_BUNDLE")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "ProductImpl_bundleProduct")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "ProductImpl_bundleProduct")
 public class ProductBundleImpl extends ProductImpl implements ProductBundle {
 
     private static final long serialVersionUID = 1L;
 
     @Column(name = "PRICING_MODEL")
-    @AdminPresentation(friendlyName = "productBundlePricingModel", 
-        group = GroupName.Price, order = 1,
-        helpText = "productBundlePricingModelHelp", 
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductBundlePricingModelType",
-        defaultValue = "ITEM_SUM",
-        requiredOverride = RequiredOverride.REQUIRED)
+    @AdminPresentation(friendlyName = "productBundlePricingModel",
+            group = GroupName.Price, order = 1,
+            helpText = "productBundlePricingModelHelp",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductBundlePricingModelType",
+            defaultValue = "ITEM_SUM",
+            requiredOverride = RequiredOverride.REQUIRED)
     protected String pricingModel;
 
     @Column(name = "AUTO_BUNDLE")
@@ -83,18 +84,20 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
     protected Boolean bundlePromotable = false;
 
     @Column(name = "BUNDLE_PRIORITY")
-    @AdminPresentation(excluded = true, friendlyName = "productBundlePriority", group="productBundleGroup")
-    protected Integer priority=99;
+    @AdminPresentation(excluded = true, friendlyName = "productBundlePriority",
+            group = "productBundleGroup")
+    protected Integer priority = 99;
 
-    @OneToMany(mappedBy = "bundle", targetEntity = SkuBundleItemImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "bundle", targetEntity = SkuBundleItemImpl.class,
+            cascade = {CascadeType.ALL})
     @OrderBy(value = "sequence")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "skuBundleItemsTitle",
-        sortProperty = "sequence",
-        tab = TabName.General)
+            sortProperty = "sequence",
+            tab = TabName.General)
     protected List<SkuBundleItem> skuBundleItems = new ArrayList<SkuBundleItem>();
-    
+
     @Override
     public boolean isOnSale() {
         Money retailPrice = getRetailPrice();
@@ -121,7 +124,7 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
         }
         return null;
     }
-    
+
     @Override
     public Money getSalePrice() {
         if (ProductBundlePricingModelType.ITEM_SUM.equals(getPricingModel())) {
@@ -144,7 +147,7 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
     @Override
     public Money getBundleItemsSalePrice() {
         Money price = Money.ZERO;
-        for (SkuBundleItem item : getSkuBundleItems()){
+        for (SkuBundleItem item : getSkuBundleItems()) {
             if (item.getSalePrice() != null) {
                 price = price.add(item.getSalePrice().multiply(item.getQuantity()));
             } else {
@@ -153,7 +156,7 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
         }
         return price;
     }
-    
+
     @Override
     public void clearDynamicPrices() {
         super.clearDynamicPrices();
@@ -225,14 +228,17 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
                 Sku sku = skuBundleItem.getSku();
 
                 if (sku != null && sku.getRetailPrice() != null) {
-                    totalNormalPrice = totalNormalPrice.add(sku.getRetailPrice().multiply(skuBundleItem.getQuantity()));
+                    totalNormalPrice = totalNormalPrice.add(
+                            sku.getRetailPrice().multiply(skuBundleItem.getQuantity()));
                 }
 
                 if (ProductBundlePricingModelType.ITEM_SUM.equals(getPricingModel())) {
                     if (skuBundleItem.getSalePrice() != null) {
-                        totalBundlePrice = totalBundlePrice.add(skuBundleItem.getSalePrice().multiply(skuBundleItem.getQuantity()));
+                        totalBundlePrice = totalBundlePrice.add(
+                                skuBundleItem.getSalePrice().multiply(skuBundleItem.getQuantity()));
                     } else {
-                        totalBundlePrice = totalBundlePrice.add(skuBundleItem.getRetailPrice().multiply(skuBundleItem.getQuantity()));
+                        totalBundlePrice = totalBundlePrice.add(skuBundleItem.getRetailPrice()
+                                .multiply(skuBundleItem.getQuantity()));
                     }
                 }
 
@@ -255,7 +261,8 @@ public class ProductBundleImpl extends ProductImpl implements ProductBundle {
     }
 
     @Override
-    public CreateResponse<ProductBundle> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws
+    public CreateResponse<ProductBundle> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws
             CloneNotSupportedException {
         CreateResponse<ProductBundle> createResponse = super.createOrRetrieveCopyInstance(context);
         if (createResponse.isAlreadyPopulated()) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -92,19 +92,17 @@ import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
 /**
- * The Class ProductImpl is the default implementation of {@link Product}. A
- * product is a general description of an item that can be sold (for example: a
- * hat). Products are not sold or added to a cart. {@link Sku}s which are
- * specific items (for example: a XL Blue Hat) are sold or added to a cart. <br>
+ * The Class ProductImpl is the default implementation of {@link Product}. A product is a general
+ * description of an item that can be sold (for example: a hat). Products are not sold or added to a
+ * cart. {@link Sku}s which are specific items (for example: a XL Blue Hat) are sold or added to a
+ * cart. <br>
  * <br>
- * If you want to add fields specific to your implementation of
- * BroadLeafCommerce you should extend this class and add your fields. If you
- * need to make significant changes to the ProductImpl then you should implement
- * your own version of {@link Product}. <br>
+ * If you want to add fields specific to your implementation of BroadLeafCommerce you should extend
+ * this class and add your fields. If you need to make significant changes to the ProductImpl then
+ * you should implement your own version of {@link Product}. <br>
  * <br>
- * This implementation uses a Hibernate implementation of JPA configured through
- * annotations. The Entity references the following tables: BLC_PRODUCT,
- * BLC_PRODUCT_SKU_XREF, BLC_PRODUCT_IMAGE
+ * This implementation uses a Hibernate implementation of JPA configured through annotations. The
+ * Entity references the following tables: BLC_PRODUCT, BLC_PRODUCT_SKU_XREF, BLC_PRODUCT_IMAGE
  *
  * @author btaylor
  * @see {@link Product}, {@link SkuImpl}, {@link CategoryImpl}
@@ -120,35 +118,59 @@ import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DU
 @AdminPresentationMergeOverrides(
         {
                 @AdminPresentationMergeOverride(name = "defaultSku.displayTemplate", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                        booleanOverrideValue = true)),
                 @AdminPresentationMergeOverride(name = "defaultSku.urlKey", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                        booleanOverrideValue = true)),
                 @AdminPresentationMergeOverride(name = "defaultSku.retailPrice", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE, overrideValue = "REQUIRED")),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                        overrideValue = "REQUIRED")),
                 @AdminPresentationMergeOverride(name = "defaultSku.name", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE, overrideValue = "REQUIRED")),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                        overrideValue = "REQUIRED")),
                 @AdminPresentationMergeOverride(name = "defaultSku.activeEndDate", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VALIDATIONCONFIGURATIONS, validationConfigurations = {
-                        @ValidationConfiguration(
-                                validationImplementation = "blAfterStartDateValidator",
-                                configurationItems = {
-                                        @ConfigurationItem(itemName = "otherField", itemValue = "defaultSku.activeStartDate")
-                                })
-                })),
-                @AdminPresentationMergeOverride(name = "defaultSku.auditable.createdBy", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
-                @AdminPresentationMergeOverride(name = "defaultSku.auditable.dateCreated", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
-                @AdminPresentationMergeOverride(name = "defaultSku.auditable.dateUpdated", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
-                @AdminPresentationMergeOverride(name = "defaultSku.auditable.updatedBy", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true))
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VALIDATIONCONFIGURATIONS,
+                        validationConfigurations = {
+                                @ValidationConfiguration(
+                                        validationImplementation = "blAfterStartDateValidator",
+                                        configurationItems = {
+                                                @ConfigurationItem(itemName = "otherField",
+                                                        itemValue = "defaultSku.activeStartDate")
+                                        })
+                        })),
+                @AdminPresentationMergeOverride(name = "defaultSku.auditable.createdBy",
+                        mergeEntries =
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)),
+                @AdminPresentationMergeOverride(name = "defaultSku.auditable.dateCreated",
+                        mergeEntries =
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)),
+                @AdminPresentationMergeOverride(name = "defaultSku.auditable.dateUpdated",
+                        mergeEntries =
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true)),
+                @AdminPresentationMergeOverride(name = "defaultSku.auditable.updatedBy",
+                        mergeEntries =
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = true))
         })
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class ProductImpl implements Product, ProductAdminPresentation, Status, AdminMainEntity, Locatable, TemplatePathContainer {
+public class ProductImpl
+        implements Product, ProductAdminPresentation, Status, AdminMainEntity, Locatable,
+        TemplatePathContainer {
 
     private static final Log LOG = LogFactory.getLog(ProductImpl.class);
     /**
@@ -168,10 +190,12 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "ProductImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.catalog.domain.ProductImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.ProductImpl")
             })
     @Column(name = "PRODUCT_ID")
-    @AdminPresentation(friendlyName = "ProductImpl_Product_ID", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "ProductImpl_Product_ID",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Column(name = "URL")
@@ -267,8 +291,10 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     @Transient
     protected String promoMessage;
 
-    @OneToMany(mappedBy = "product", targetEntity = CrossSaleProductImpl.class, cascade = {CascadeType.ALL})
-    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @OneToMany(mappedBy = "product", targetEntity = CrossSaleProductImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "crossSaleProductsTitle",
@@ -280,8 +306,10 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
             gridVisibleFields = {"defaultSku.name", "promotionMessage"})
     protected List<RelatedProduct> crossSaleProducts = new ArrayList<RelatedProduct>();
 
-    @OneToMany(mappedBy = "product", targetEntity = UpSaleProductImpl.class, cascade = {CascadeType.ALL})
-    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @OneToMany(mappedBy = "product", targetEntity = UpSaleProductImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
     @OrderBy(value = "sequence")
     @AdminPresentationAdornedTargetCollection(friendlyName = "upsaleProductsTitle",
@@ -293,7 +321,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
             gridVisibleFields = {"defaultSku.name", "promotionMessage"})
     protected List<RelatedProduct> upSaleProducts = new ArrayList<RelatedProduct>();
 
-    @OneToMany(fetch = FetchType.LAZY, targetEntity = SkuImpl.class, mappedBy = "product", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, targetEntity = SkuImpl.class, mappedBy = "product",
+            cascade = CascadeType.ALL)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "ProductImpl_Additional_Skus",
@@ -302,7 +331,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
     @ManyToOne(targetEntity = CategoryImpl.class)
     @JoinColumn(name = "DEFAULT_CATEGORY_ID")
-    @AdminPresentation(friendlyName = "ProductImpl_Product_Default_Category", order = FieldOrder.DEFAULT_CATEGORY,
+    @AdminPresentation(friendlyName = "ProductImpl_Product_Default_Category",
+            order = FieldOrder.DEFAULT_CATEGORY,
             group = GroupName.General,
             prominent = true, gridOrder = 2,
             requiredOverride = RequiredOverride.REQUIRED)
@@ -320,9 +350,11 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
             targetObjectProperty = "category",
             parentObjectProperty = "product",
             gridVisibleFields = {"name"})
-    protected List<CategoryProductXref> allParentCategoryXrefs = new ArrayList<CategoryProductXref>();
+    protected List<CategoryProductXref> allParentCategoryXrefs =
+            new ArrayList<CategoryProductXref>();
 
-    @OneToMany(mappedBy = "product", targetEntity = ProductAttributeImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "product", targetEntity = ProductAttributeImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "productAttributesTitle",
@@ -364,7 +396,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
     @Override
     public void setEnableDefaultSkuInInventory(Boolean enableDefaultSkuInventory) {
-        this.enableDefaultSkuInventory = enableDefaultSkuInventory != null && enableDefaultSkuInventory;
+        this.enableDefaultSkuInventory =
+                enableDefaultSkuInventory != null && enableDefaultSkuInventory;
     }
 
     @Override
@@ -437,7 +470,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
                 LOG.debug("product, " + id + ", inactive due to archived status");
             }
         }
-        return DateUtil.isActive(getActiveStartDate(), getActiveEndDate(), true) && 'Y' != getArchived();
+        return DateUtil.isActive(getActiveStartDate(), getActiveEndDate(), true)
+                && 'Y' != getArchived();
     }
 
     @Override
@@ -663,7 +697,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
         List<CategoryProductXref> xrefs = getAllParentCategoryXrefs();
         if (!CollectionUtils.isEmpty(xrefs)) {
             for (CategoryProductXref xref : xrefs) {
-                if (xref.getCategory().isActive() && xref.getDefaultReference() != null && xref.getDefaultReference()) {
+                if (xref.getCategory().isActive() && xref.getDefaultReference() != null
+                        && xref.getDefaultReference()) {
                     response = xref.getCategory();
                     break;
                 }
@@ -897,7 +932,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     public List<RelatedProduct> getCumulativeCrossSaleProducts() {
         List<RelatedProduct> returnProducts = getCrossSaleProducts();
         if (defaultCategory != null) {
-            List<RelatedProduct> categoryProducts = defaultCategory.getCumulativeCrossSaleProducts();
+            List<RelatedProduct> categoryProducts =
+                    defaultCategory.getCumulativeCrossSaleProducts();
             if (categoryProducts != null) {
                 returnProducts.addAll(categoryProducts);
             }
@@ -981,7 +1017,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
 
             @Override
             public int compare(ProductOptionXref o1, ProductOptionXref o2) {
-                return ObjectUtils.compare(o1.getProductOption().getDisplayOrder(), o2.getProductOption().getDisplayOrder(), true);
+                return ObjectUtils.compare(o1.getProductOption().getDisplayOrder(),
+                        o2.getProductOption().getDisplayOrder(), true);
             }
 
         });
@@ -1067,7 +1104,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
             List<ProductOptionXref> xrefs = getProductOptionXrefs();
             if (xrefs != null) {
                 for (ProductOptionXref xref : xrefs) {
-                    List<ProductOptionValue> productOptionValues = xref.getProductOption().getAllowedValues();
+                    List<ProductOptionValue> productOptionValues =
+                            xref.getProductOption().getAllowedValues();
                     if (productOptionValues != null && !productOptionValues.isEmpty()) {
                         HashSet<String> values = new HashSet<String>();
                         for (ProductOptionValue value : productOptionValues) {
@@ -1158,8 +1196,11 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     }
 
     @Override
-    public <G extends Product> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
-        boolean isPropagation = context.getCopyHints().get("PROPAGATION") != null && "TRUE".equalsIgnoreCase((String) context.getCopyHints().get("PROPAGATION"));
+    public <G extends Product> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws CloneNotSupportedException {
+        boolean isPropagation =
+                context.getCopyHints().get("PROPAGATION") != null && "TRUE".equalsIgnoreCase(
+                        (String) context.getCopyHints().get("PROPAGATION"));
 
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -1177,7 +1218,8 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
         cloned.setMetaTitle(metaTitle);
         cloned.setEnableDefaultSkuInInventory(enableDefaultSkuInventory);
         if (defaultCategory != null && !context.getCopyHints().containsKey(MANUAL_DUPLICATION)) {
-            cloned.setDefaultCategory(defaultCategory.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setDefaultCategory(
+                    defaultCategory.createOrRetrieveCopyInstance(context).getClone());
         } else if (context.getToCatalog().getId().equals(context.getFromCatalog().getId())) {
             cloned.setDefaultCategory(defaultCategory);
         }
@@ -1185,20 +1227,23 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
         if (defaultSku != null) {
             cloned.setDefaultSku(defaultSku.createOrRetrieveCopyInstance(context).getClone());
         }
-        if (context.getToCatalog().getId().equals(context.getFromCatalog().getId()) || isPropagation) {
+        if (context.getToCatalog().getId().equals(context.getFromCatalog().getId())
+                || isPropagation) {
             for (Sku entry : additionalSkus) {
                 Sku clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
                 cloned.getAdditionalSkus().add(clonedEntry);
             }
             for (ProductOptionXref entry : productOptions) {
-                ProductOptionXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+                ProductOptionXref clonedEntry =
+                        entry.createOrRetrieveCopyInstance(context).getClone();
                 cloned.getProductOptionXrefs().add(clonedEntry);
 
             }
         }
         Map<String, ProductAttribute> attributeMap = new HashMap<>();
         for (Map.Entry<String, ProductAttribute> entry : getProductAttributes().entrySet()) {
-            ProductAttribute clonedEntry = entry.getValue().createOrRetrieveCopyInstance(context).getClone();
+            ProductAttribute clonedEntry =
+                    entry.getValue().createOrRetrieveCopyInstance(context).getClone();
             attributeMap.put(entry.getKey(), clonedEntry);
         }
         if (attributeMap.size() > 0) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -17,6 +17,17 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -27,6 +38,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
@@ -48,18 +60,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_OPTION")
@@ -76,7 +76,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     @GeneratedValue(generator= "ProductOptionId")
     @GenericGenerator(
         name="ProductOptionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ProductOptionImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductOptionImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -60,118 +49,134 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_PRODUCT_OPTION")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class ProductOptionImpl implements ProductOption, AdminMainEntity, ProductOptionAdminPresentation {
+public class ProductOptionImpl
+        implements ProductOption, AdminMainEntity, ProductOptionAdminPresentation {
 
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "ProductOptionId")
+    @GeneratedValue(generator = "ProductOptionId")
     @GenericGenerator(
-        name="ProductOptionId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ProductOptionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductOptionImpl")
-        }
+            name = "ProductOptionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ProductOptionImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.ProductOptionImpl")
+            }
     )
     @Column(name = "PRODUCT_OPTION_ID")
     protected Long id;
 
     @Column(name = "NAME")
-    @Index(name="PRODUCT_OPTION_NAME_INDEX", columnNames={"NAME"})
+    @Index(name = "PRODUCT_OPTION_NAME_INDEX", columnNames = {"NAME"})
     @AdminPresentation(friendlyName = "productOption_name",
-        group = GroupName.General, order = FieldOrder.name,
-        prominent = true, gridOrder = 1000)
+            group = GroupName.General, order = FieldOrder.name,
+            prominent = true, gridOrder = 1000)
     protected String name;
 
     @Column(name = "OPTION_TYPE")
     @AdminPresentation(friendlyName = "productOption_Type",
-        group = GroupName.General, order = FieldOrder.type,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionType",
-        prominent = true, gridOrder = 2000)
+            group = GroupName.General, order = FieldOrder.type,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionType",
+            prominent = true, gridOrder = 2000)
     protected String type;
-    
+
     @Column(name = "ATTRIBUTE_NAME")
     @AdminPresentation(friendlyName = "productOption_attributeName",
-        group = GroupName.Details, order = FieldOrder.attributeName,
-        tooltip = "productOption_attributeNameTip",
-        requiredOverride = RequiredOverride.REQUIRED)
+            group = GroupName.Details, order = FieldOrder.attributeName,
+            tooltip = "productOption_attributeNameTip",
+            requiredOverride = RequiredOverride.REQUIRED)
     protected String attributeName;
-    
+
     @Column(name = "LABEL")
     @AdminPresentation(friendlyName = "productOption_Label",
-        group = GroupName.General, order = FieldOrder.label,
-        tooltip = "productOption_labelTip",
-        translatable = true)
+            group = GroupName.General, order = FieldOrder.label,
+            tooltip = "productOption_labelTip",
+            translatable = true)
     protected String label;
 
     @Column(name = "REQUIRED")
     @AdminPresentation(friendlyName = "productOption_Required",
-        group = GroupName.Validation, order = FieldOrder.required,
-        prominent = true, gridOrder = 3000)
+            group = GroupName.Validation, order = FieldOrder.required,
+            prominent = true, gridOrder = 3000)
     protected Boolean required;
 
     @Column(name = "USE_IN_SKU_GENERATION")
     @AdminPresentation(friendlyName = "productOption_UseInSKUGeneration",
-        group = GroupName.Details, order = FieldOrder.useInSkuGeneration,
-        tooltip = "productOption_useInSkuGenerationTip",
-        defaultValue = "false")
+            group = GroupName.Details, order = FieldOrder.useInSkuGeneration,
+            tooltip = "productOption_useInSkuGenerationTip",
+            defaultValue = "false")
     private Boolean useInSkuGeneration = Boolean.FALSE;
 
     @Column(name = "DISPLAY_ORDER")
     @AdminPresentation(friendlyName = "productOption_displayOrder",
-        group = GroupName.Details, order = FieldOrder.displayOrder,
-        tooltip = "productOption_displayOrderTip")
+            group = GroupName.Details, order = FieldOrder.displayOrder,
+            tooltip = "productOption_displayOrderTip")
     protected Integer displayOrder;
 
     @Column(name = "VALIDATION_STRATEGY_TYPE")
     @AdminPresentation(friendlyName = "productOption_validationStrategyType",
-        group = GroupName.Validation, order = FieldOrder.validationStrategyType,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionValidationStrategyType",
-        defaultValue = "NONE")
+            group = GroupName.Validation, order = FieldOrder.validationStrategyType,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionValidationStrategyType",
+            defaultValue = "NONE")
     private String productOptionValidationStrategyType;
 
     @Column(name = "VALIDATION_TYPE")
     @AdminPresentation(friendlyName = "productOption_validationType",
-        group = GroupName.Validation, order = FieldOrder.validationType,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionValidationType",
-        defaultValue = "REGEX",
-        visibility = VisibilityEnum.HIDDEN_ALL)
+            group = GroupName.Validation, order = FieldOrder.validationType,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.ProductOptionValidationType",
+            defaultValue = "REGEX",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     private String productOptionValidationType;
 
     @Column(name = "VALIDATION_STRING")
     @AdminPresentation(friendlyName = "productOption_validationSring",
-        group = GroupName.Validation, order = FieldOrder.validationString)
+            group = GroupName.Validation, order = FieldOrder.validationString)
     protected String validationString;
 
     @Column(name = "ERROR_CODE")
     @AdminPresentation(friendlyName = "productOption_errorCode",
-        group = GroupName.Validation, order = FieldOrder.errorCode)
+            group = GroupName.Validation, order = FieldOrder.errorCode)
     protected String errorCode;
 
     @Column(name = "ERROR_MESSAGE")
     @AdminPresentation(friendlyName = "productOption_errorMessage",
-        group = GroupName.Validation, order = FieldOrder.errorMessage,
-        translatable = true)
+            group = GroupName.Validation, order = FieldOrder.errorMessage,
+            translatable = true)
     protected String errorMessage;
 
-    @OneToMany(mappedBy = "productOption", targetEntity = ProductOptionValueImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "productOption", targetEntity = ProductOptionValueImpl.class,
+            cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
     @OrderBy(value = "displayOrder")
     @AdminPresentationCollection(friendlyName = "ProductOptionImpl_Allowed_Values",
-        group = GroupName.General,
-        addType = AddMethodType.PERSIST)
+            group = GroupName.General,
+            addType = AddMethodType.PERSIST)
     protected List<ProductOptionValue> allowedValues = new ArrayList<>();
 
     @Lob
@@ -188,7 +193,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     @BatchSize(size = 50)
     @ClonePolicyCollectionOverride
     protected List<ProductOptionXref> products = new ArrayList<>();
-    
+
     @Override
     public Long getId() {
         return id;
@@ -218,7 +223,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     public void setType(ProductOptionType type) {
         this.type = type == null ? null : type.getType();
     }
-    
+
     @Override
     public String getAttributeName() {
         return attributeName;
@@ -228,12 +233,12 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     public void setAttributeName(String attributeName) {
         this.attributeName = attributeName;
     }
-    
+
     @Override
     public String getLabel() {
         return DynamicTranslationProvider.getValue(this, "label", label);
     }
-    
+
     @Override
     public void setLabel(String label) {
         this.label = label;
@@ -279,7 +284,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     }
 
     @Override
-    public void setProducts(List<Product> products){
+    public void setProducts(List<Product> products) {
         throw new UnsupportedOperationException("Use setProductOptionXrefs(..) instead");
     }
 
@@ -310,7 +315,9 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
 
     @Override
     public void setProductOptionValidationStrategyType(ProductOptionValidationStrategyType productOptionValidationStrategyType) {
-        this.productOptionValidationStrategyType = productOptionValidationStrategyType == null ? null : productOptionValidationStrategyType.getType();
+        this.productOptionValidationStrategyType = productOptionValidationStrategyType == null
+                ? null
+                : productOptionValidationStrategyType.getType();
     }
 
     @Override
@@ -324,7 +331,8 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
 
     @Override
     public void setProductOptionValidationType(ProductOptionValidationType productOptionValidationType) {
-        this.productOptionValidationType = productOptionValidationType == null ? null : productOptionValidationType.getType();
+        this.productOptionValidationType =
+                productOptionValidationType == null ? null : productOptionValidationType.getType();
     }
 
     @Override
@@ -363,13 +371,16 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     }
 
     @Override
-    public void setLongDescription(String longDescription){this.longDescription = longDescription;};
+    public void setLongDescription(String longDescription) {this.longDescription = longDescription;}
+
+    ;
 
     @Override
     public String getLongDescription() {return longDescription;}
 
     @Override
-    public <G extends ProductOption> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends ProductOption> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -387,11 +398,11 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
         cloned.setType(getType());
         cloned.setProductOptionValidationStrategyType(getProductOptionValidationStrategyType());
         cloned.setProductOptionValidationType(getProductOptionValidationType());
-        for(ProductOptionValue entry : allowedValues){
+        for (ProductOptionValue entry : allowedValues) {
             ProductOptionValue clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getAllowedValues().add(clonedEntry);
         }
-        for(ProductOptionXref entry : products){
+        for (ProductOptionXref entry : products) {
             ProductOptionXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getProductXrefs().add(clonedEntry);
         }
@@ -417,7 +428,8 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
                 .append(this.required, rhs.required)
                 .append(this.useInSkuGeneration, rhs.useInSkuGeneration)
                 .append(this.displayOrder, rhs.displayOrder)
-                .append(this.productOptionValidationStrategyType, rhs.productOptionValidationStrategyType)
+                .append(this.productOptionValidationStrategyType,
+                        rhs.productOptionValidationStrategyType)
                 .append(this.productOptionValidationType, rhs.productOptionValidationType)
                 .append(this.validationString, rhs.validationString)
                 .append(this.errorCode, rhs.errorCode)

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -56,27 +56,30 @@ import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DU
 @Table(name = "BLC_PRODUCT_OPTION_VALUE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class ProductOptionValueImpl implements ProductOptionValue, ProductOptionValueAdminPresentation {
+public class ProductOptionValueImpl
+        implements ProductOptionValue, ProductOptionValueAdminPresentation {
 
     private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "ProductOptionValueId")
     @GenericGenerator(
-        name = "ProductOptionValueId",
-        strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-                @Parameter(name = "segment_value", value = "ProductOptionValueImpl"),
-                @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.catalog.domain.ProductOptionValueImpl")
-        })
+            name = "ProductOptionValueId",
+            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ProductOptionValueImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.ProductOptionValueImpl")
+            })
     @Column(name = "PRODUCT_OPTION_VALUE_ID")
     protected Long id;
 
     @Column(name = "ATTRIBUTE_VALUE")
-    @AdminPresentation(friendlyName = "productOptionValue_attributeValue", 
+    @AdminPresentation(friendlyName = "productOptionValue_attributeValue",
             prominent = true, order = FieldOrder.value,
             translatable = true, gridOrder = FieldOrder.value,
             requiredOverride = RequiredOverride.REQUIRED,
@@ -85,12 +88,13 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
 
     @Column(name = "DISPLAY_ORDER")
     @AdminPresentation(friendlyName = "productOptionValue_displayOrder", prominent = true,
-            gridOrder =FieldOrder.order, order = FieldOrder.order,
+            gridOrder = FieldOrder.order, order = FieldOrder.order,
             group = GroupName.General)
     protected Long displayOrder;
 
     @Column(name = "PRICE_ADJUSTMENT", precision = 19, scale = 5)
-    @AdminPresentation(friendlyName = "productOptionValue_adjustment", fieldType = SupportedFieldType.MONEY,
+    @AdminPresentation(friendlyName = "productOptionValue_adjustment",
+            fieldType = SupportedFieldType.MONEY,
             prominent = true, gridOrder = FieldOrder.adjustment, order = FieldOrder.adjustment,
             group = GroupName.General)
     protected BigDecimal priceAdjustment;
@@ -139,11 +143,12 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
         Money returnPrice = null;
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
-            HashMap pricingConsiderationContext = SkuPricingConsiderationContext.getSkuPricingConsiderationContext();
+            HashMap pricingConsiderationContext =
+                    SkuPricingConsiderationContext.getSkuPricingConsiderationContext();
             Money adjustment = priceAdjustment == null ? null : new Money(priceAdjustment);
             DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext
-                                                     .getSkuPricingService()
-                                                     .getPriceAdjustment(this, adjustment, pricingConsiderationContext);
+                    .getSkuPricingService()
+                    .getPriceAdjustment(this, adjustment, pricingConsiderationContext);
             returnPrice = dynamicPrices.getPriceAdjustment();
 
         } else if (priceAdjustment != null) {
@@ -207,7 +212,8 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
     }
 
     @Override
-    public <G extends ProductOptionValue> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends ProductOptionValue> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -221,7 +227,7 @@ public class ProductOptionValueImpl implements ProductOptionValue, ProductOption
         } else {
             cloned.setProductOption(productOption);
         }
-        
-        return  createResponse;
+
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,6 +27,19 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
@@ -64,7 +64,7 @@ public class ProductOptionXrefImpl implements ProductOptionXref {
     @GeneratedValue(generator= "ProductOptionXrefId")
     @GenericGenerator(
         name="ProductOptionXrefId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ProductOptionXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductOptionXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -41,6 +31,17 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
 /**
@@ -52,7 +53,8 @@ import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DU
 @AdminPresentationClass(excludeFromPolymorphism = false)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductOptions")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class ProductOptionXrefImpl implements ProductOptionXref {
@@ -61,23 +63,24 @@ public class ProductOptionXrefImpl implements ProductOptionXref {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "ProductOptionXrefId")
+    @GeneratedValue(generator = "ProductOptionXrefId")
     @GenericGenerator(
-        name="ProductOptionXrefId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ProductOptionXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.ProductOptionXrefImpl")
-        }
+            name = "ProductOptionXrefId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ProductOptionXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.ProductOptionXrefImpl")
+            }
     )
     @Column(name = "PRODUCT_OPTION_XREF_ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = ProductImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = ProductImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_ID")
     protected Product product = new ProductImpl();
 
-    @ManyToOne(targetEntity = ProductOptionImpl.class, optional=false)
+    @ManyToOne(targetEntity = ProductOptionImpl.class, optional = false)
     @JoinColumn(name = "PRODUCT_OPTION_ID")
     protected ProductOption productOption = new ProductOptionImpl();
 
@@ -112,7 +115,8 @@ public class ProductOptionXrefImpl implements ProductOptionXref {
     }
 
     @Override
-    public <G extends ProductOptionXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends ProductOptionXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -123,7 +127,8 @@ public class ProductOptionXrefImpl implements ProductOptionXref {
                 cloned.setProduct(product.createOrRetrieveCopyInstance(context).getClone());
             }
             if (productOption != null) {
-                cloned.setProductOption(productOption.createOrRetrieveCopyInstance(context).getClone());
+                cloned.setProductOption(
+                        productOption.createOrRetrieveCopyInstance(context).getClone());
             }
         } else {
             cloned.setProduct(product);

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -41,30 +31,40 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
- * The Class SkuAttributeImpl is the default implementation of {@link SkuAttribute}.
- * A SKU Attribute is a designator on a SKU that differentiates it from other similar SKUs
- * (for example: Blue attribute for hat).
- * If you want to add fields specific to your implementation of BroadLeafCommerce you should extend
- * this class and add your fields.  If you need to make significant changes to the SkuImpl then you
- * should implement your own version of {@link Sku}.
+ * The Class SkuAttributeImpl is the default implementation of {@link SkuAttribute}. A SKU Attribute
+ * is a designator on a SKU that differentiates it from other similar SKUs (for example: Blue
+ * attribute for hat). If you want to add fields specific to your implementation of
+ * BroadLeafCommerce you should extend this class and add your fields.  If you need to make
+ * significant changes to the SkuImpl then you should implement your own version of {@link Sku}.
  * <br>
  * <br>
- * This implementation uses a Hibernate implementation of JPA configured through annotations.
- * The Entity references the following tables:
- * BLC_SKU_ATTRIBUTES,
- * 
- * 
- *   @see {@link SkuAttribute}, {@link SkuImpl}
- *   @author btaylor
+ * This implementation uses a Hibernate implementation of JPA configured through annotations. The
+ * Entity references the following tables: BLC_SKU_ATTRIBUTES,
+ *
+ * @author btaylor
+ * @see {@link SkuAttribute}, {@link SkuImpl}
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_SKU_ATTRIBUTE")
+@Table(name = "BLC_SKU_ATTRIBUTE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG, skipOverlaps=true)
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG,
+                skipOverlaps = true)
 })
 public class SkuAttributeImpl implements SkuAttribute {
 
@@ -73,33 +73,36 @@ public class SkuAttributeImpl implements SkuAttribute {
 
     /** The id. */
     @Id
-    @GeneratedValue(generator= "SkuAttributeId")
+    @GeneratedValue(generator = "SkuAttributeId")
     @GenericGenerator(
-        name="SkuAttributeId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SkuAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuAttributeImpl")
-        }
+            name = "SkuAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuAttributeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.SkuAttributeImpl")
+            }
     )
     @Column(name = "SKU_ATTR_ID")
     protected Long id;
-    
+
     /** The name. */
-    @Column(name = "NAME", nullable=false)
-    @Index(name="SKUATTR_NAME_INDEX", columnNames={"NAME"})
-    @AdminPresentation(friendlyName = "SkuAttributeImpl_Attribute_Name", order=1 , group = "SkuAttributeImpl_Description", prominent=true, gridOrder = 1)
+    @Column(name = "NAME", nullable = false)
+    @Index(name = "SKUATTR_NAME_INDEX", columnNames = {"NAME"})
+    @AdminPresentation(friendlyName = "SkuAttributeImpl_Attribute_Name", order = 1,
+            group = "SkuAttributeImpl_Description", prominent = true, gridOrder = 1)
     protected String name;
 
     /** The value. */
-    @Column(name = "VALUE", nullable=false)
-    @AdminPresentation(friendlyName = "SkuAttributeImpl_Attribute_Value", order=2, group = "SkuAttributeImpl_Description", prominent=true, gridOrder = 2)
+    @Column(name = "VALUE", nullable = false)
+    @AdminPresentation(friendlyName = "SkuAttributeImpl_Attribute_Value", order = 2,
+            group = "SkuAttributeImpl_Description", prominent = true, gridOrder = 2)
     protected String value;
-  
+
     /** The sku. */
-    @ManyToOne(targetEntity = SkuImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = SkuImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "SKU_ID")
-    @Index(name="SKUATTR_SKU_INDEX", columnNames={"SKU_ID"})
+    @Index(name = "SKUATTR_SKU_INDEX", columnNames = {"SKU_ID"})
     protected Sku sku;
 
     /* (non-Javadoc)
@@ -133,7 +136,7 @@ public class SkuAttributeImpl implements SkuAttribute {
     public void setValue(String value) {
         this.value = value;
     }
-    
+
     /* (non-Javadoc)
      * @see org.broadleafcommerce.core.catalog.domain.SkuAttribute#getName()
      */
@@ -157,7 +160,7 @@ public class SkuAttributeImpl implements SkuAttribute {
     public String toString() {
         return value;
     }
-    
+
     /* (non-Javadoc)
      * @see org.broadleafcommerce.core.catalog.domain.SkuAttribute#getSku()
      */
@@ -217,7 +220,8 @@ public class SkuAttributeImpl implements SkuAttribute {
     }
 
     @Override
-    public <G extends SkuAttribute> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SkuAttribute> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuAttributeImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,6 +27,19 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 /**
  * The Class SkuAttributeImpl is the default implementation of {@link SkuAttribute}.
@@ -76,7 +76,7 @@ public class SkuAttributeImpl implements SkuAttribute {
     @GeneratedValue(generator= "SkuAttributeId")
     @GenericGenerator(
         name="SkuAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SkuAttributeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuAttributeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
@@ -10,25 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -57,6 +45,19 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * @deprecated instead, use the ProductType Module's Product Add-Ons to build and configure bundles
  */
@@ -66,7 +67,8 @@ import java.math.BigDecimal;
 @Table(name = "BLC_SKU_BUNDLE_ITEM")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPresentation {
@@ -77,42 +79,46 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
     @Id
     @GeneratedValue(generator = "SkuBundleItemId")
     @GenericGenerator(
-        name="SkuBundleItemId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name = "segment_value", value = "SkuBundleItemImpl"),
-            @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl")
-        }
+            name = "SkuBundleItemId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuBundleItemImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl")
+            }
     )
     @Column(name = "SKU_BUNDLE_ITEM_ID")
-    @AdminPresentation(friendlyName = "SkuBundleItemImpl_ID", group = GroupName.General, visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "SkuBundleItemImpl_ID", group = GroupName.General,
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @Column(name = "QUANTITY", nullable=false)
+    @Column(name = "QUANTITY", nullable = false)
     @AdminPresentation(friendlyName = "bundleItemQuantity",
-        group = GroupName.General, order = FieldOrder.QUANTITY,
-        prominent = true, gridOrder = FieldOrder.QUANTITY,
-        requiredOverride = RequiredOverride.REQUIRED)
+            group = GroupName.General, order = FieldOrder.QUANTITY,
+            prominent = true, gridOrder = FieldOrder.QUANTITY,
+            requiredOverride = RequiredOverride.REQUIRED)
     protected Integer quantity;
 
-    @Column(name = "ITEM_SALE_PRICE", precision=19, scale=5)
+    @Column(name = "ITEM_SALE_PRICE", precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "bundleItemSalePrice",
-        group = GroupName.General, order = FieldOrder.ITEM_SALE_PRICE,
-        prominent = true, gridOrder = FieldOrder.ITEM_SALE_PRICE,
-        tooltip="bundleItemSalePriceTooltip", 
-        fieldType = SupportedFieldType.MONEY)
+            group = GroupName.General, order = FieldOrder.ITEM_SALE_PRICE,
+            prominent = true, gridOrder = FieldOrder.ITEM_SALE_PRICE,
+            tooltip = "bundleItemSalePriceTooltip",
+            fieldType = SupportedFieldType.MONEY)
     protected BigDecimal itemSalePrice;
 
-    @ManyToOne(fetch = FetchType.LAZY, targetEntity = ProductBundleImpl.class, optional = false, cascade = CascadeType.REFRESH)
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = ProductBundleImpl.class, optional = false,
+            cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_BUNDLE_ID", referencedColumnName = "PRODUCT_ID")
     protected ProductBundle bundle;
 
     @ManyToOne(fetch = FetchType.LAZY, targetEntity = SkuImpl.class, optional = false)
     @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID")
     @AdminPresentation(friendlyName = "Sku",
-        group = GroupName.General, order = FieldOrder.SKU,
-        prominent = true, gridOrder = FieldOrder.SKU,
-        validationConfigurations = @ValidationConfiguration(validationImplementation = "blProductBundleSkuBundleItemValidator"))
+            group = GroupName.General, order = FieldOrder.SKU,
+            prominent = true, gridOrder = FieldOrder.SKU,
+            validationConfigurations = @ValidationConfiguration(
+                    validationImplementation = "blProductBundleSkuBundleItemValidator"))
     @AdminPresentationToOneLookup()
     protected Sku sku;
 
@@ -149,10 +155,10 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
     public void setQuantity(Integer quantity) {
         this.quantity = quantity;
     }
-   
-    public Money getDynamicSalePrice(Sku sku, BigDecimal salePrice) {   
+
+    public Money getDynamicSalePrice(Sku sku, BigDecimal salePrice) {
         Money returnPrice = null;
-        
+
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             if (dynamicPrices != null) {
                 returnPrice = dynamicPrices.getSalePrice();
@@ -166,12 +172,13 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
             }
         } else {
             if (salePrice != null) {
-                returnPrice = new Money(salePrice,Money.defaultCurrency());
+                returnPrice = new Money(salePrice, Money.defaultCurrency());
             }
         }
-        
-        return returnPrice;   
+
+        return returnPrice;
     }
+
     @Override
     public void setSalePrice(Money salePrice) {
         if (salePrice != null) {
@@ -193,14 +200,14 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
 
     @Override
     public Money getRetailPrice() {
-         return getSku().getRetailPrice();
-     }
+        return getSku().getRetailPrice();
+    }
 
     @Override
     public ProductBundle getBundle() {
         // We deproxy the bundle to allow logic introduced by filters to still take place (this can be an issue since
         // the bundle is lazy loaded).
-        if(deproxiedBundle == null) {
+        if (deproxiedBundle == null) {
             PostLoaderDao postLoaderDao = DefaultPostLoaderDao.getPostLoaderDao();
             Long id = bundle.getId();
             if (postLoaderDao != null && id != null) {
@@ -265,7 +272,8 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
     }
 
     @Override
-    public <G extends SkuBundleItem> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SkuBundleItem> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -278,7 +286,8 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
             cloned.setSku(sku.createOrRetrieveCopyInstance(context).getClone());
         }
         if (bundle != null) {
-            cloned.setBundle((ProductBundle) bundle.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setBundle(
+                    (ProductBundle) bundle.createOrRetrieveCopyInstance(context).getClone());
         }
         return createResponse;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuBundleItemImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -26,6 +38,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -43,19 +56,6 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 /**
  * @deprecated instead, use the ProductType Module's Product Add-Ons to build and configure bundles
@@ -78,7 +78,7 @@ public class SkuBundleItemImpl implements SkuBundleItem, SkuBundleItemAdminPrese
     @GeneratedValue(generator = "SkuBundleItemId")
     @GenericGenerator(
         name="SkuBundleItemId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name = "segment_value", value = "SkuBundleItemImpl"),
             @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
@@ -10,26 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -52,66 +39,84 @@ import org.hibernate.annotations.Parameter;
 import java.math.BigDecimal;
 import java.util.List;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author Phillip Verheyden
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_SKU_FEE")
+@Table(name = "BLC_SKU_FEE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true)
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true)
 })
 public class SkuFeeImpl implements SkuFee {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Id
     @GeneratedValue(generator = "SkuFeeId")
     @GenericGenerator(
-        name = "SkuFeeId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SkuFeeImpl"),
-            @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.order.domain.SkuFeeImpl")
-        }
+            name = "SkuFeeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuFeeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.order.domain.SkuFeeImpl")
+            }
     )
     @Column(name = "SKU_FEE_ID")
     protected Long id;
 
     @Column(name = "NAME")
     protected String name;
-    
+
     @Column(name = "DESCRIPTION")
     protected String description;
-    
-    @Column(name ="AMOUNT", precision=19, scale=5, nullable=false)
+
+    @Column(name = "AMOUNT", precision = 19, scale = 5, nullable = false)
     protected BigDecimal amount;
-    
+
     @Column(name = "TAXABLE")
     protected Boolean taxable = Boolean.FALSE;
-    
+
     @Lob
     @Column(name = "EXPRESSION", length = Length.LONG32 - 1)
     protected String expression;
 
     @Column(name = "FEE_TYPE")
-    @AdminPresentation(fieldType=SupportedFieldType.BROADLEAF_ENUMERATION, broadleafEnumeration="org.broadleafcommerce.core.catalog.service.type.SkuFeeType")
+    @AdminPresentation(fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.catalog.service.type.SkuFeeType")
     protected String feeType = SkuFeeType.FULFILLMENT.getType();
-    
+
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = SkuImpl.class)
     @JoinTable(name = "BLC_SKU_FEE_XREF",
-            joinColumns = @JoinColumn(name = "SKU_FEE_ID", referencedColumnName = "SKU_FEE_ID", nullable = true),
-            inverseJoinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID", nullable = true))
+            joinColumns = @JoinColumn(name = "SKU_FEE_ID", referencedColumnName = "SKU_FEE_ID",
+                    nullable = true),
+            inverseJoinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID",
+                    nullable = true))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     protected List<Sku> skus;
-    
+
     @ManyToOne(targetEntity = BroadleafCurrencyImpl.class)
     @JoinColumn(name = "CURRENCY_CODE")
-    @AdminPresentation(friendlyName = "TaxDetailImpl_Currency_Code", order=1, group = "FixedPriceFulfillmentOptionImpl_Details", prominent=true)
+    @AdminPresentation(friendlyName = "TaxDetailImpl_Currency_Code", order = 1,
+            group = "FixedPriceFulfillmentOptionImpl_Details", prominent = true)
     protected BroadleafCurrency currency;
-
 
 
 
@@ -184,20 +189,22 @@ public class SkuFeeImpl implements SkuFee {
     public void setFeeType(SkuFeeType feeType) {
         this.feeType = (feeType == null) ? null : feeType.getType();
     }
-    
+
     @Override
     public List<Sku> getSkus() {
         return skus;
     }
-    
+
     @Override
     public void setSkus(List<Sku> skus) {
         this.skus = skus;
     }
+
     @Override
     public BroadleafCurrency getCurrency() {
         return currency;
     }
+
     @Override
     public void setCurrency(BroadleafCurrency currency) {
         this.currency = currency;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuFeeImpl.java
@@ -17,27 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
-import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.broadleafcommerce.core.catalog.service.type.SkuFeeType;
-import org.hibernate.Length;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-import java.util.List;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -51,6 +30,27 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
+import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.core.catalog.service.type.SkuFeeType;
+import org.hibernate.Length;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * @author Phillip Verheyden
@@ -71,7 +71,7 @@ public class SkuFeeImpl implements SkuFee {
     @GeneratedValue(generator = "SkuFeeId")
     @GenericGenerator(
         name = "SkuFeeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SkuFeeImpl"),
             @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.order.domain.SkuFeeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -113,25 +113,24 @@ import jakarta.persistence.Transient;
 import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 
 /**
- * The Class SkuImpl is the default implementation of {@link Sku}. A SKU is a
- * specific item that can be sold including any specific attributes of the item
- * such as color or size. <br>
+ * The Class SkuImpl is the default implementation of {@link Sku}. A SKU is a specific item that can
+ * be sold including any specific attributes of the item such as color or size. <br>
  * <br>
- * If you want to add fields specific to your implementation of
- * BroadLeafCommerce you should extend this class and add your fields. If you
- * need to make significant changes to the SkuImpl then you should implement
- * your own version of {@link Sku}.<br>
+ * If you want to add fields specific to your implementation of BroadLeafCommerce you should extend
+ * this class and add your fields. If you need to make significant changes to the SkuImpl then you
+ * should implement your own version of {@link Sku}.<br>
  * <br>
- * This implementation uses a Hibernate implementation of JPA configured through
- * annotations. The Entity references the following tables: BLC_SKU,
- * BLC_SKU_IMAGE
+ * This implementation uses a Hibernate implementation of JPA configured through annotations. The
+ * Entity references the following tables: BLC_SKU, BLC_SKU_IMAGE
  *
  * !!!!!!!!!!!!!!!!!
- * <p>For admin required field validation, if this Sku is apart of an additionalSkus list (meaning it is not a defaultSku) then
- * it should have no required restrictions on it. All additional Skus can delegate to the defaultSku of the related product
- * for all of its fields. For this reason, if you would like to mark more fields as required then rather than using
- * {@link AdminPresentation#requiredOverride()}, use the mo:overrides section in bl-admin-applicationContext.xml for Product
- * and reference each required field like 'defaultSku.name' or 'defaultSku.retailPrice'.</p>
+ * <p>For admin required field validation, if this Sku is apart of an additionalSkus list (meaning
+ * it is not a defaultSku) then
+ * it should have no required restrictions on it. All additional Skus can delegate to the defaultSku
+ * of the related product for all of its fields. For this reason, if you would like to mark more
+ * fields as required then rather than using {@link AdminPresentation#requiredOverride()}, use the
+ * mo:overrides section in bl-admin-applicationContext.xml for Product and reference each required
+ * field like 'defaultSku.name' or 'defaultSku.retailPrice'.</p>
  *
  * @author btaylor
  * @see {@link Sku}
@@ -140,35 +139,37 @@ import static jakarta.persistence.ConstraintMode.NO_CONSTRAINT;
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU", indexes = {
         @Index(name = "SKU_URL_KEY_INDEX", columnList = "URL_KEY"),
-        @Index(name="SKU_EXTERNAL_ID_INDEX", columnList="EXTERNAL_ID"),
-        @Index(name = "SKU_UPC_INDEX", columnList =  "UPC" ),
+        @Index(name = "SKU_EXTERNAL_ID_INDEX", columnList = "EXTERNAL_ID"),
+        @Index(name = "SKU_UPC_INDEX", columnList = "UPC"),
         @Index(name = "SKU_NAME_INDEX", columnList = "NAME"),
-        @Index(name="SKU_TAXABLE_INDEX", columnList="TAXABLE_FLAG"),
-        @Index(name="SKU_DISCOUNTABLE_INDEX", columnList="DISCOUNTABLE_FLAG"),
+        @Index(name = "SKU_TAXABLE_INDEX", columnList = "TAXABLE_FLAG"),
+        @Index(name = "SKU_DISCOUNTABLE_INDEX", columnList = "DISCOUNTABLE_FLAG"),
         @Index(name = "SKU_AVAILABLE_INDEX", columnList = "AVAILABLE_FLAG"),
-        @Index(name="SKU_ACTIVE_START_INDEX", columnList = "ACTIVE_START_DATE"),
-        @Index(name="SKU_ACTIVE_END_INDEX",columnList = "ACTIVE_END_DATE")
+        @Index(name = "SKU_ACTIVE_START_INDEX", columnList = "ACTIVE_START_DATE"),
+        @Index(name = "SKU_ACTIVE_END_INDEX", columnList = "ACTIVE_END_DATE")
 })
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class SkuImpl implements Sku, SkuAdminPresentation {
-    
+
     private static final Log LOG = LogFactory.getLog(SkuImpl.class);
-    
+
     private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "SkuId")
     @GenericGenerator(
-        name = "SkuId",
-        strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name = "segment_value", value = "SkuImpl"),
-            @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.catalog.domain.SkuImpl")
-        }
+            name = "SkuId",
+            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.SkuImpl")
+            }
     )
     @Column(name = "SKU_ID")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_ID", visibility = VisibilityEnum.HIDDEN_ALL)
@@ -176,20 +177,20 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "EXTERNAL_ID")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_ExternalID",
-        group = GroupName.Miscellaneous, order = FieldOrder.EXTERNAL_ID,
-        tooltip = "SkuImpl_Sku_ExternalID_Tooltip")
+            group = GroupName.Miscellaneous, order = FieldOrder.EXTERNAL_ID,
+            tooltip = "SkuImpl_Sku_ExternalID_Tooltip")
     protected String externalId;
 
     @Column(name = "URL_KEY")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_UrlKey",
-        group = GroupName.Advanced, order = 4000,
-        excluded = true)
+            group = GroupName.Advanced, order = 4000,
+            excluded = true)
     protected String urlKey;
 
     @Column(name = "DISPLAY_TEMPLATE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Display_Template",
-        group = GroupName.Advanced, order = 5000,
-        excluded = true)
+            group = GroupName.Advanced, order = 5000,
+            excluded = true)
     protected String displayTemplate;
 
     @Column(name = "UPC")
@@ -199,17 +200,17 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "SALE_PRICE", precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Sale_Price",
-        group = GroupName.Price, order = FieldOrder.SALE_PRICE,
-        tooltip = "SkuImpl_Sku_Sale_Price_tooltip",
-        prominent = true, gridOrder = 6,
-        fieldType = SupportedFieldType.MONEY)
+            group = GroupName.Price, order = FieldOrder.SALE_PRICE,
+            tooltip = "SkuImpl_Sku_Sale_Price_tooltip",
+            prominent = true, gridOrder = 6,
+            fieldType = SupportedFieldType.MONEY)
     protected BigDecimal salePrice;
 
     @Column(name = "RETAIL_PRICE", precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Retail_Price",
-        group = GroupName.Price, order = FieldOrder.RETAIL_PRICE,
-        prominent = true, gridOrder = 5,
-        fieldType = SupportedFieldType.MONEY)
+            group = GroupName.Price, order = FieldOrder.RETAIL_PRICE,
+            prominent = true, gridOrder = 5,
+            fieldType = SupportedFieldType.MONEY)
     protected BigDecimal retailPrice;
 
     @Column(name = "COST", precision = 19, scale = 5)
@@ -220,17 +221,17 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "NAME")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Name",
-        group = GroupName.General, order = FieldOrder.NAME,
-        prominent = true, gridOrder = 1, columnWidth = "260px",
-        translatable = true)
+            group = GroupName.General, order = FieldOrder.NAME,
+            prominent = true, gridOrder = 1, columnWidth = "260px",
+            translatable = true)
     protected String name;
 
     @Column(name = "DESCRIPTION")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Description",
-        group = GroupName.General, order = FieldOrder.SHORT_DESCRIPTION,
-        largeEntry = true, 
-        excluded = true,
-        translatable = true)
+            group = GroupName.General, order = FieldOrder.SHORT_DESCRIPTION,
+            largeEntry = true,
+            excluded = true,
+            translatable = true)
     protected String description;
 
     //if you are going to remove @Lob you need to adjust
@@ -240,16 +241,19 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @Lob
     @Column(name = "LONG_DESCRIPTION", length = Length.LONG32 - 1)
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Large_Description",
-        group = GroupName.General, order = FieldOrder.LONG_DESCRIPTION,
-        largeEntry = true, 
-        fieldType = SupportedFieldType.HTML_BASIC,
-        translatable = true)
+            group = GroupName.General, order = FieldOrder.LONG_DESCRIPTION,
+            largeEntry = true,
+            fieldType = SupportedFieldType.HTML_BASIC,
+            translatable = true)
     protected String longDescription;
 
     @Column(name = "TAX_CODE")
-    @AdminPresentation(friendlyName = "SkuImpl_Sku_TaxCode", order = 1001, group = GroupName.Financial)
-    @AdminPresentationDataDrivenEnumeration(optionCanEditValues = true, optionHideIfEmpty = true, optionFilterParams = { @OptionFilterParam(
-            param = "type.key", value = "TAX_CODE", paramType = OptionFilterParamType.STRING) })
+    @AdminPresentation(friendlyName = "SkuImpl_Sku_TaxCode", order = 1001,
+            group = GroupName.Financial)
+    @AdminPresentationDataDrivenEnumeration(optionCanEditValues = true, optionHideIfEmpty = true,
+            optionFilterParams = {@OptionFilterParam(
+                    param = "type.key", value = "TAX_CODE",
+                    paramType = OptionFilterParamType.STRING)})
     protected String taxCode;
 
     @Column(name = "TAXABLE_FLAG")
@@ -259,9 +263,9 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "DISCOUNTABLE_FLAG")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Discountable",
-        group = GroupName.Discountable,
-        helpText = "SkuImpl_Sku_Discountable_helptext",
-        defaultValue = "Y")
+            group = GroupName.Discountable,
+            helpText = "SkuImpl_Sku_Discountable_helptext",
+            defaultValue = "Y")
     protected Character discountable;
 
     @Column(name = "AVAILABLE_FLAG")
@@ -271,22 +275,23 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "ACTIVE_START_DATE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Start_Date",
-        group = GroupName.ActiveDateRange, order = FieldOrder.ACTIVE_START_DATE,
-        tooltip = "skuStartDateTooltip",
-        defaultValue = "today")
+            group = GroupName.ActiveDateRange, order = FieldOrder.ACTIVE_START_DATE,
+            tooltip = "skuStartDateTooltip",
+            defaultValue = "today")
     protected Date activeStartDate;
 
     @Column(name = "ACTIVE_END_DATE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_End_Date",
-        group = GroupName.ActiveDateRange, order = FieldOrder.ACTIVE_END_DATE,
-        tooltip = "skuEndDateTooltip",
-        validationConfigurations = {
-            @ValidationConfiguration(
-                validationImplementation = "blAfterStartDateValidator",
-                configurationItems = {
-                        @ConfigurationItem(itemName = "otherField", itemValue = "activeStartDate")
-                }) 
-        })
+            group = GroupName.ActiveDateRange, order = FieldOrder.ACTIVE_END_DATE,
+            tooltip = "skuEndDateTooltip",
+            validationConfigurations = {
+                    @ValidationConfiguration(
+                            validationImplementation = "blAfterStartDateValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "activeStartDate")
+                            })
+            })
     protected Date activeEndDate;
 
     @Embedded
@@ -297,11 +302,11 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "IS_MACHINE_SORTABLE")
     @AdminPresentation(friendlyName = "ProductImpl_Is_Product_Machine_Sortable",
-        group = GroupName.ShippingOther, order = FieldOrder.IS_MACHINE_SORTABLE,
-        defaultValue = "false")
+            group = GroupName.ShippingOther, order = FieldOrder.IS_MACHINE_SORTABLE,
+            defaultValue = "false")
     protected Boolean isMachineSortable;
 
-    @OneToMany(mappedBy = "sku", targetEntity = SkuMediaXrefImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "sku", targetEntity = SkuMediaXrefImpl.class, cascade = {CascadeType.ALL})
     @MapKey(name = "key")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSkuMedia")
     @BatchSize(size = 50)
@@ -316,15 +321,16 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
             forceFreeFormKeys = true
     )
     @AdminPresentationMapFields(
-        mapDisplayFields = {
-            @AdminPresentationMapField(
-                    fieldName = "primary",
-                    fieldPresentation = @AdminPresentation(fieldType = SupportedFieldType.MEDIA,
-                            group = GroupName.Image,
-                            order = FieldOrder.PRIMARY_MEDIA,
-                            friendlyName = "SkuImpl_Primary_Media")
-            )
-    })
+            mapDisplayFields = {
+                    @AdminPresentationMapField(
+                            fieldName = "primary",
+                            fieldPresentation = @AdminPresentation(
+                                    fieldType = SupportedFieldType.MEDIA,
+                                    group = GroupName.Image,
+                                    order = FieldOrder.PRIMARY_MEDIA,
+                                    friendlyName = "SkuImpl_Primary_Media")
+                    )
+            })
     protected Map<String, SkuMediaXref> skuMedia = new HashMap<String, SkuMediaXref>();
 
     @Transient
@@ -336,7 +342,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     //todo: 6.3 cascade refresh was deleted due to potential hiberante issue, when after a clone process
     //we refresh original & clone records, and after refresh it will be flushed at some point
     //and during flush there will be exception about shared collection in sku.skuPriceData
-    @ManyToOne(optional = true, targetEntity = ProductImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne(optional = true, targetEntity = ProductImpl.class,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "DEFAULT_PRODUCT_ID", foreignKey = @ForeignKey(NO_CONSTRAINT))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProducts")
     @IgnoreEnterpriseBehavior
@@ -346,63 +353,74 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
      * This relationship will be non-null if and only if this Sku is contained in the list of
      * additional Skus for a Product (for Skus based on ProductOptions)
      */
-    @ManyToOne(optional = true, targetEntity = ProductImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne(optional = true, targetEntity = ProductImpl.class,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "ADDL_PRODUCT_ID")
     protected Product product;
 
-    @OneToMany(mappedBy = "sku", targetEntity = SkuAttributeImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "sku", targetEntity = SkuAttributeImpl.class, cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductAttributes")
     @BatchSize(size = 50)
-    @AdminPresentationCollection(friendlyName = "skuAttributesTitle", tab = TabName.Advanced, order = 1000)
+    @AdminPresentationCollection(friendlyName = "skuAttributesTitle", tab = TabName.Advanced,
+            order = 1000)
     protected List<SkuAttribute> skuAttributes = new ArrayList<SkuAttribute>();
 
-    @OneToMany(targetEntity = SkuProductOptionValueXrefImpl.class, cascade = CascadeType.ALL, mappedBy = "sku")
+    @OneToMany(targetEntity = SkuProductOptionValueXrefImpl.class, cascade = CascadeType.ALL,
+            mappedBy = "sku")
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     @ClonePolicyCollectionOverride
     @ClonePolicyArchive
     //Use a Set instead of a List - see https://github.com/BroadleafCommerce/BroadleafCommerce/issues/917
-    protected Set<SkuProductOptionValueXref> productOptionValueXrefs = new HashSet<SkuProductOptionValueXref>();
+    protected Set<SkuProductOptionValueXref> productOptionValueXrefs =
+            new HashSet<SkuProductOptionValueXref>();
 
     @Transient
     protected Set<ProductOptionValue> legacyProductOptionValues = new HashSet<ProductOptionValue>();
 
     @ManyToMany(fetch = FetchType.LAZY, targetEntity = SkuFeeImpl.class)
     @JoinTable(name = "BLC_SKU_FEE_XREF",
-            joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID", nullable = true),
-            inverseJoinColumns = @JoinColumn(name = "SKU_FEE_ID", referencedColumnName = "SKU_FEE_ID", nullable = true))
+            joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID",
+                    nullable = true),
+            inverseJoinColumns = @JoinColumn(name = "SKU_FEE_ID",
+                    referencedColumnName = "SKU_FEE_ID", nullable = true))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
     protected List<SkuFee> fees = new ArrayList<SkuFee>();
 
     @ElementCollection
-    @CollectionTable(name = "BLC_SKU_FULFILLMENT_FLAT_RATES", 
-        joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID", nullable = true))
-    @MapKeyJoinColumn(name = "FULFILLMENT_OPTION_ID", referencedColumnName = "FULFILLMENT_OPTION_ID")
+    @CollectionTable(name = "BLC_SKU_FULFILLMENT_FLAT_RATES",
+            joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID",
+                    nullable = true))
+    @MapKeyJoinColumn(name = "FULFILLMENT_OPTION_ID",
+            referencedColumnName = "FULFILLMENT_OPTION_ID")
     @MapKeyClass(FulfillmentOptionImpl.class)
     @Column(name = "RATE", precision = 19, scale = 5)
     @Cascade(org.hibernate.annotations.CascadeType.ALL)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
-    protected Map<FulfillmentOption, BigDecimal> fulfillmentFlatRates = new HashMap<FulfillmentOption, BigDecimal>();
+    protected Map<FulfillmentOption, BigDecimal> fulfillmentFlatRates =
+            new HashMap<FulfillmentOption, BigDecimal>();
 
     @ManyToMany(targetEntity = FulfillmentOptionImpl.class)
     @JoinTable(name = "BLC_SKU_FULFILLMENT_EXCLUDED",
             joinColumns = @JoinColumn(name = "SKU_ID", referencedColumnName = "SKU_ID"),
-            inverseJoinColumns = @JoinColumn(name = "FULFILLMENT_OPTION_ID",referencedColumnName = "FULFILLMENT_OPTION_ID"))
+            inverseJoinColumns = @JoinColumn(name = "FULFILLMENT_OPTION_ID",
+                    referencedColumnName = "FULFILLMENT_OPTION_ID"))
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
     @BatchSize(size = 50)
-    protected List<FulfillmentOption> excludedFulfillmentOptions = new ArrayList<FulfillmentOption>();
+    protected List<FulfillmentOption> excludedFulfillmentOptions =
+            new ArrayList<FulfillmentOption>();
 
     @Column(name = "INVENTORY_TYPE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_InventoryType",
-        group = GroupName.Inventory, order = 1000,
-        helpText = "skuInventoryTypeHelpText",
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.core.inventory.service.type.InventoryType",
-        columnWidth = "180px", prominent = true)
+            group = GroupName.Inventory, order = 1000,
+            helpText = "skuInventoryTypeHelpText",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.inventory.service.type.InventoryType",
+            columnWidth = "180px", prominent = true)
     protected String inventoryType;
-    
+
     @Column(name = "QUANTITY_AVAILABLE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_QuantityAvailable",
             group = GroupName.Inventory, order = 1010)
@@ -410,17 +428,18 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     @Column(name = "FULFILLMENT_TYPE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_FulfillmentType",
-        group = GroupName.ShippingFulfillment, order = FieldOrder.FULFILLMENT_TYPE,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration = "org.broadleafcommerce.core.order.service.type.FulfillmentType")
+            group = GroupName.ShippingFulfillment, order = FieldOrder.FULFILLMENT_TYPE,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.order.service.type.FulfillmentType")
     protected String fulfillmentType;
-    
+
     /**
-     * Note that this field is not the target of the currencyCodeField attribute on either retailPrice or salePrice.
-     * This is because SKUs are special in that we want to return the currency on this SKU if there is one, falling back
-     * to the defaultSku's currency if possible.
-     * 
+     * Note that this field is not the target of the currencyCodeField attribute on either
+     * retailPrice or salePrice. This is because SKUs are special in that we want to return the
+     * currency on this SKU if there is one, falling back to the defaultSku's currency if possible.
+     *
      * Normally null and hidden.  Use Meta-Data overrides to display in the admin.
+     *
      * @see Sku#getCurrency() for further cautions about using this field.
      */
     @ManyToOne(targetEntity = BroadleafCurrencyImpl.class)
@@ -428,7 +447,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @AdminPresentation(friendlyName = "SkuImpl_Currency",
             group = GroupName.Advanced, order = 3000,
             visibility = VisibilityEnum.HIDDEN_ALL)
-    @AdminPresentationToOneLookup(lookupType = LookupType.DROPDOWN, lookupDisplayProperty = "friendlyName")
+    @AdminPresentationToOneLookup(lookupType = LookupType.DROPDOWN,
+            lookupDisplayProperty = "friendlyName")
     protected BroadleafCurrency currency;
 
     @Override
@@ -450,12 +470,12 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setUrlKey(String urlKey) {
         this.urlKey = urlKey;
     }
-    
+
     @Override
     public String getDisplayTemplate() {
         return displayTemplate;
     }
-    
+
     @Override
     public void setDisplayTemplate(String displayTemplate) {
         this.displayTemplate = displayTemplate;
@@ -469,7 +489,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     }
 
     protected boolean hasDefaultSku() {
-        return (product != null && product.getDefaultSku() != null && getId() != null && !getId().equals(product.getDefaultSku().getId()));
+        return (product != null && product.getDefaultSku() != null && getId() != null
+                && !getId().equals(product.getDefaultSku().getId()));
     }
 
     protected Sku lookupDefaultSku() {
@@ -489,7 +510,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
                     if (optionValuePriceAdjustments == null) {
                         optionValuePriceAdjustments = value.getPriceAdjustment();
                     } else {
-                        optionValuePriceAdjustments = optionValuePriceAdjustments.add(value.getPriceAdjustment());
+                        optionValuePriceAdjustments =
+                                optionValuePriceAdjustments.add(value.getPriceAdjustment());
                     }
                 }
             }
@@ -504,7 +526,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             // We have dynamic pricing, so we will pull the sale price from there
-            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
+            DynamicSkuPrices dynamicPrices =
+                    SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             returnPrice = dynamicPrices.getSalePrice();
             optionValueAdjustments = dynamicPrices.getPriceAdjustment();
             if (SkuPricingConsiderationContext.isPricingConsiderationActive()) {
@@ -523,7 +546,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (returnPrice == null) {
             return null;
         }
-        
+
         if (optionValueAdjustments != null) {
             returnPrice = returnPrice.add(optionValueAdjustments);
         }
@@ -547,8 +570,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     }
 
     /*
-     * This allows us a way to determine or calculate the retail price. If one is not available this method will return null. 
-     * This allows the call to hasRetailPrice() to determine if there is a retail price without the overhead of an exception. 
+     * This allows us a way to determine or calculate the retail price. If one is not available this method will return null.
+     * This allows the call to hasRetailPrice() to determine if there is a retail price without the overhead of an exception.
      */
     protected Money getRetailPriceInternal() {
         Money returnPrice = null;
@@ -556,7 +579,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
             // We have dynamic pricing, so we will pull the retail price from there
-            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
+            DynamicSkuPrices dynamicPrices =
+                    SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             returnPrice = dynamicPrices.getRetailPrice();
             optionValueAdjustments = dynamicPrices.getPriceAdjustment();
             if (SkuPricingConsiderationContext.isPricingConsiderationActive()) {
@@ -571,11 +595,11 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
             returnPrice = lookupDefaultSku().getRetailPrice();
             optionValueAdjustments = getProductOptionValueAdjustments();
         }
-        
+
         if (returnPrice != null && optionValueAdjustments != null) {
             returnPrice = returnPrice.add(optionValueAdjustments);
         }
-        
+
         return returnPrice;
     }
 
@@ -608,7 +632,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @Override
     public DynamicSkuPrices getPriceData() {
         if (SkuPricingConsiderationContext.hasDynamicPricing()) {
-            DynamicSkuPrices dynamicPrices = SkuPricingConsiderationContext.getDynamicSkuPrices(this);
+            DynamicSkuPrices dynamicPrices =
+                    SkuPricingConsiderationContext.getDynamicSkuPrices(this);
             return dynamicPrices;
         } else {
             DynamicSkuPrices dsp = new DynamicSkuPrices();
@@ -687,7 +712,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
             purchaseCost = lookupDefaultSku().getCost();
         }
 
-        if (price != null && !(price.getAmount().compareTo(BigDecimal.ZERO)==0)) {
+        if (price != null && !(price.getAmount().compareTo(BigDecimal.ZERO) == 0)) {
             if (purchaseCost != null) {
                 margin = price.subtract(purchaseCost).divide(price.getAmount());
             }
@@ -703,7 +728,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (name == null && hasDefaultSku()) {
             return lookupDefaultSku().getName();
         }
-        
+
         return DynamicTranslationProvider.getValue(this, "name", name);
     }
 
@@ -717,7 +742,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (description == null && hasDefaultSku()) {
             return lookupDefaultSku().getDescription();
         }
-        
+
         return DynamicTranslationProvider.getValue(this, "description", description);
     }
 
@@ -731,7 +756,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (longDescription == null && hasDefaultSku()) {
             return lookupDefaultSku().getLongDescription();
         }
-        
+
         return DynamicTranslationProvider.getValue(this, "longDescription", longDescription);
     }
 
@@ -797,7 +822,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (InventoryType.UNAVAILABLE.equals(getInventoryType())) {
             return false;
         }
-        
+
         if (available == null) {
             if (hasDefaultSku()) {
                 return lookupDefaultSku().isAvailable();
@@ -906,7 +931,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
                 LOG.debug("sku, " + id + ", inactive due to category being inactive");
             }
         }
-        return this.isActive() && (product == null || product.isActive()) && (category == null || category.isActive());
+        return this.isActive() && (product == null || product.isActive()) && (category == null
+                || category.isActive());
     }
 
     @Override
@@ -928,8 +954,9 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setSkuMedia(Map<String, Media> skuMedia) {
         this.skuMedia.clear();
         this.legacySkuMedia.clear();
-        for(Map.Entry<String, Media> entry : skuMedia.entrySet()){
-            this.skuMedia.put(entry.getKey(), new SkuMediaXrefImpl(this, entry.getValue(), entry.getKey()));
+        for (Map.Entry<String, Media> entry : skuMedia.entrySet()) {
+            this.skuMedia.put(entry.getKey(),
+                    new SkuMediaXrefImpl(this, entry.getValue(), entry.getKey()));
         }
     }
 
@@ -977,7 +1004,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
             } else {
                 SkuMediaXref primaryXref = skuMediaMap.get("primary");
 
-                return (primaryXref == null)? null : primaryXref.getMedia();
+                return (primaryXref == null) ? null : primaryXref.getMedia();
             }
         }
 
@@ -996,9 +1023,13 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
 
     protected Map<String, SkuMediaXref> sortSkuMedia(Map<String, SkuMediaXref> skuMedia) {
         return skuMedia.values().stream()
-                .sorted(Comparator.comparing(xref -> ((OrderedSkuMediaXref) xref).getDisplayOrder()))
+                .sorted(Comparator.comparing(
+                        xref -> ((OrderedSkuMediaXref) xref).getDisplayOrder()))
                 .collect(Collectors.toMap(SkuMediaXref::getKey, Function.identity(),
-                        (key1,key2) ->{ throw new IllegalStateException(String.format("Duplicate key %s", key1)); },
+                        (key1, key2) -> {
+                            throw new IllegalStateException(
+                                    String.format("Duplicate key %s", key1));
+                        },
                         LinkedHashMap::new));
     }
 
@@ -1021,7 +1052,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setProduct(Product product) {
         this.product = product;
     }
-    
+
     @Override
     public Set<SkuProductOptionValueXref> getProductOptionValueXrefs() {
         return productOptionValueXrefs;
@@ -1057,12 +1088,15 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         //Changing this API to Set is ill-advised (especially in a patch release). The tendrils are widespread. Instead
         //we just migrate the call from the List to the internal Set representation. This is in response
         //to https://github.com/BroadleafCommerce/BroadleafCommerce/issues/917.
-        return (List<ProductOptionValue>) Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[]{List.class}, new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return MethodUtils.invokeMethod(getProductOptionValuesCollection(), method.getName(), args, method.getParameterTypes());
-            }
-        });
+        return (List<ProductOptionValue>) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[] {List.class}, new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args)
+                            throws Throwable {
+                        return MethodUtils.invokeMethod(getProductOptionValuesCollection(),
+                                method.getName(), args, method.getParameterTypes());
+                    }
+                });
     }
 
     @Override
@@ -1146,12 +1180,12 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setInventoryType(InventoryType inventoryType) {
         this.inventoryType = (inventoryType == null) ? null : inventoryType.getType();
     }
-    
+
     @Override
     public Integer getQuantityAvailable() {
         return quantityAvailable;
     }
-    
+
     @Override
     public void setQuantityAvailable(Integer quantityAvailable) {
         this.quantityAvailable = quantityAvailable;
@@ -1205,7 +1239,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setSkuAttributes(Map<String, SkuAttribute> skuAttributes) {
         List<SkuAttribute> skuAttributeList = new ArrayList<SkuAttribute>();
 
-        for(Map.Entry<String, SkuAttribute> entry : skuAttributes.entrySet()){
+        for (Map.Entry<String, SkuAttribute> entry : skuAttributes.entrySet()) {
             skuAttributeList.add(entry.getValue());
         }
 
@@ -1302,14 +1336,15 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     public void setUpc(String upc) {
         this.upc = upc;
     }
-    
+
     @Override
     public FieldEntity getFieldEntityType() {
         return FieldEntity.SKU;
     }
 
     @Override
-    public <G extends Sku> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Sku> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -1342,27 +1377,32 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (product != null) {
             cloned.setProduct(product.createOrRetrieveCopyInstance(context).getClone());
         }
-        for(Map.Entry<String, SkuAttribute> entry : getSkuAttributes().entrySet()){
-            SkuAttribute clonedEntry = entry.getValue().createOrRetrieveCopyInstance(context).getClone();
-            cloned.getSkuAttributes().put(entry.getKey(),clonedEntry);
+        for (Map.Entry<String, SkuAttribute> entry : getSkuAttributes().entrySet()) {
+            SkuAttribute clonedEntry =
+                    entry.getValue().createOrRetrieveCopyInstance(context).getClone();
+            cloned.getSkuAttributes().put(entry.getKey(), clonedEntry);
         }
-        for(SkuProductOptionValueXref entry : productOptionValueXrefs){
-            SkuProductOptionValueXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+        for (SkuProductOptionValueXref entry : productOptionValueXrefs) {
+            SkuProductOptionValueXref clonedEntry =
+                    entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getProductOptionValueXrefs().add(clonedEntry);
         }
-        for(Map.Entry<String, SkuMediaXref> entry : skuMedia.entrySet()){
-            SkuMediaXrefImpl clonedEntry = ((SkuMediaXrefImpl)entry.getValue()).createOrRetrieveCopyInstance(context).getClone();
-            cloned.getSkuMediaXrefIgnoreDefaultSku().put(entry.getKey(),clonedEntry);
+        for (Map.Entry<String, SkuMediaXref> entry : skuMedia.entrySet()) {
+            SkuMediaXrefImpl clonedEntry =
+                    ((SkuMediaXrefImpl) entry.getValue()).createOrRetrieveCopyInstance(context)
+                            .getClone();
+            cloned.getSkuMediaXrefIgnoreDefaultSku().put(entry.getKey(), clonedEntry);
         }
-        for(FulfillmentOption entry : excludedFulfillmentOptions){
+        for (FulfillmentOption entry : excludedFulfillmentOptions) {
             FulfillmentOption clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getExcludedFulfillmentOptions().add(clonedEntry);
         }
-        for(Map.Entry<FulfillmentOption, BigDecimal> entry : fulfillmentFlatRates.entrySet()){
-            FulfillmentOption clonedEntry = entry.getKey().createOrRetrieveCopyInstance(context).getClone();
-            cloned.getFulfillmentFlatRates().put(clonedEntry,entry.getValue());
+        for (Map.Entry<FulfillmentOption, BigDecimal> entry : fulfillmentFlatRates.entrySet()) {
+            FulfillmentOption clonedEntry =
+                    entry.getKey().createOrRetrieveCopyInstance(context).getClone();
+            cloned.getFulfillmentFlatRates().put(clonedEntry, entry.getValue());
         }
 
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -47,16 +37,30 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU_MEDIA_MAP")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSkuMedia")
-@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@AdminPresentationClass(excludeFromPolymorphism = false,
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class SkuMediaXrefImpl implements SkuMediaXref, Media, MultiTenantCloneable<SkuMediaXrefImpl> {
+public class SkuMediaXrefImpl
+        implements SkuMediaXref, Media, MultiTenantCloneable<SkuMediaXrefImpl> {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -72,20 +76,21 @@ public class SkuMediaXrefImpl implements SkuMediaXref, Media, MultiTenantCloneab
     }
 
     @Id
-    @GeneratedValue(generator= "SkuMediaId")
+    @GeneratedValue(generator = "SkuMediaId")
     @GenericGenerator(
-        name="SkuMediaId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SkuMediaXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuMediaXrefImpl")
-        }
+            name = "SkuMediaId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuMediaXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.SkuMediaXrefImpl")
+            }
     )
     @Column(name = "SKU_MEDIA_ID")
     protected Long id;
 
     //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
-    @ManyToOne(targetEntity = SkuImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = SkuImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "BLC_SKU_SKU_ID")
     @AdminPresentation(excluded = true)
     protected Sku sku;
@@ -96,7 +101,7 @@ public class SkuMediaXrefImpl implements SkuMediaXref, Media, MultiTenantCloneab
     @ClonePolicy
     protected Media media;
 
-    @Column(name = "MAP_KEY", nullable=false)
+    @Column(name = "MAP_KEY", nullable = false)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String key;
 
@@ -208,7 +213,8 @@ public class SkuMediaXrefImpl implements SkuMediaXref, Media, MultiTenantCloneab
     }
 
     @Override
-    public <G extends SkuMediaXrefImpl> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SkuMediaXrefImpl> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuMediaXrefImpl.java
@@ -17,25 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCloneable;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.media.domain.Media;
-import org.broadleafcommerce.common.media.domain.MediaImpl;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,6 +27,25 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.media.domain.Media;
+import org.broadleafcommerce.common.media.domain.MediaImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -75,7 +75,7 @@ public class SkuMediaXrefImpl implements SkuMediaXref, Media, MultiTenantCloneab
     @GeneratedValue(generator= "SkuMediaId")
     @GenericGenerator(
         name="SkuMediaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SkuMediaXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuMediaXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.Polymorphism;
-import org.hibernate.annotations.PolymorphismType;
-
-import java.util.Objects;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +27,21 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Polymorphism;
+import org.hibernate.annotations.PolymorphismType;
+
+import java.util.Objects;
 
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
@@ -70,7 +70,7 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
     @GeneratedValue(generator= "SkuProductOptionValueXrefId")
     @GenericGenerator(
         name="SkuProductOptionValueXrefId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SkuProductOptionValueXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuProductOptionValueXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -43,6 +33,17 @@ import org.hibernate.annotations.PolymorphismType;
 
 import java.util.Objects;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DUPLICATION;
 
 @Entity
@@ -52,14 +53,15 @@ import static org.broadleafcommerce.common.copy.MultiTenantCopyContext.MANUAL_DU
 @AdminPresentationClass(excludeFromPolymorphism = false)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blProductRelationships")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref {
 
     private static final long serialVersionUID = 1L;
-    
-    public SkuProductOptionValueXrefImpl() { }
+
+    public SkuProductOptionValueXrefImpl() {}
 
     public SkuProductOptionValueXrefImpl(Sku sku, ProductOptionValue val) {
         this.sku = sku;
@@ -67,23 +69,25 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
     }
 
     @Id
-    @GeneratedValue(generator= "SkuProductOptionValueXrefId")
+    @GeneratedValue(generator = "SkuProductOptionValueXrefId")
     @GenericGenerator(
-        name="SkuProductOptionValueXrefId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SkuProductOptionValueXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXrefImpl")
-        }
+            name = "SkuProductOptionValueXrefId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuProductOptionValueXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.SkuProductOptionValueXrefImpl")
+            }
     )
     @Column(name = "SKU_OPTION_VALUE_XREF_ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = SkuImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = SkuImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "SKU_ID")
     protected Sku sku;
 
-    @ManyToOne(targetEntity = ProductOptionValueImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = ProductOptionValueImpl.class, optional = false,
+            cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_OPTION_VALUE_ID")
     protected ProductOptionValue productOptionValue;
 
@@ -101,24 +105,25 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
     public Sku getSku() {
         return sku;
     }
-    
+
     @Override
     public void setSku(Sku sku) {
         this.sku = sku;
     }
-    
+
     @Override
     public ProductOptionValue getProductOptionValue() {
         return productOptionValue;
     }
-    
+
     @Override
     public void setProductOptionValue(ProductOptionValue productOptionValue) {
         this.productOptionValue = productOptionValue;
     }
 
     @Override
-    public <G extends SkuProductOptionValueXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SkuProductOptionValueXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -128,10 +133,11 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
             cloned.setSku(sku.createOrRetrieveCopyInstance(context).getClone());
         }
         if (productOptionValue != null) {
-            if(context.getCopyHints().containsKey(MANUAL_DUPLICATION)){
+            if (context.getCopyHints().containsKey(MANUAL_DUPLICATION)) {
                 cloned.setProductOptionValue(productOptionValue);
-            }else {
-                cloned.setProductOptionValue(productOptionValue.createOrRetrieveCopyInstance(context).getClone());
+            } else {
+                cloned.setProductOptionValue(
+                        productOptionValue.createOrRetrieveCopyInstance(context).getClone());
             }
         }
         return createResponse;
@@ -139,8 +145,10 @@ public class SkuProductOptionValueXrefImpl implements SkuProductOptionValueXref 
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         SkuProductOptionValueXrefImpl that = (SkuProductOptionValueXrefImpl) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(getSku(), that.getSku()) &&

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCloneable;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
@@ -44,12 +34,24 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_PRODUCT_UP_SALE")
+@Table(name = "BLC_PRODUCT_UP_SALE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blRelatedProducts")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<UpSaleProductImpl> {
@@ -57,46 +59,48 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "UpSaleProductId")
+    @GeneratedValue(generator = "UpSaleProductId")
     @GenericGenerator(
-        name="UpSaleProductId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="UpSaleProductImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.UpSaleProductImpl")
-        }
+            name = "UpSaleProductId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "UpSaleProductImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.catalog.domain.UpSaleProductImpl")
+            }
     )
     @Column(name = "UP_SALE_PRODUCT_ID")
     private Long id;
-    
+
     @Column(name = "PROMOTION_MESSAGE")
-    @AdminPresentation(friendlyName = "UpSaleProductImpl_Upsale_Promotion_Message", translatable=true, largeEntry=true)
+    @AdminPresentation(friendlyName = "UpSaleProductImpl_Upsale_Promotion_Message",
+            translatable = true, largeEntry = true)
     private String promotionMessage;
 
     @Column(name = "SEQUENCE", precision = 10, scale = 6)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     private BigDecimal sequence;
-    
+
     @ManyToOne(targetEntity = ProductImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "PRODUCT_ID")
-    @Index(name="UPSALE_PRODUCT_INDEX", columnNames={"PRODUCT_ID"})
+    @Index(name = "UPSALE_PRODUCT_INDEX", columnNames = {"PRODUCT_ID"})
     private Product product;
-    
+
     @ManyToOne(targetEntity = CategoryImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
-    @Index(name="UPSALE_CATEGORY_INDEX", columnNames={"CATEGORY_ID"})
+    @Index(name = "UPSALE_CATEGORY_INDEX", columnNames = {"CATEGORY_ID"})
     protected Category category;
 
     @ManyToOne(targetEntity = ProductImpl.class)
     @JoinColumn(name = "RELATED_SALE_PRODUCT_ID", referencedColumnName = "PRODUCT_ID")
-    @Index(name="UPSALE_RELATED_INDEX", columnNames={"RELATED_SALE_PRODUCT_ID"})
+    @Index(name = "UPSALE_RELATED_INDEX", columnNames = {"RELATED_SALE_PRODUCT_ID"})
     private Product relatedSaleProduct = new ProductImpl();
 
     @Override
     public Long getId() {
         return id;
-    } 
-    
+    }
+
     @Override
     public void setId(Long id) {
         this.id = id;
@@ -106,7 +110,7 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     public String getPromotionMessage() {
         return promotionMessage;
     }
-    
+
     @Override
     public void setPromotionMessage(String promotionMessage) {
         this.promotionMessage = promotionMessage;
@@ -116,7 +120,7 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     public BigDecimal getSequence() {
         return sequence;
     }
-    
+
     @Override
     public void setSequence(BigDecimal sequence) {
         this.sequence = sequence;
@@ -126,12 +130,12 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     public Product getProduct() {
         return product;
     }
-    
+
     @Override
     public void setProduct(Product product) {
         this.product = product;
     }
-    
+
     @Override
     public Category getCategory() {
         return category;
@@ -145,7 +149,7 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     @Override
     public Product getRelatedProduct() {
         return relatedSaleProduct;
-    }   
+    }
 
     @Override
     public void setRelatedProduct(Product relatedSaleProduct) {
@@ -154,17 +158,29 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         UpSaleProductImpl that = (UpSaleProductImpl) o;
 
-        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null) return false;
-        if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (product != null ? !product.equals(that.product) : that.product != null) return false;
-        if (relatedSaleProduct != null ? !relatedSaleProduct.equals(that.relatedSaleProduct) : that.relatedSaleProduct != null) return false;
-        if (promotionMessage != null ? !promotionMessage.equals(that.promotionMessage) : that.promotionMessage != null) return false;
+        if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null)
+            return false;
+        if (category != null ? !category.equals(that.category) : that.category != null)
+            return false;
+        if (product != null ? !product.equals(that.product) : that.product != null)
+            return false;
+        if (relatedSaleProduct != null
+                ? !relatedSaleProduct.equals(that.relatedSaleProduct)
+                : that.relatedSaleProduct != null)
+            return false;
+        if (promotionMessage != null
+                ? !promotionMessage.equals(that.promotionMessage)
+                : that.promotionMessage != null)
+            return false;
 
         return true;
     }
@@ -180,7 +196,8 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     }
 
     @Override
-    public <G extends UpSaleProductImpl> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends UpSaleProductImpl> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -194,7 +211,8 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
         }
         cloned.setPromotionMessage(promotionMessage);
         if (relatedSaleProduct != null) {
-            cloned.setRelatedProduct(relatedSaleProduct.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setRelatedProduct(
+                    relatedSaleProduct.createOrRetrieveCopyInstance(context).getClone());
         }
         cloned.setSequence(sequence);
         return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/UpSaleProductImpl.java
@@ -17,22 +17,6 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCloneable;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -43,6 +27,22 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -60,7 +60,7 @@ public class UpSaleProductImpl implements UpSaleProduct, MultiTenantCloneable<Up
     @GeneratedValue(generator= "UpSaleProductId")
     @GenericGenerator(
         name="UpSaleProductId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="UpSaleProductImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.UpSaleProductImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/domain/SkuAvailabilityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/domain/SkuAvailabilityImpl.java
@@ -10,20 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.inventory.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -38,28 +31,35 @@ import org.hibernate.annotations.Parameter;
 
 import java.util.Date;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
 /**
  * The Class SkuAvailabilityImpl is the default implementation of {@link SkuAvailability}.
  * <br>
  * <br>
- * This class is retrieved using the AvailabilityService.   The service allows availability to be
- * be location specific (e.g. for store specific inventory availability)
+ * This class is retrieved using the AvailabilityService.   The service allows availability to be be
+ * location specific (e.g. for store specific inventory availability)
  * <br>
  * <br>
- * This implementation uses a Hibernate implementation of JPA configured through annotations.
- * The Entity references the following tables:
- * BLC_SKU_AVAILABILITY
+ * This implementation uses a Hibernate implementation of JPA configured through annotations. The
+ * Entity references the following tables: BLC_SKU_AVAILABILITY
  *
- * @see {@link Sku}
  * @author bpolster
- * 
- * @deprecated This is no longer required and is instead implemented as a third-party inventory module
+ * @see {@link Sku}
+ * @deprecated This is no longer required and is instead implemented as a third-party inventory
+ * module
  */
 @Deprecated
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SKU_AVAILABILITY")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blInventoryElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blInventoryElements")
 public class SkuAvailabilityImpl implements SkuAvailability {
 
     /** The Constant serialVersionUID. */
@@ -69,48 +69,58 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     @Id
     @GeneratedValue(generator = "SkuAvailabilityId")
     @GenericGenerator(
-        name="SkuAvailabilityId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SkuAvailabilityImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.inventory.domain.SkuAvailabilityImpl")
-        }
+            name = "SkuAvailabilityId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SkuAvailabilityImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.inventory.domain.SkuAvailabilityImpl")
+            }
     )
     @Column(name = "SKU_AVAILABILITY_ID")
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Sku_Availability_ID", group = "SkuAvailabilityImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Sku_Availability_ID",
+            group = "SkuAvailabilityImpl_Primary_Key", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     /** The sale price. */
     @Column(name = "SKU_ID")
-    @Index(name="SKUAVAIL_SKU_INDEX", columnNames={"SKU_ID"})
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Sku_ID", visibility = VisibilityEnum.HIDDEN_ALL)
+    @Index(name = "SKUAVAIL_SKU_INDEX", columnNames = {"SKU_ID"})
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Sku_ID",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long skuId;
 
     /** The retail price. */
     @Column(name = "LOCATION_ID")
-    @Index(name="SKUAVAIL_LOCATION_INDEX", columnNames={"LOCATION_ID"})
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Location_ID", group = "SkuAvailabilityImpl_Description")
+    @Index(name = "SKUAVAIL_LOCATION_INDEX", columnNames = {"LOCATION_ID"})
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Location_ID",
+            group = "SkuAvailabilityImpl_Description")
     protected Long locationId;
 
     /** The quantity on hand. */
     @Column(name = "QTY_ON_HAND")
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Quantity_On_Hand", group = "SkuAvailabilityImpl_Description")
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Quantity_On_Hand",
+            group = "SkuAvailabilityImpl_Description")
     protected Integer quantityOnHand;
 
     /** The reserve quantity. */
     @Column(name = "RESERVE_QTY")
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Reserve_Quantity", group = "SkuAvailabilityImpl_Description")
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Reserve_Quantity",
+            group = "SkuAvailabilityImpl_Description")
     protected Integer reserveQuantity;
 
     /** The description. */
     @Column(name = "AVAILABILITY_STATUS")
-    @Index(name="SKUAVAIL_STATUS_INDEX", columnNames={"AVAILABILITY_STATUS"})
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Availability_Status", group = "SkuAvailabilityImpl_Description", fieldType= SupportedFieldType.BROADLEAF_ENUMERATION, broadleafEnumeration="org.broadleafcommerce.core.inventory.service.type.AvailabilityStatusType")
+    @Index(name = "SKUAVAIL_STATUS_INDEX", columnNames = {"AVAILABILITY_STATUS"})
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Availability_Status",
+            group = "SkuAvailabilityImpl_Description",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.inventory.service.type.AvailabilityStatusType")
     protected String availabilityStatus;
 
     /** The date this product will be available. */
     @Column(name = "AVAILABILITY_DATE")
-    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Available_Date", group = "SkuAvailabilityImpl_Description")
+    @AdminPresentation(friendlyName = "SkuAvailabilityImpl_Available_Date",
+            group = "SkuAvailabilityImpl_Description")
     protected Date availabilityDate;
 
     @Override
@@ -162,7 +172,7 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     public void setAvailabilityDate(Date availabilityDate) {
         this.availabilityDate = availabilityDate;
     }
-    
+
     @Override
     public AvailabilityStatusType getAvailabilityStatus() {
         return AvailabilityStatusType.getInstance(availabilityStatus);
@@ -176,9 +186,9 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     }
 
     /**
-     * Returns the reserve quantity.   Nulls will be treated the same as 0.
-     * Implementations may want to manage a reserve quantity at each location so that the
-     * available quantity for purchases is the quantityOnHand - reserveQuantity.
+     * Returns the reserve quantity.   Nulls will be treated the same as 0. Implementations may want
+     * to manage a reserve quantity at each location so that the available quantity for purchases is
+     * the quantityOnHand - reserveQuantity.
      */
     @Override
     public Integer getReserveQuantity() {
@@ -186,9 +196,9 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     }
 
     /**
-     * Sets the reserve quantity.
-     * Implementations may want to manage a reserve quantity at each location so that the
-     * available quantity for purchases is the quantityOnHand - reserveQuantity.
+     * Sets the reserve quantity. Implementations may want to manage a reserve quantity at each
+     * location so that the available quantity for purchases is the quantityOnHand -
+     * reserveQuantity.
      */
     @Override
     public void setReserveQuantity(Integer reserveQuantity) {
@@ -196,9 +206,8 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     }
 
     /**
-     * Returns the getQuantityOnHand() - getReserveQuantity().
-     * Preferred implementation is to return null if getQuantityOnHand() is null and to treat
-     * a null in getReserveQuantity() as ZERO.
+     * Returns the getQuantityOnHand() - getReserveQuantity(). Preferred implementation is to return
+     * null if getQuantityOnHand() is null and to treat a null in getReserveQuantity() as ZERO.
      */
     @Override
     public Integer getAvailableQuantity() {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/domain/SkuAvailabilityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/inventory/domain/SkuAvailabilityImpl.java
@@ -17,6 +17,14 @@
  */
 package org.broadleafcommerce.core.inventory.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
@@ -29,14 +37,6 @@ import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
 import java.util.Date;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 
 /**
  * The Class SkuAvailabilityImpl is the default implementation of {@link SkuAvailability}.
@@ -70,7 +70,7 @@ public class SkuAvailabilityImpl implements SkuAvailability {
     @GeneratedValue(generator = "SkuAvailabilityId")
     @GenericGenerator(
         name="SkuAvailabilityId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SkuAvailabilityImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.inventory.domain.SkuAvailabilityImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateFulfillmentGroupOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateFulfillmentGroupOfferImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
@@ -44,6 +33,18 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_CANDIDATE_FG_OFFER", indexes = {
         @Index(name = "CANDIDATE_FG_INDEX", columnList = "FULFILLMENT_GROUP_ID"),
@@ -55,14 +56,16 @@ public class CandidateFulfillmentGroupOfferImpl implements CandidateFulfillmentG
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CandidateFGOfferId")
+    @GeneratedValue(generator = "CandidateFGOfferId")
     @GenericGenerator(
-        name="CandidateFGOfferId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CandidateFulfillmentGroupOfferImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CandidateFulfillmentGroupOfferImpl")
-        }
+            name = "CandidateFGOfferId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value",
+                            value = "CandidateFulfillmentGroupOfferImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.CandidateFulfillmentGroupOfferImpl")
+            }
     )
     @Column(name = "CANDIDATE_FG_OFFER_ID")
     protected Long id;
@@ -71,11 +74,11 @@ public class CandidateFulfillmentGroupOfferImpl implements CandidateFulfillmentG
     @JoinColumn(name = "FULFILLMENT_GROUP_ID")
     protected FulfillmentGroup fulfillmentGroup;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
     protected Offer offer;
 
-    @Column(name = "DISCOUNTED_PRICE", precision=19, scale=5)
+    @Column(name = "DISCOUNTED_PRICE", precision = 19, scale = 5)
     protected BigDecimal discountedPrice;
 
     @Transient
@@ -116,9 +119,12 @@ public class CandidateFulfillmentGroupOfferImpl implements CandidateFulfillmentG
 
     @Override
     public Money getDiscountedPrice() {
-        return discountedPrice == null ? null : BroadleafCurrencyUtils.getMoney(discountedPrice, getFulfillmentGroup().getOrder().getCurrency());
+        return discountedPrice == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(discountedPrice,
+                        getFulfillmentGroup().getOrder().getCurrency());
     }
-    
+
     @Override
     public void setDiscountedPrice(Money discountedPrice) {
         this.discountedPrice = discountedPrice.getAmount();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateFulfillmentGroupOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateFulfillmentGroupOfferImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
-import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
-import org.broadleafcommerce.common.persistence.PostLoaderDao;
-import org.broadleafcommerce.common.util.HibernateUtils;
-import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
-import org.broadleafcommerce.core.order.domain.FulfillmentGroupImpl;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.proxy.HibernateProxy;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +28,21 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.persistence.PostLoaderDao;
+import org.broadleafcommerce.common.util.HibernateUtils;
+import org.broadleafcommerce.core.order.domain.FulfillmentGroup;
+import org.broadleafcommerce.core.order.domain.FulfillmentGroupImpl;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "BLC_CANDIDATE_FG_OFFER", indexes = {
@@ -58,7 +58,7 @@ public class CandidateFulfillmentGroupOfferImpl implements CandidateFulfillmentG
     @GeneratedValue(generator= "CandidateFGOfferId")
     @GenericGenerator(
         name="CandidateFGOfferId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CandidateFulfillmentGroupOfferImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CandidateFulfillmentGroupOfferImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
@@ -65,7 +65,7 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
     @GeneratedValue(generator = "CandidateItemOfferId")
     @GenericGenerator(
             name = "CandidateItemOfferId",
-            type = IdOverrideTableGenerator.classд,
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CandidateItemOfferImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -49,6 +38,18 @@ import org.hibernate.proxy.HibernateProxy;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_CANDIDATE_ITEM_OFFER", indexes = {
         @Index(name = "CANDIDATE_ITEM_INDEX", columnList = "ORDER_ITEM_ID"),
@@ -64,10 +65,11 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
     @GeneratedValue(generator = "CandidateItemOfferId")
     @GenericGenerator(
             name = "CandidateItemOfferId",
-            type = IdOverrideTableGenerator.class,
+            type = IdOverrideTableGenerator.classд,
             parameters = {
                     @Parameter(name = "segment_value", value = "CandidateItemOfferImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.CandidateItemOfferImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.CandidateItemOfferImpl")
             }
     )
     @Column(name = "CANDIDATE_ITEM_OFFER_ID")
@@ -138,7 +140,10 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
 
     @Override
     public Money getDiscountedPrice() {
-        return discountedPrice == null ? null : BroadleafCurrencyUtils.getMoney(discountedPrice, getOrderItem().getOrder().getCurrency());
+        return discountedPrice == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(discountedPrice,
+                        getOrderItem().getOrder().getCurrency());
     }
 
     @Override
@@ -146,11 +151,14 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
         this.discountedPrice = discountedPrice.getAmount();
     }
 
-    public void checkCloneable(CandidateItemOffer itemOffer) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = itemOffer.getClass().getMethod("clone", new Class[]{});
-        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !itemOffer.getClass().getName().startsWith("org.broadleafcommerce")) {
+    public void checkCloneable(CandidateItemOffer itemOffer)
+            throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
+        Method cloneMethod = itemOffer.getClass().getMethod("clone", new Class[] {});
+        if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce")
+                && !itemOffer.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
-            throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
+            throw new CloneNotSupportedException(
+                    "Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
         }
     }
 
@@ -159,11 +167,14 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
         //instantiate from the fully qualified name via reflection
         CandidateItemOffer candidateItemOffer;
         try {
-            candidateItemOffer = (CandidateItemOffer) Class.forName(this.getClass().getName()).newInstance();
+            candidateItemOffer =
+                    (CandidateItemOffer) Class.forName(this.getClass().getName()).newInstance();
             try {
                 checkCloneable(candidateItemOffer);
             } catch (CloneNotSupportedException e) {
-                LOG.warn("Clone implementation missing in inheritance hierarchy outside of Broadleaf: " + candidateItemOffer.getClass().getName(), e);
+                LOG.warn(
+                        "Clone implementation missing in inheritance hierarchy outside of Broadleaf: "
+                                + candidateItemOffer.getClass().getName(), e);
             }
             //candidateItemOffer.setCandidateQualifiersMap(getCandidateQualifiersMap());
             //candidateItemOffer.setCandidateTargets(getCandidateTargets());
@@ -228,7 +239,8 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
     }
 
     @Override
-    public <G extends CandidateItemOffer> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CandidateItemOffer> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateItemOfferImpl.java
@@ -10,13 +10,24 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -24,6 +35,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.util.HibernateUtils;
 import org.broadleafcommerce.core.order.domain.OrderItem;
@@ -37,18 +49,6 @@ import org.hibernate.proxy.HibernateProxy;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Table(name = "BLC_CANDIDATE_ITEM_OFFER", indexes = {
         @Index(name = "CANDIDATE_ITEM_INDEX", columnList = "ORDER_ITEM_ID"),
@@ -61,14 +61,14 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CandidateItemOfferId")
+    @GeneratedValue(generator = "CandidateItemOfferId")
     @GenericGenerator(
-        name="CandidateItemOfferId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CandidateItemOfferImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CandidateItemOfferImpl")
-        }
+            name = "CandidateItemOfferId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CandidateItemOfferImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.CandidateItemOfferImpl")
+            }
     )
     @Column(name = "CANDIDATE_ITEM_OFFER_ID")
     protected Long id;
@@ -77,11 +77,11 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
     @JoinColumn(name = "ORDER_ITEM_ID")
     protected OrderItem orderItem;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
     protected Offer offer;
 
-    @Column(name = "DISCOUNTED_PRICE", precision=19, scale=5)
+    @Column(name = "DISCOUNTED_PRICE", precision = 19, scale = 5)
     private BigDecimal discountedPrice;
 
     @Transient
@@ -135,17 +135,17 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
 
         return deproxiedOffer;
     }
-    
+
     @Override
     public Money getDiscountedPrice() {
         return discountedPrice == null ? null : BroadleafCurrencyUtils.getMoney(discountedPrice, getOrderItem().getOrder().getCurrency());
     }
-    
+
     @Override
     public void setDiscountedPrice(Money discountedPrice) {
         this.discountedPrice = discountedPrice.getAmount();
     }
-    
+
     public void checkCloneable(CandidateItemOffer itemOffer) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
         Method cloneMethod = itemOffer.getClass().getMethod("clone", new Class[]{});
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !itemOffer.getClass().getName().startsWith("org.broadleafcommerce")) {
@@ -153,7 +153,7 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
         }
     }
-    
+
     @Override
     public CandidateItemOffer clone() {
         //instantiate from the fully qualified name via reflection
@@ -172,10 +172,10 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        
+
         return candidateItemOffer;
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -239,6 +239,6 @@ public class CandidateItemOfferImpl implements CandidateItemOffer, Cloneable {
         cloned.setOrderItem(orderItem);
         // TODO clone here?
         cloned.setOffer(offer.createOrRetrieveCopyInstance(context).getClone());
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateOrderOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateOrderOfferImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
-import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
-import org.broadleafcommerce.common.persistence.PostLoaderDao;
-import org.broadleafcommerce.common.util.HibernateUtils;
-import org.broadleafcommerce.core.order.domain.Order;
-import org.broadleafcommerce.core.order.domain.OrderImpl;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.proxy.HibernateProxy;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +28,21 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.persistence.PostLoaderDao;
+import org.broadleafcommerce.common.util.HibernateUtils;
+import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.domain.OrderImpl;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.proxy.HibernateProxy;
+
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "BLC_CANDIDATE_ORDER_OFFER", indexes = {
@@ -58,7 +58,7 @@ public class CandidateOrderOfferImpl implements CandidateOrderOffer {
     @GeneratedValue(generator= "CandidateOrderOfferId")
     @GenericGenerator(
         name="CandidateOrderOfferId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CandidateOrderOfferImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CandidateOrderOfferImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateOrderOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CandidateOrderOfferImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
@@ -44,6 +33,18 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_CANDIDATE_ORDER_OFFER", indexes = {
         @Index(name = "CANDIDATE_ORDER_INDEX", columnList = "ORDER_ID"),
@@ -55,14 +56,15 @@ public class CandidateOrderOfferImpl implements CandidateOrderOffer {
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CandidateOrderOfferId")
+    @GeneratedValue(generator = "CandidateOrderOfferId")
     @GenericGenerator(
-        name="CandidateOrderOfferId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CandidateOrderOfferImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CandidateOrderOfferImpl")
-        }
+            name = "CandidateOrderOfferId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CandidateOrderOfferImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.CandidateOrderOfferImpl")
+            }
     )
     @Column(name = "CANDIDATE_ORDER_OFFER_ID")
     protected Long id;
@@ -71,11 +73,11 @@ public class CandidateOrderOfferImpl implements CandidateOrderOffer {
     @JoinColumn(name = "ORDER_ID")
     protected Order order;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
     protected Offer offer;
 
-    @Column(name = "DISCOUNTED_PRICE", precision=19, scale=5)
+    @Column(name = "DISCOUNTED_PRICE", precision = 19, scale = 5)
     protected BigDecimal discountedPrice;
 
     @Transient
@@ -123,9 +125,11 @@ public class CandidateOrderOfferImpl implements CandidateOrderOffer {
 
     @Override
     public Money getDiscountedPrice() {
-        return discountedPrice == null ? null : BroadleafCurrencyUtils.getMoney(discountedPrice, getOrder().getCurrency());
+        return discountedPrice == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(discountedPrice, getOrder().getCurrency());
     }
-    
+
     @Override
     public void setDiscountedPrice(Money discountedPrice) {
         this.discountedPrice = discountedPrice.getAmount();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CustomerOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CustomerOfferImpl.java
@@ -10,12 +10,18 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
+
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,11 +33,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @Table(name = "BLC_CUSTOMER_OFFER_XREF", indexes = {
@@ -43,23 +44,24 @@ public class CustomerOfferImpl implements CustomerOffer {
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "CustomerOfferId")
+    @GeneratedValue(generator = "CustomerOfferId")
     @GenericGenerator(
-        name="CustomerOfferId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CustomerOfferImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CustomerOfferImpl")
-        }
+            name = "CustomerOfferId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CustomerOfferImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.CustomerOfferImpl")
+            }
     )
     @Column(name = "CUSTOMER_OFFER_ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = CustomerImpl.class, optional=false)
+    @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     protected Customer customer;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
     protected Offer offer;
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CustomerOfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/CustomerOfferImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -32,6 +27,11 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Table(name = "BLC_CUSTOMER_OFFER_XREF", indexes = {
@@ -46,7 +46,7 @@ public class CustomerOfferImpl implements CustomerOffer {
     @GeneratedValue(generator= "CustomerOfferId")
     @GenericGenerator(
         name="CustomerOfferId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CustomerOfferImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.CustomerOfferImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/FulfillmentGroupAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/FulfillmentGroupAdjustmentImpl.java
@@ -17,10 +17,22 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -43,18 +55,6 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Table(name = "BLC_FG_ADJUSTMENT", indexes = {
         @Index(name = "FGADJUSTMENT_INDEX", columnList = "FULFILLMENT_GROUP_ID"),
@@ -75,7 +75,7 @@ public class FulfillmentGroupAdjustmentImpl implements FulfillmentGroupAdjustmen
     @GeneratedValue(generator= "FGAdjustmentId")
     @GenericGenerator(
         name="FGAdjustmentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentGroupAdjustmentImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.FulfillmentGroupAdjustmentImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/FulfillmentGroupAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/FulfillmentGroupAdjustmentImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
@@ -55,6 +44,18 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_FG_ADJUSTMENT", indexes = {
         @Index(name = "FGADJUSTMENT_INDEX", columnList = "FULFILLMENT_GROUP_ID"),
@@ -66,20 +67,23 @@ import java.math.BigDecimal;
         @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
                 booleanOverrideValue = true))
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "FulfillmentGroupAdjustmentImpl_baseFulfillmentGroupAdjustment")
-public class FulfillmentGroupAdjustmentImpl implements FulfillmentGroupAdjustment, CurrencyCodeIdentifiable {
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "FulfillmentGroupAdjustmentImpl_baseFulfillmentGroupAdjustment")
+public class FulfillmentGroupAdjustmentImpl
+        implements FulfillmentGroupAdjustment, CurrencyCodeIdentifiable {
 
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "FGAdjustmentId")
+    @GeneratedValue(generator = "FGAdjustmentId")
     @GenericGenerator(
-        name="FGAdjustmentId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="FulfillmentGroupAdjustmentImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.FulfillmentGroupAdjustmentImpl")
-        }
+            name = "FGAdjustmentId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FulfillmentGroupAdjustmentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.FulfillmentGroupAdjustmentImpl")
+            }
     )
     @Column(name = "FG_ADJUSTMENT_ID")
     protected Long id;
@@ -89,33 +93,35 @@ public class FulfillmentGroupAdjustmentImpl implements FulfillmentGroupAdjustmen
     @AdminPresentation(excluded = true)
     protected FulfillmentGroup fulfillmentGroup;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
-    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_Offer", order=1000,
+    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_Offer", order = 1000,
             prominent = true, gridOrder = 1000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
 
-    @Column(name = "ADJUSTMENT_REASON", nullable=false)
-    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_FG_Adjustment_Reason", order=2000)
+    @Column(name = "ADJUSTMENT_REASON", nullable = false)
+    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_FG_Adjustment_Reason",
+            order = 2000)
     protected String reason;
 
-    @Column(name = "ADJUSTMENT_VALUE", nullable=false, precision=19, scale=5)
-    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_FG_Adjustment_Value", order=3000,
+    @Column(name = "ADJUSTMENT_VALUE", nullable = false, precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_FG_Adjustment_Value",
+            order = 3000,
             fieldType = SupportedFieldType.MONEY, prominent = true,
             gridOrder = 2000)
     protected BigDecimal value = Money.ZERO.getAmount();
 
     @Column(name = "IS_FUTURE_CREDIT")
     @AdminPresentation(friendlyName = "FulfillmentGroupAdjustmentImpl_isFutureCredit", order = 4000,
-            showIfProperty="admin.showIfProperty.offerAdjustmentType")
+            showIfProperty = "admin.showIfProperty.offerAdjustmentType")
     protected Boolean isFutureCredit = false;
 
     @Transient
     protected Offer deproxiedOffer;
 
     @Override
-    public void init(FulfillmentGroup fulfillmentGroup, Offer offer, String reason){
+    public void init(FulfillmentGroup fulfillmentGroup, Offer offer, String reason) {
         this.fulfillmentGroup = fulfillmentGroup;
         this.offer = offer;
 
@@ -125,7 +131,8 @@ public class FulfillmentGroupAdjustmentImpl implements FulfillmentGroupAdjustmen
             this.reason = reason;
         }
         if (offer != null) {
-            this.setFutureCredit(OfferAdjustmentType.FUTURE_CREDIT.equals(offer.getAdjustmentType()));
+            this.setFutureCredit(
+                    OfferAdjustmentType.FUTURE_CREDIT.equals(offer.getAdjustmentType()));
         }
     }
 
@@ -184,9 +191,12 @@ public class FulfillmentGroupAdjustmentImpl implements FulfillmentGroupAdjustmen
 
     @Override
     public Money getValue() {
-        return value == null ? null : BroadleafCurrencyUtils.getMoney(value, getFulfillmentGroup().getOrder().getCurrency());
+        return value == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(value,
+                        getFulfillmentGroup().getOrder().getCurrency());
     }
-    
+
     @Override
     public void setValue(Money value) {
         this.value = value.getAmount();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/LegacyOfferUsesImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/LegacyOfferUsesImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -29,8 +29,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
 /**
- * Holds the backwards compatibility field for uses. Also hold the backwards compatibility mutator implementations
- * for maxUses.
+ * Holds the backwards compatibility field for uses. Also hold the backwards compatibility mutator
+ * implementations for maxUses.
  *
  * @author Jeff Fischer
  */
@@ -41,13 +41,14 @@ public class LegacyOfferUsesImpl implements LegacyOfferUses, MultiTenantCloneabl
     protected Offer offer;
 
     @Column(name = "USES")
-    @AdminPresentation(friendlyName = "OfferImpl_Offer_Current_Uses", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "OfferImpl_Offer_Current_Uses",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected int uses;
-    
+
     @Column(name = "APPLY_OFFER_TO_MARKED_ITEMS")
     @AdminPresentation(excluded = true)
     @Deprecated
-    protected boolean applyDiscountToMarkedItems;    
+    protected boolean applyDiscountToMarkedItems;
 
     @Override
     public void setUses(int uses) {
@@ -68,7 +69,7 @@ public class LegacyOfferUsesImpl implements LegacyOfferUses, MultiTenantCloneabl
     public void setMaxUses(int maxUses) {
         offer.setMaxUsesPerOrder(maxUses);
     }
-    
+
     @Override
     @Deprecated
     public boolean isApplyDiscountToMarkedItems() {
@@ -79,14 +80,14 @@ public class LegacyOfferUsesImpl implements LegacyOfferUses, MultiTenantCloneabl
     public boolean getApplyDiscountToMarkedItems() {
         return applyDiscountToMarkedItems;
     }
-    
+
     @Override
     @Deprecated
     public void setApplyDiscountToMarkedItems(boolean applyDiscountToMarkedItems) {
         this.applyDiscountToMarkedItems = applyDiscountToMarkedItems;
     }
 
-    
+
 
     public Offer getOffer() {
         return offer;
@@ -98,12 +99,15 @@ public class LegacyOfferUsesImpl implements LegacyOfferUses, MultiTenantCloneabl
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LegacyOfferUsesImpl)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LegacyOfferUsesImpl))
+            return false;
 
         LegacyOfferUsesImpl that = (LegacyOfferUsesImpl) o;
 
-        if (uses != that.uses) return false;
+        if (uses != that.uses)
+            return false;
         return offer.equals(that.offer);
 
     }
@@ -115,7 +119,8 @@ public class LegacyOfferUsesImpl implements LegacyOfferUses, MultiTenantCloneabl
         return result;
     }
 
-    public <G extends LegacyOfferUses> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+    public <G extends LegacyOfferUses> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context)
             throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         LegacyOfferUses clone = createResponse.getClone();

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferAuditImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferAuditImpl.java
@@ -10,21 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.logging.Log;
@@ -34,6 +26,15 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.util.Date;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "BLC_OFFER_AUDIT", indexes = {
@@ -52,11 +53,12 @@ public class OfferAuditImpl implements OfferAudit {
     @Id
     @GeneratedValue(generator = "OfferAuditId")
     @GenericGenerator(
-            name="OfferAuditId",
-            type= IdOverrideTableGenerator.class,
+            name = "OfferAuditId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="OfferAuditImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferAuditImpl")
+                    @Parameter(name = "segment_value", value = "OfferAuditImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferAuditImpl")
             }
     )
     @Column(name = "OFFER_AUDIT_ID")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferAuditImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferAuditImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,6 +25,15 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.Date;
 
 @Entity
 @Table(name = "BLC_OFFER_AUDIT", indexes = {
@@ -53,7 +53,7 @@ public class OfferAuditImpl implements OfferAudit {
     @GeneratedValue(generator = "OfferAuditId")
     @GenericGenerator(
             name="OfferAuditId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="OfferAuditImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferAuditImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
@@ -10,28 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -64,6 +49,22 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_OFFER_CODE", indexes = {
         @Index(name = "OFFERCODE_CODE_INDEX", columnList = "OFFER_CODE"),
@@ -71,10 +72,12 @@ import java.util.List;
         @Index(name = "OFFERCODE_OFFER_INDEX", columnList = "OFFER_ID")})
 @Inheritance(strategy = InheritanceType.JOINED)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blOrderElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE, friendlyName = "OfferCodeImpl_baseOfferCode")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE,
+        friendlyName = "OfferCodeImpl_baseOfferCode")
 @SQLDelete(sql = "UPDATE BLC_OFFER_CODE SET ARCHIVED = 'Y' WHERE OFFER_CODE_ID = ?")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferCodeImpl implements OfferCode {
@@ -82,32 +85,37 @@ public class OfferCodeImpl implements OfferCode {
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OfferCodeId")
+    @GeneratedValue(generator = "OfferCodeId")
     @GenericGenerator(
-        name="OfferCodeId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferCodeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferCodeImpl")
-        }
+            name = "OfferCodeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferCodeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferCodeImpl")
+            }
     )
     @Column(name = "OFFER_CODE_ID")
     @AdminPresentation(friendlyName = "OfferCodeImpl_Offer_Code_Id")
     protected Long id;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "OFFER_ID")
-    @AdminPresentation(friendlyName = "OfferCodeImpl_Offer", order=2000,
+    @AdminPresentation(friendlyName = "OfferCodeImpl_Offer", order = 2000,
             prominent = true, gridOrder = 2000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
 
-    @Column(name = "OFFER_CODE", nullable=false)
-    @AdminPresentation(friendlyName = "OfferCodeImpl_Offer_Code", order = 1000, prominent = true, gridOrder = 1000,
-            validationConfigurations = { @ValidationConfiguration(validationImplementation = "blRegexPropertyValidator",
-                    configurationItems = {
-                            @ConfigurationItem(itemName = ConfigurationItem.ERROR_MESSAGE, itemValue = "The name can contain alphanumeric or \"()-=*.?;,+/:&_\" symbols with a maximum length of 255"),
-                            @ConfigurationItem(itemName = "regularExpression", itemValue = "^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]{1,255}$")})})
+    @Column(name = "OFFER_CODE", nullable = false)
+    @AdminPresentation(friendlyName = "OfferCodeImpl_Offer_Code", order = 1000, prominent = true,
+            gridOrder = 1000,
+            validationConfigurations = {
+                    @ValidationConfiguration(validationImplementation = "blRegexPropertyValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = ConfigurationItem.ERROR_MESSAGE,
+                                            itemValue = "The name can contain alphanumeric or \"()-=*.?;,+/:&_\" symbols with a maximum length of 255"),
+                                    @ConfigurationItem(itemName = "regularExpression",
+                                            itemValue = "^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]{1,255}$")})})
     protected String offerCode;
 
     @Column(name = "START_DATE")
@@ -117,13 +125,14 @@ public class OfferCodeImpl implements OfferCode {
 
     @Column(name = "END_DATE")
     @AdminPresentation(friendlyName = "OfferCodeImpl_Code_End_Date", order = 4000,
-        validationConfigurations = {
-            @ValidationConfiguration(
-                validationImplementation = "blAfterStartDateValidator",
-                configurationItems = {
-                    @ConfigurationItem(itemName = "otherField", itemValue = "offerCodeStartDate")
-                    }) 
-        })
+            validationConfigurations = {
+                    @ValidationConfiguration(
+                            validationImplementation = "blAfterStartDateValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "offerCodeStartDate")
+                            })
+            })
     protected Date offerCodeEndDate;
 
     @Column(name = "MAX_USES")
@@ -141,9 +150,10 @@ public class OfferCodeImpl implements OfferCode {
 
     @Embedded
     protected ArchiveStatus archiveStatus = new ArchiveStatus();
-    
-    @ManyToMany(fetch = FetchType.LAZY, mappedBy="addedOfferCodes", targetEntity = OrderImpl.class)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOrderElements")
+
+    @ManyToMany(fetch = FetchType.LAZY, mappedBy = "addedOfferCodes",
+            targetEntity = OrderImpl.class)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
     protected List<Order> orders = new ArrayList<>();
 
     @Transient
@@ -151,7 +161,7 @@ public class OfferCodeImpl implements OfferCode {
 
     @Transient
     protected Offer deproxiedOffer;
-    
+
     @Override
     public Long getId() {
         return id;
@@ -205,12 +215,12 @@ public class OfferCodeImpl implements OfferCode {
     public void setMaxUses(int maxUses) {
         this.maxUses = maxUses;
     }
-    
+
     @Override
     public boolean isUnlimitedUse() {
         return getMaxUses() == 0;
     }
-    
+
     @Override
     public boolean isLimitedUse() {
         return getMaxUses() > 0;
@@ -267,16 +277,16 @@ public class OfferCodeImpl implements OfferCode {
     public void setOrders(List<Order> orders) {
         this.orders = orders;
     }
-    
+
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -293,7 +303,8 @@ public class OfferCodeImpl implements OfferCode {
         // If the start date for this offer code has not been set, just delegate to the offer to determine if the code is
         // active rather than requiring the user to set offer code dates as well
         if (offerCodeStartDate == null) {
-            datesActive = DateUtil.isActive(getOffer().getStartDate(), getOffer().getEndDate(), true);
+            datesActive =
+                    DateUtil.isActive(getOffer().getStartDate(), getOffer().getEndDate(), true);
         } else {
             datesActive = DateUtil.isActive(offerCodeStartDate, offerCodeEndDate, true);
         }
@@ -303,30 +314,31 @@ public class OfferCodeImpl implements OfferCode {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(offer)
-            .append(offerCode)
-            .append(emailAddress)
-            .build();
+                .append(offer)
+                .append(offerCode)
+                .append(emailAddress)
+                .build();
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (o != null && getClass().isAssignableFrom(o.getClass())) {
             OfferCodeImpl that = (OfferCodeImpl) o;
             return new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.offer, that.offer)
-                .append(this.offerCode, that.offerCode)
-                .append(this.emailAddress, that.emailAddress)
-                .build();
+                    .append(this.id, that.id)
+                    .append(this.offer, that.offer)
+                    .append(this.offerCode, that.offerCode)
+                    .append(this.emailAddress, that.emailAddress)
+                    .build();
         }
-        
+
         return false;
     }
 
 
     @Override
-    public <G extends OfferCode> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferCode> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -342,6 +354,6 @@ public class OfferCodeImpl implements OfferCode {
         cloned.setOfferCode(offerCode);
         cloned.setUses(uses);
         cloned.setEmailAddress(emailAddress);
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferCodeImpl.java
@@ -17,6 +17,21 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -26,6 +41,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -48,22 +64,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Table(name = "BLC_OFFER_CODE", indexes = {
         @Index(name = "OFFERCODE_CODE_INDEX", columnList = "OFFER_CODE"),
@@ -85,7 +85,7 @@ public class OfferCodeImpl implements OfferCode {
     @GeneratedValue(generator= "OfferCodeId")
     @GenericGenerator(
         name="OfferCodeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferCodeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferCodeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -10,28 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -71,6 +56,8 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,6 +67,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 @Entity
 @Table(name = "BLC_OFFER", indexes = {
@@ -93,7 +95,8 @@ import java.util.Set;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
 @SQLDelete(sql = "UPDATE BLC_OFFER SET ARCHIVED = 'Y' WHERE OFFER_ID = ?")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation {
@@ -101,93 +104,95 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public static final long serialVersionUID = 1L;
 
     public static final String EXCLUDE_OFFERCODE_COPY_HINT = "exclude-offer-offerCodes";
-    
+
     @Id
-    @GeneratedValue(generator= "OfferId")
+    @GeneratedValue(generator = "OfferId")
     @GenericGenerator(
-        name="OfferId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferImpl")
-        }
+            name = "OfferId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferImpl")
+            }
     )
     @Column(name = "OFFER_ID")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Id", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @OneToMany(mappedBy = "offer", targetEntity = OfferCodeImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "offer", targetEntity = OfferCodeImpl.class, cascade = {CascadeType.ALL})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "offerCodeTitle",
-        group = GroupName.Codes, order = FieldOrder.OfferCodes,
-        addType = AddMethodType.PERSIST)
+            group = GroupName.Codes, order = FieldOrder.OfferCodes,
+            addType = AddMethodType.PERSIST)
     protected List<OfferCode> offerCodes = new ArrayList<OfferCode>(100);
 
-    @Column(name = "OFFER_NAME", nullable=false)
+    @Column(name = "OFFER_NAME", nullable = false)
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Name",
-        group = GroupName.Description, order = FieldOrder.Name,
-        prominent = true, gridOrder = 1, translatable = true,
-        defaultValue = "New Offer")
+            group = GroupName.Description, order = FieldOrder.Name,
+            prominent = true, gridOrder = 1, translatable = true,
+            defaultValue = "New Offer")
     protected String name;
 
     @Column(name = "OFFER_DESCRIPTION")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Description",
-        group = GroupName.Description, order = FieldOrder.Description,
-        largeEntry = true, fieldType = SupportedFieldType.DESCRIPTION, defaultValue = "")
+            group = GroupName.Description, order = FieldOrder.Description,
+            largeEntry = true, fieldType = SupportedFieldType.DESCRIPTION, defaultValue = "")
     protected String description;
 
     @Column(name = "MARKETING_MESSAGE")
     @AdminPresentation(friendlyName = "OfferImpl_marketingMessage",
-        group = GroupName.Marketing, order = FieldOrder.Message,
-        translatable = true, defaultValue = "")
+            group = GroupName.Marketing, order = FieldOrder.Message,
+            translatable = true, defaultValue = "")
     protected String marketingMessage;
 
-    @Column(name = "OFFER_TYPE", nullable=false)
+    @Column(name = "OFFER_TYPE", nullable = false)
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Type",
-        group = GroupName.Description, order = FieldOrder.OfferType,
-        fieldType=SupportedFieldType.BROADLEAF_ENUMERATION, 
-        broadleafEnumeration="org.broadleafcommerce.core.offer.service.type.OfferType",
-        defaultValue = "ORDER")
+            group = GroupName.Description, order = FieldOrder.OfferType,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferType",
+            defaultValue = "ORDER")
     protected String type;
 
     @Column(name = "OFFER_DISCOUNT_TYPE")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Discount_Type",
-        group = GroupName.Description, order = FieldOrder.DiscountType,
-        requiredOverride = RequiredOverride.REQUIRED,
-        fieldType=SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration="org.broadleafcommerce.core.offer.service.type.OfferDiscountType")
+            group = GroupName.Description, order = FieldOrder.DiscountType,
+            requiredOverride = RequiredOverride.REQUIRED,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferDiscountType")
     protected String discountType;
 
-    @Column(name = "OFFER_VALUE", nullable=false, precision=19, scale=5)
+    @Column(name = "OFFER_VALUE", nullable = false, precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Value",
-        group = GroupName.Description, order = FieldOrder.Amount,
-        prominent = true, gridOrder = 4,
+            group = GroupName.Description, order = FieldOrder.Amount,
+            prominent = true, gridOrder = 4,
             defaultValue = "0.00")
     protected BigDecimal value;
 
     @Column(name = "OFFER_PRIORITY")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Priority",
-        group = GroupName.Advanced, order = FieldOrder.Priority)
+            group = GroupName.Advanced, order = FieldOrder.Priority)
     protected Integer priority;
 
     @Column(name = "START_DATE")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Start_Date",
-        group = GroupName.ActivityRange, order = FieldOrder.StartDate,
-        prominent = true, gridOrder = 2,
-        defaultValue = "today")
+            group = GroupName.ActivityRange, order = FieldOrder.StartDate,
+            prominent = true, gridOrder = 2,
+            defaultValue = "today")
     protected Date startDate;
 
     @Column(name = "END_DATE")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_End_Date",
-        group = GroupName.ActivityRange, order = FieldOrder.EndDate,
-        validationConfigurations = { 
-            @ValidationConfiguration(
-                validationImplementation = "blAfterStartDateValidator",
-                configurationItems = {
-                        @ConfigurationItem(itemName = "otherField", itemValue = "startDate")
-                }) 
-        })
+            group = GroupName.ActivityRange, order = FieldOrder.EndDate,
+            validationConfigurations = {
+                    @ValidationConfiguration(
+                            validationImplementation = "blAfterStartDateValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "startDate")
+                            })
+            })
     protected Date endDate;
 
     @Column(name = "TARGET_SYSTEM")
@@ -209,11 +214,11 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     protected Boolean applyToChildItems = false;
 
     /**
-     * Determines if other offers of the same type can be combined with this offer. 
+     * Determines if other offers of the same type can be combined with this offer.
      */
     @Column(name = "COMBINABLE_WITH_OTHER_OFFERS")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Combinable",
-        tooltip = "OfferImplCombinableWithOtherOffers_tooltip",
+            tooltip = "OfferImplCombinableWithOtherOffers_tooltip",
             group = GroupName.CombineStack,
             order = FieldOrder.CombinableWithOtherOffers,
             defaultValue = "true")
@@ -228,19 +233,23 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Column(name = "MAX_USES")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Max_Uses_Per_Order",
-        tooltip = "OfferImplMaxUsesPerOrder_tooltip", order = FieldOrder.MaxUsesPerOrder,
-        group = GroupName.Restrictions)
+            tooltip = "OfferImplMaxUsesPerOrder_tooltip", order = FieldOrder.MaxUsesPerOrder,
+            group = GroupName.Restrictions)
     protected Integer maxUsesPerOrder;
 
     @Column(name = "MAX_USES_PER_CUSTOMER")
     @AdminPresentation(friendlyName = "OfferImpl_Max_Uses_Per_Customer",
-        group = GroupName.Restrictions, order = FieldOrder.MaxUsesPerCustomer,
-        tooltip = "OfferImplMaxUsesPerCustomer_tooltip",
-        defaultValue = "0")
+            group = GroupName.Restrictions, order = FieldOrder.MaxUsesPerCustomer,
+            tooltip = "OfferImplMaxUsesPerCustomer_tooltip",
+            defaultValue = "0")
     protected Long maxUsesPerCustomer;
 
     @Column(name = "MAX_USES_STRATEGY")
-    @AdminPresentation(friendlyName = "OfferImpl_Max_Uses_Strategy", allowNoValueEnumOption = false, defaultValue = "CUSTOMER", group = GroupName.Restrictions, order = FieldOrder.MaxUsesStrategy, fieldType = SupportedFieldType.BROADLEAF_ENUMERATION, broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.CustomerMaxUsesStrategyType")
+    @AdminPresentation(friendlyName = "OfferImpl_Max_Uses_Strategy", allowNoValueEnumOption = false,
+            defaultValue = "CUSTOMER", group = GroupName.Restrictions,
+            order = FieldOrder.MaxUsesStrategy,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.CustomerMaxUsesStrategyType")
     protected String maxUsesStrategy;
 
     @Column(name = "MINIMUM_DAYS_PER_USAGE")
@@ -252,29 +261,29 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Column(name = "OFFER_ITEM_QUALIFIER_RULE")
     @AdminPresentation(friendlyName = "OfferImpl_Item_Qualifier_Rule",
-        group = GroupName.QualifierRuleRestriction,
-        tooltip = "OfferItemRestrictionRuleType_tooltip",
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferItemRestrictionRuleType",
-        defaultValue = "NONE",
-        visibility = VisibilityEnum.HIDDEN_ALL)
+            group = GroupName.QualifierRuleRestriction,
+            tooltip = "OfferItemRestrictionRuleType_tooltip",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferItemRestrictionRuleType",
+            defaultValue = "NONE",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected String offerItemQualifierRuleType;
 
-    @Column(name = "QUALIFYING_ITEM_MIN_TOTAL", precision=19, scale=5)
-    @AdminPresentation(friendlyName="OfferImpl_Qualifying_Item_Subtotal",
-        group = GroupName.QualifierRuleRestriction, order = FieldOrder.QualifyingItemSubTotal,
+    @Column(name = "QUALIFYING_ITEM_MIN_TOTAL", precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OfferImpl_Qualifying_Item_Subtotal",
+            group = GroupName.QualifierRuleRestriction, order = FieldOrder.QualifyingItemSubTotal,
             defaultValue = "0.00")
     protected BigDecimal qualifyingItemSubTotal;
 
-    @Column(name = "ORDER_MIN_TOTAL", precision=19, scale=5)
-    @AdminPresentation(friendlyName="OfferImpl_Order_Subtotal",
-        tooltip = "OfferImplMinOrderSubtotal_tooltip",
-        group = GroupName.Restrictions, order = FieldOrder.OrderMinSubTotal,
+    @Column(name = "ORDER_MIN_TOTAL", precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OfferImpl_Order_Subtotal",
+            tooltip = "OfferImplMinOrderSubtotal_tooltip",
+            group = GroupName.Restrictions, order = FieldOrder.OrderMinSubTotal,
             defaultValue = "0.00")
     protected BigDecimal orderMinSubTotal;
 
-    @Column(name = "TARGET_MIN_TOTAL", precision=19, scale=5)
-    @AdminPresentation(friendlyName="OfferImpl_Target_Subtotal",
+    @Column(name = "TARGET_MIN_TOTAL", precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OfferImpl_Target_Subtotal",
             tooltip = "OfferImplMinTargetSubtotal_tooltip",
             group = GroupName.Restrictions, order = FieldOrder.TargetMinSubTotal,
             defaultValue = "0.00")
@@ -282,104 +291,121 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Column(name = "OFFER_ITEM_TARGET_RULE")
     @AdminPresentation(friendlyName = "OfferImpl_Item_Target_Rule",
-        group = GroupName.CombineStack,
-        tooltip = "OfferItemRestrictionRuleType_tooltip",
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferItemRestrictionRuleType",
-        defaultValue = "NONE",
-        visibility = VisibilityEnum.HIDDEN_ALL)
+            group = GroupName.CombineStack,
+            tooltip = "OfferItemRestrictionRuleType_tooltip",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferItemRestrictionRuleType",
+            defaultValue = "NONE",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected String offerItemTargetRuleType;
-    
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer", targetEntity = OfferQualifyingCriteriaXrefImpl.class, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer",
+            targetEntity = OfferQualifyingCriteriaXrefImpl.class, cascade = CascadeType.ALL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
     @AdminPresentation(friendlyName = "OfferImpl_Qualifying_Item_Rule",
-        tab = TabName.Qualifiers,
-        fieldType = SupportedFieldType.RULE_WITH_QUANTITY,
-        ruleIdentifier = RuleIdentifier.ORDERITEM,
-        validationConfigurations =
-            @ValidationConfiguration(validationImplementation = "blOfferQualifyingCriteriaValidator"))
-    protected Set<OfferQualifyingCriteriaXref> qualifyingItemCriteria = new HashSet<OfferQualifyingCriteriaXref>();
+            tab = TabName.Qualifiers,
+            fieldType = SupportedFieldType.RULE_WITH_QUANTITY,
+            ruleIdentifier = RuleIdentifier.ORDERITEM,
+            validationConfigurations =
+            @ValidationConfiguration(
+                    validationImplementation = "blOfferQualifyingCriteriaValidator"))
+    protected Set<OfferQualifyingCriteriaXref> qualifyingItemCriteria =
+            new HashSet<OfferQualifyingCriteriaXref>();
 
     @Transient
-    protected Set<OfferItemCriteria> legacyQualifyingItemCriteria = new HashSet<OfferItemCriteria>();
+    protected Set<OfferItemCriteria> legacyQualifyingItemCriteria =
+            new HashSet<OfferItemCriteria>();
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer", targetEntity = OfferTargetCriteriaXrefImpl.class, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer",
+            targetEntity = OfferTargetCriteriaXrefImpl.class, cascade = CascadeType.ALL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
     @AdminPresentation(friendlyName = "OfferImpl_Target_Item_Rule",
-        group = GroupName.RuleConfiguration,
-        fieldType = SupportedFieldType.RULE_WITH_QUANTITY, 
-        ruleIdentifier = RuleIdentifier.ORDERITEM,
-        validationConfigurations = @ValidationConfiguration(validationImplementation = "blOfferTargetCriteriaItemValidator"))
-    protected Set<OfferTargetCriteriaXref> targetItemCriteria = new HashSet<OfferTargetCriteriaXref>();
+            group = GroupName.RuleConfiguration,
+            fieldType = SupportedFieldType.RULE_WITH_QUANTITY,
+            ruleIdentifier = RuleIdentifier.ORDERITEM,
+            validationConfigurations = @ValidationConfiguration(
+                    validationImplementation = "blOfferTargetCriteriaItemValidator"))
+    protected Set<OfferTargetCriteriaXref> targetItemCriteria =
+            new HashSet<OfferTargetCriteriaXref>();
 
     @Transient
     protected Set<OfferItemCriteria> legacyTargetItemCriteria = new HashSet<OfferItemCriteria>();
-    
+
     @Column(name = "TOTALITARIAN_OFFER")
     @AdminPresentation(friendlyName = "OfferImpl_Totalitarian_Offer",
-        group = GroupName.Advanced,
-        visibility = VisibilityEnum.HIDDEN_ALL, defaultValue = "false")
+            group = GroupName.Advanced,
+            visibility = VisibilityEnum.HIDDEN_ALL, defaultValue = "false")
     protected Boolean totalitarianOffer = false;
 
     @Column(name = "REQUIRES_RELATED_TAR_QUAL")
     @AdminPresentation(friendlyName = "OfferImpl_Requires_Related_Target_And_Qualifiers",
-        group = GroupName.ShouldBeRelated,
-        tooltip = "OfferImplRelatedTargetQualifier_tooltip",
-        visibility = VisibilityEnum.HIDDEN_ALL, defaultValue = "false")
+            group = GroupName.ShouldBeRelated,
+            tooltip = "OfferImplRelatedTargetQualifier_tooltip",
+            visibility = VisibilityEnum.HIDDEN_ALL, defaultValue = "false")
     protected Boolean requiresRelatedTargetAndQualifiers = false;
 
-    @OneToMany(mappedBy = "offer", targetEntity = OfferOfferRuleXrefImpl.class, cascade = { CascadeType.ALL })
+    @OneToMany(mappedBy = "offer", targetEntity = OfferOfferRuleXrefImpl.class,
+            cascade = {CascadeType.ALL})
     @MapKey(name = "key")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
     @AdminPresentationMapFields(
-        toOneTargetProperty = "offerRule",
-        toOneParentProperty = "offer",
-        mapDisplayFields = {
-            @AdminPresentationMapField(
-                fieldName = RuleIdentifier.CUSTOMER_FIELD_KEY,
-                fieldPresentation = @AdminPresentation(fieldType = SupportedFieldType.RULE_SIMPLE,
-                    group = GroupName.Customer, order = FieldOrder.CustomerRule,
-                    ruleIdentifier = RuleIdentifier.CUSTOMER, friendlyName = "OfferImpl_Customer_Rule")
-            ),
-            @AdminPresentationMapField(
-            fieldName = RuleIdentifier.TIME_FIELD_KEY,
-                fieldPresentation = @AdminPresentation(fieldType = SupportedFieldType.RULE_SIMPLE_TIME,
-                    group = GroupName.ActivityRange, order = FieldOrder.TimeRule,
-                    ruleIdentifier = RuleIdentifier.TIME, friendlyName = "OfferImpl_Time_Rule")
-            ),
-            @AdminPresentationMapField(
-                fieldName = RuleIdentifier.ORDER_FIELD_KEY,
-                fieldPresentation = @AdminPresentation(fieldType = SupportedFieldType.RULE_SIMPLE, 
-                    group = GroupName.Restrictions,
-                    ruleIdentifier = RuleIdentifier.ORDER, friendlyName = "OfferImpl_Order_Rule")
-            ),
-            @AdminPresentationMapField(
-                fieldName = RuleIdentifier.FULFILLMENT_GROUP_FIELD_KEY,
-                fieldPresentation = @AdminPresentation(fieldType = SupportedFieldType.RULE_SIMPLE, 
-                    group = GroupName.RuleConfiguration,
-                    ruleIdentifier = RuleIdentifier.FULFILLMENTGROUP, friendlyName = "OfferImpl_FG_Rule")
-            )
-        }
+            toOneTargetProperty = "offerRule",
+            toOneParentProperty = "offer",
+            mapDisplayFields = {
+                    @AdminPresentationMapField(
+                            fieldName = RuleIdentifier.CUSTOMER_FIELD_KEY,
+                            fieldPresentation = @AdminPresentation(
+                                    fieldType = SupportedFieldType.RULE_SIMPLE,
+                                    group = GroupName.Customer, order = FieldOrder.CustomerRule,
+                                    ruleIdentifier = RuleIdentifier.CUSTOMER,
+                                    friendlyName = "OfferImpl_Customer_Rule")
+                    ),
+                    @AdminPresentationMapField(
+                            fieldName = RuleIdentifier.TIME_FIELD_KEY,
+                            fieldPresentation = @AdminPresentation(
+                                    fieldType = SupportedFieldType.RULE_SIMPLE_TIME,
+                                    group = GroupName.ActivityRange, order = FieldOrder.TimeRule,
+                                    ruleIdentifier = RuleIdentifier.TIME,
+                                    friendlyName = "OfferImpl_Time_Rule")
+                    ),
+                    @AdminPresentationMapField(
+                            fieldName = RuleIdentifier.ORDER_FIELD_KEY,
+                            fieldPresentation = @AdminPresentation(
+                                    fieldType = SupportedFieldType.RULE_SIMPLE,
+                                    group = GroupName.Restrictions,
+                                    ruleIdentifier = RuleIdentifier.ORDER,
+                                    friendlyName = "OfferImpl_Order_Rule")
+                    ),
+                    @AdminPresentationMapField(
+                            fieldName = RuleIdentifier.FULFILLMENT_GROUP_FIELD_KEY,
+                            fieldPresentation = @AdminPresentation(
+                                    fieldType = SupportedFieldType.RULE_SIMPLE,
+                                    group = GroupName.RuleConfiguration,
+                                    ruleIdentifier = RuleIdentifier.FULFILLMENTGROUP,
+                                    friendlyName = "OfferImpl_FG_Rule")
+                    )
+            }
     )
     Map<String, OfferOfferRuleXref> offerMatchRules = new HashMap<String, OfferOfferRuleXref>();
 
     @Column(name = "OFFER_ADJUSTMENT_TYPE")
     @AdminPresentation(friendlyName = "OfferImpl_Offer_Adjustment_Type",
             group = GroupName.Description, order = FieldOrder.DiscountType + 1,
-            fieldType=SupportedFieldType.BROADLEAF_ENUMERATION,
-            broadleafEnumeration="org.broadleafcommerce.core.offer.service.type.OfferAdjustmentType",
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.offer.service.type.OfferAdjustmentType",
             tooltip = "OfferImpl_Offer_Adjustment_Type_tooltip",
-            showIfProperty="admin.showIfProperty.offerAdjustmentType")
+            showIfProperty = "admin.showIfProperty.offerAdjustmentType")
     protected String adjustmentType;
-    
+
     @Column(name = "USE_LIST_FOR_DISCOUNTS")
     @AdminPresentation(friendlyName = "OfferImpl_Use_List_For_Discounts",
             group = GroupName.Description, fieldComponentRendererTemplate = "HIDDEN_BOOLEAN",
             defaultValue = "false")
     protected Boolean useListForDiscounts = false;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer", targetEntity = OfferPriceDataImpl.class, cascade = CascadeType.ALL)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "offer", targetEntity = OfferPriceDataImpl.class,
+            cascade = CascadeType.ALL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
     @AdminPresentationCollection(
             friendlyName = "OfferImpl_Offer_Price_Data",
             group = GroupName.Description, order = FieldOrder.OfferType + 10)
@@ -437,10 +463,11 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public void setDiscountType(OfferDiscountType discountType) {
         this.discountType = discountType.getType();
     }
-    
+
     @Override
     public OfferItemRestrictionRuleType getOfferItemQualifierRuleType() {
-        OfferItemRestrictionRuleType returnType = OfferItemRestrictionRuleType.getInstance(offerItemQualifierRuleType);
+        OfferItemRestrictionRuleType returnType =
+                OfferItemRestrictionRuleType.getInstance(offerItemQualifierRuleType);
         if (returnType == null) {
             return OfferItemRestrictionRuleType.NONE;
         } else {
@@ -452,10 +479,11 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public void setOfferItemQualifierRuleType(OfferItemRestrictionRuleType restrictionRuleType) {
         this.offerItemQualifierRuleType = restrictionRuleType.getType();
     }
-    
+
     @Override
     public OfferItemRestrictionRuleType getOfferItemTargetRuleType() {
-        OfferItemRestrictionRuleType returnType = OfferItemRestrictionRuleType.getInstance(offerItemTargetRuleType);
+        OfferItemRestrictionRuleType returnType =
+                OfferItemRestrictionRuleType.getInstance(offerItemTargetRuleType);
         if (returnType == null) {
             return OfferItemRestrictionRuleType.NONE;
         } else {
@@ -492,7 +520,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Date getStartDate() {
-        if ('Y'==getArchived()) {
+        if ('Y' == getArchived()) {
             return null;
         }
         return startDate;
@@ -512,7 +540,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
     }
-    
+
     @Override
     public String getTargetSystem() {
         return targetSystem;
@@ -576,7 +604,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
         return automaticallyAdded;
     }
 
-    
+
     @Override
     public void setAutomaticallyAdded(boolean automaticallyAdded) {
         this.automaticallyAdded = automaticallyAdded;
@@ -616,7 +644,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public boolean isUnlimitedUsePerCustomer() {
         return getMaxUsesPerCustomer() == 0;
     }
-    
+
     @Override
     public boolean isLimitedUsePerCustomer() {
         return getMaxUsesPerCustomer() > 0;
@@ -636,7 +664,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     public boolean isUnlimitedUsePerOrder() {
         return getMaxUsesPerOrder() == 0;
     }
-    
+
     @Override
     public boolean isLimitedUsePerOrder() {
         return getMaxUsesPerOrder() > 0;
@@ -698,12 +726,12 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Map<String, OfferOfferRuleXref> getOfferMatchRulesXref() {
-       return offerMatchRules;
+        return offerMatchRules;
     }
 
     @Override
     public void setOfferMatchRulesXref(Map<String, OfferOfferRuleXref> offerMatchRulesXref) {
-       this.offerMatchRules = offerMatchRulesXref;
+        this.offerMatchRules = offerMatchRulesXref;
     }
 
     @Override
@@ -731,13 +759,13 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -750,12 +778,14 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public boolean isActive() {
-        return DateUtil.isActive(startDate, endDate, true) && 'Y'!=getArchived();
+        return DateUtil.isActive(startDate, endDate, true) && 'Y' != getArchived();
     }
-    
+
     @Override
     public Money getQualifyingItemSubTotal() {
-        return qualifyingItemSubTotal == null ? null : BroadleafCurrencyUtils.getMoney(qualifyingItemSubTotal, null);
+        return qualifyingItemSubTotal == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(qualifyingItemSubTotal, null);
     }
 
     @Override
@@ -765,7 +795,9 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Money getOrderMinSubTotal() {
-        return orderMinSubTotal == null ? null : BroadleafCurrencyUtils.getMoney(orderMinSubTotal, null);
+        return orderMinSubTotal == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(orderMinSubTotal, null);
     }
 
     @Override
@@ -775,7 +807,9 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Money getTargetMinSubTotal() {
-        return targetMinSubTotal == null ? null : BroadleafCurrencyUtils.getMoney(targetMinSubTotal, null);
+        return targetMinSubTotal == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(targetMinSubTotal, null);
     }
 
     @Override
@@ -795,9 +829,11 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
 
     @Override
     public Boolean getRequiresRelatedTargetAndQualifiers() {
-        return requiresRelatedTargetAndQualifiers == null ? false : requiresRelatedTargetAndQualifiers;
+        return requiresRelatedTargetAndQualifiers == null
+                ? false
+                : requiresRelatedTargetAndQualifiers;
     }
-    
+
     @Override
     public void setRequiresRelatedTargetAndQualifiers(Boolean requiresRelatedTargetAndQualifiers) {
         this.requiresRelatedTargetAndQualifiers = requiresRelatedTargetAndQualifiers;
@@ -826,37 +862,39 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
         if (adjustmentType == null) {
             return false;
         }
-        return OfferAdjustmentType.FUTURE_CREDIT.equals(OfferAdjustmentType.getInstance(adjustmentType));
+        return OfferAdjustmentType.FUTURE_CREDIT.equals(
+                OfferAdjustmentType.getInstance(adjustmentType));
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(name)
-            .append(startDate)
-            .append(type)
-            .append(value)
-            .build();
+                .append(name)
+                .append(startDate)
+                .append(type)
+                .append(value)
+                .build();
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (o != null && getClass().isAssignableFrom(o.getClass())) {
             OfferImpl that = (OfferImpl) o;
             return new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.name, that.name)
-                .append(this.startDate, that.startDate)
-                .append(this.type, that.type)
-                .append(this.value, that.value)
-                .build();
+                    .append(this.id, that.id)
+                    .append(this.name, that.name)
+                    .append(this.startDate, that.startDate)
+                    .append(this.type, that.type)
+                    .append(this.value, that.value)
+                    .build();
         }
-        
+
         return false;
     }
 
     @Override
-    public <G extends Offer> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Offer> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -892,27 +930,31 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
                 cloned.getOfferCodes().add(clonedEntry);
             }
         }
-        for(OfferQualifyingCriteriaXref entry : qualifyingItemCriteria){
-            OfferQualifyingCriteriaXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+        for (OfferQualifyingCriteriaXref entry : qualifyingItemCriteria) {
+            OfferQualifyingCriteriaXref clonedEntry =
+                    entry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getQualifyingItemCriteriaXref().add(clonedEntry);
         }
         Set<OfferTargetCriteriaXref> offerTargetCriteriaXrefs = new HashSet<>();
-        for(OfferTargetCriteriaXref entry : targetItemCriteria){
-            OfferTargetCriteriaXref clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
+        for (OfferTargetCriteriaXref entry : targetItemCriteria) {
+            OfferTargetCriteriaXref clonedEntry =
+                    entry.createOrRetrieveCopyInstance(context).getClone();
             offerTargetCriteriaXrefs.add(clonedEntry);
         }
         cloned.setTargetItemCriteriaXref(offerTargetCriteriaXrefs);
-        for(Map.Entry<String, OfferOfferRuleXref> entry : offerMatchRules.entrySet()){
-            OfferOfferRuleXref clonedEntry = entry.getValue().createOrRetrieveCopyInstance(context).getClone();
-            cloned.getOfferMatchRulesXref().put(entry.getKey(),clonedEntry);
+        for (Map.Entry<String, OfferOfferRuleXref> entry : offerMatchRules.entrySet()) {
+            OfferOfferRuleXref clonedEntry =
+                    entry.getValue().createOrRetrieveCopyInstance(context).getClone();
+            cloned.getOfferMatchRulesXref().put(entry.getKey(), clonedEntry);
         }
 
         for (OfferPriceData offerPriceDataEntry : offerPriceData) {
-            OfferPriceData clonedEntry = offerPriceDataEntry.createOrRetrieveCopyInstance(context).getClone();
+            OfferPriceData clonedEntry =
+                    offerPriceDataEntry.createOrRetrieveCopyInstance(context).getClone();
             cloned.getOfferPriceData().add(clonedEntry);
         }
 
-        return  createResponse;
+        return createResponse;
     }
 
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -17,6 +17,21 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -31,6 +46,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationMapField;
@@ -55,8 +71,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,21 +80,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 @Entity
 @Table(name = "BLC_OFFER", indexes = {
@@ -107,7 +106,7 @@ public class OfferImpl implements Offer, AdminMainEntity, OfferAdminPresentation
     @GeneratedValue(generator= "OfferId")
     @GenericGenerator(
         name="OfferId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferInfoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferInfoImpl.java
@@ -10,12 +10,22 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
+
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -28,15 +38,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -46,22 +47,24 @@ public class OfferInfoImpl implements OfferInfo {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OfferInfoId")
+    @GeneratedValue(generator = "OfferInfoId")
     @GenericGenerator(
-        name="OfferInfoId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferInfoImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferInfoImpl")
-        }
+            name = "OfferInfoId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferInfoImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferInfoImpl")
+            }
     )
     @Column(name = "OFFER_INFO_ID")
     protected Long id;
 
     @ElementCollection
-    @MapKeyColumn(name="FIELD_NAME")
-    @Column(name="FIELD_VALUE")
-    @CollectionTable(name="BLC_OFFER_INFO_FIELDS", joinColumns=@JoinColumn(name="OFFER_INFO_FIELDS_ID"))
+    @MapKeyColumn(name = "FIELD_NAME")
+    @Column(name = "FIELD_VALUE")
+    @CollectionTable(name = "BLC_OFFER_INFO_FIELDS",
+            joinColumns = @JoinColumn(name = "OFFER_INFO_FIELDS_ID"))
     @BatchSize(size = 50)
     protected Map<String, String> fieldValues = new HashMap<String, String>();
 
@@ -116,16 +119,16 @@ public class OfferInfoImpl implements OfferInfo {
     }
 
     @Override
-    public <G extends OfferInfo> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferInfo> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
         OfferInfo cloned = createResponse.getClone();
-        for(Map.Entry<String,String> entry : fieldValues.entrySet())
-        {
-            cloned.getFieldValues().put(entry.getKey(),entry.getValue());
+        for (Map.Entry<String, String> entry : fieldValues.entrySet()) {
+            cloned.getFieldValues().put(entry.getKey(), entry.getValue());
         }
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferInfoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferInfoImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -37,6 +28,15 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -49,7 +49,7 @@ public class OfferInfoImpl implements OfferInfo {
     @GeneratedValue(generator= "OfferInfoId")
     @GenericGenerator(
         name="OfferInfoId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferInfoImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferInfoImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferItemCriteriaImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferItemCriteriaImpl.java
@@ -17,22 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.Length;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,6 +25,22 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.Length;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -64,7 +64,7 @@ public class OfferItemCriteriaImpl implements OfferItemCriteria {
     @GeneratedValue(generator= "OfferItemCriteriaId")
     @GenericGenerator(
         name="OfferItemCriteriaId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferItemCriteriaImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferItemCriteriaImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferItemCriteriaImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferItemCriteriaImpl.java
@@ -10,21 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -42,45 +34,57 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Table(name = "BLC_OFFER_ITEM_CRITERIA")
-@Inheritance(strategy=InheritanceType.JOINED)
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+@Inheritance(strategy = InheritanceType.JOINED)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
 @AdminPresentationClass(friendlyName = "OfferItemCriteriaImpl_baseOfferItemCriteria")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferItemCriteriaImpl implements OfferItemCriteria {
-    
+
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OfferItemCriteriaId")
+    @GeneratedValue(generator = "OfferItemCriteriaId")
     @GenericGenerator(
-        name="OfferItemCriteriaId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferItemCriteriaImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferItemCriteriaImpl")
-        }
+            name = "OfferItemCriteriaId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferItemCriteriaImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferItemCriteriaImpl")
+            }
     )
     @Column(name = "OFFER_ITEM_CRITERIA_ID")
-    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Item_Criteria_Id", group = "OfferItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Item_Criteria_Id",
+            group = "OfferItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
-    @Column(name = "QUANTITY", nullable=false)
-    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Quantity", group = "OfferItemCriteriaImpl_Description", visibility =VisibilityEnum.HIDDEN_ALL)
+
+    @Column(name = "QUANTITY", nullable = false)
+    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Quantity",
+            group = "OfferItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Integer quantity;
-    
+
     @Lob
     @Column(name = "ORDER_ITEM_MATCH_RULE", length = Length.LONG32 - 1)
-    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Order_Item_Match_Rule", group = "OfferItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "OfferItemCriteriaImpl_Order_Item_Match_Rule",
+            group = "OfferItemCriteriaImpl_Description", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String orderItemMatchRule;
 
     @Override
@@ -116,10 +120,10 @@ public class OfferItemCriteriaImpl implements OfferItemCriteria {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(id)
-            .append(orderItemMatchRule)
-            .append(quantity)
-            .build();
+                .append(id)
+                .append(orderItemMatchRule)
+                .append(quantity)
+                .build();
     }
 
     @Override
@@ -127,17 +131,18 @@ public class OfferItemCriteriaImpl implements OfferItemCriteria {
         if (o != null && getClass().isAssignableFrom(o.getClass())) {
             OfferItemCriteriaImpl that = (OfferItemCriteriaImpl) o;
             return new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.orderItemMatchRule, that.orderItemMatchRule)
-                .append(this.quantity, that.quantity)
-                .build();
+                    .append(this.id, that.id)
+                    .append(this.orderItemMatchRule, that.orderItemMatchRule)
+                    .append(this.quantity, that.quantity)
+                    .build();
         }
 
         return false;
     }
 
     @Override
-    public <G extends OfferItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferItemCriteria> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -145,6 +150,6 @@ public class OfferItemCriteriaImpl implements OfferItemCriteria {
         OfferItemCriteria cloned = createResponse.getClone();
         cloned.setQuantity(quantity);
         cloned.setMatchRule(orderItemMatchRule);
-       return createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferOfferRuleXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferOfferRuleXrefImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.annotation.Nonnull;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
@@ -45,13 +34,27 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_OFFER_RULE_MAP")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
-@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
+@AdminPresentationClass(excludeFromPolymorphism = false,
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
@@ -70,20 +73,21 @@ public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
     }
 
     @Id
-    @GeneratedValue(generator= "OfferOfferRuleId")
+    @GeneratedValue(generator = "OfferOfferRuleId")
     @GenericGenerator(
-        name="OfferOfferRuleId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferOfferRuleXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferOfferRuleXrefImpl")
-        }
+            name = "OfferOfferRuleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferOfferRuleXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferOfferRuleXrefImpl")
+            }
     )
     @Column(name = "OFFER_OFFER_RULE_ID")
     protected Long id;
 
     //for the collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "BLC_OFFER_OFFER_ID")
     @AdminPresentation(excluded = true)
     protected Offer offer;
@@ -94,7 +98,7 @@ public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
     @ClonePolicy
     protected OfferRule offerRule;
 
-    @Column(name = "MAP_KEY", nullable=false)
+    @Column(name = "MAP_KEY", nullable = false)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String key;
 
@@ -157,7 +161,8 @@ public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
     }
 
     @Override
-    public <G extends OfferOfferRuleXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferOfferRuleXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -170,6 +175,6 @@ public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
         if (offerRule != null) {
             cloned.setOfferRule(offerRule.createOrRetrieveCopyInstance(context).getClone());
         }
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferOfferRuleXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferOfferRuleXrefImpl.java
@@ -17,22 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.rule.SimpleRule;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.annotation.Nonnull;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -44,6 +28,22 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.rule.SimpleRule;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -73,7 +73,7 @@ public class OfferOfferRuleXrefImpl implements OfferOfferRuleXref, SimpleRule {
     @GeneratedValue(generator= "OfferOfferRuleId")
     @GenericGenerator(
         name="OfferOfferRuleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferOfferRuleXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferOfferRuleXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferPriceDataImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferPriceDataImpl.java
@@ -10,25 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -57,14 +45,30 @@ import org.hibernate.annotations.SQLDelete;
 import java.math.BigDecimal;
 import java.util.Date;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
-@Table(name = "BLC_OFFER_PRICE_DATA", indexes = {@Index(name = "OFFER_PRICE_DATA_OFFER_INDEX", columnList = "OFFER_ID")})
+@Table(name = "BLC_OFFER_PRICE_DATA",
+        indexes = {@Index(name = "OFFER_PRICE_DATA_OFFER_INDEX", columnList = "OFFER_ID")})
 @Inheritance(strategy = InheritanceType.JOINED)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blOrderElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE, friendlyName = "OfferPriceDataImpl_baseOfferPriceData")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.FALSE,
+        friendlyName = "OfferPriceDataImpl_baseOfferPriceData")
 @SQLDelete(sql = "UPDATE BLC_OFFER_PRICE_DATA SET ARCHIVED = 'Y' WHERE OFFER_PRICE_DATA_ID = ?")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferPriceDataImpl implements OfferPriceData {
@@ -72,20 +76,22 @@ public class OfferPriceDataImpl implements OfferPriceData {
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OfferPriceDataId")
+    @GeneratedValue(generator = "OfferPriceDataId")
     @GenericGenerator(
-        name="OfferPriceDataId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferPriceDataImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferPriceDataImpl")
-        }
+            name = "OfferPriceDataId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferPriceDataImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferPriceDataImpl")
+            }
     )
     @Column(name = "OFFER_PRICE_DATA_ID")
-    @AdminPresentation(friendlyName = "OfferPriceDataImpl_Offer_Price_Data_Id", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "OfferPriceDataImpl_Offer_Price_Data_Id",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "OFFER_ID")
     @AdminPresentation(friendlyName = "OfferPriceDataImpl_Offer", order = 1000)
     @AdminPresentationToOneLookup()
@@ -104,7 +110,8 @@ public class OfferPriceDataImpl implements OfferPriceData {
                     @ValidationConfiguration(
                             validationImplementation = "blAfterStartDateValidator",
                             configurationItems = {
-                                    @ConfigurationItem(itemName = "otherField", itemValue = "activeStartDate")
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "activeStartDate")
                             })
             })
     protected Date activeEndDate;
@@ -137,7 +144,7 @@ public class OfferPriceDataImpl implements OfferPriceData {
             prominent = true, gridOrder = 3000)
     protected String discountType;
 
-    @Column(name = "AMOUNT", nullable=false, precision=19, scale=5)
+    @Column(name = "AMOUNT", nullable = false, precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "OfferPriceDataImpl_Amount",
             requiredOverride = RequiredOverride.REQUIRED,
             order = 7000,
@@ -145,7 +152,7 @@ public class OfferPriceDataImpl implements OfferPriceData {
             prominent = true, gridOrder = 4000)
     protected BigDecimal amount;
 
-    @Column(name = "QUANTITY", nullable=false)
+    @Column(name = "QUANTITY", nullable = false)
     @AdminPresentation(friendlyName = "OfferPriceDataImpl_Quantity",
             requiredOverride = RequiredOverride.REQUIRED,
             order = 8000,
@@ -277,7 +284,8 @@ public class OfferPriceDataImpl implements OfferPriceData {
         // If the start date for this offer code has not been set, just delegate to the offer to determine if the code is
         // active rather than requiring the user to set offer code dates as well
         if (activeStartDate == null) {
-            datesActive = DateUtil.isActive(getOffer().getStartDate(), getOffer().getEndDate(), true);
+            datesActive =
+                    DateUtil.isActive(getOffer().getStartDate(), getOffer().getEndDate(), true);
         } else {
             datesActive = DateUtil.isActive(activeStartDate, activeEndDate, true);
         }
@@ -286,22 +294,36 @@ public class OfferPriceDataImpl implements OfferPriceData {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof OfferPriceDataImpl)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof OfferPriceDataImpl))
+            return false;
 
         OfferPriceDataImpl that = (OfferPriceDataImpl) o;
 
-        if (!getId().equals(that.getId())) return false;
-        if (!getOffer().equals(that.getOffer())) return false;
-        if (!getActiveStartDate().equals(that.getActiveStartDate())) return false;
-        if (getActiveEndDate() != null ? !getActiveEndDate().equals(that.getActiveEndDate()) : that.getActiveEndDate() != null)
+        if (!getId().equals(that.getId()))
             return false;
-        if (!getIdentifierType().equals(that.getIdentifierType())) return false;
-        if (!getIdentifierValue().equals(that.getIdentifierValue())) return false;
-        if (!getDiscountType().equals(that.getDiscountType())) return false;
-        if (!getAmount().equals(that.getAmount())) return false;
-        if (!getQuantity().equals(that.getQuantity())) return false;
-        return archiveStatus != null ? archiveStatus.equals(that.archiveStatus) : that.archiveStatus == null;
+        if (!getOffer().equals(that.getOffer()))
+            return false;
+        if (!getActiveStartDate().equals(that.getActiveStartDate()))
+            return false;
+        if (getActiveEndDate() != null
+                ? !getActiveEndDate().equals(that.getActiveEndDate())
+                : that.getActiveEndDate() != null)
+            return false;
+        if (!getIdentifierType().equals(that.getIdentifierType()))
+            return false;
+        if (!getIdentifierValue().equals(that.getIdentifierValue()))
+            return false;
+        if (!getDiscountType().equals(that.getDiscountType()))
+            return false;
+        if (!getAmount().equals(that.getAmount()))
+            return false;
+        if (!getQuantity().equals(that.getQuantity()))
+            return false;
+        return archiveStatus != null
+                ? archiveStatus.equals(that.archiveStatus)
+                : that.archiveStatus == null;
     }
 
     @Override
@@ -320,7 +342,8 @@ public class OfferPriceDataImpl implements OfferPriceData {
     }
 
     @Override
-    public <G extends OfferPriceData> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferPriceData> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferPriceDataImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferPriceDataImpl.java
@@ -17,12 +17,25 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -44,19 +57,6 @@ import org.hibernate.annotations.SQLDelete;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-
 @Entity
 @Table(name = "BLC_OFFER_PRICE_DATA", indexes = {@Index(name = "OFFER_PRICE_DATA_OFFER_INDEX", columnList = "OFFER_ID")})
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -75,7 +75,7 @@ public class OfferPriceDataImpl implements OfferPriceData {
     @GeneratedValue(generator= "OfferPriceDataId")
     @GenericGenerator(
         name="OfferPriceDataId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferPriceDataImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferPriceDataImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferQualifyingCriteriaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferQualifyingCriteriaXrefImpl.java
@@ -17,23 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.rule.QuantityBasedRule;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +27,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.rule.QuantityBasedRule;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -72,7 +72,7 @@ public class OfferQualifyingCriteriaXrefImpl implements OfferQualifyingCriteriaX
     @GeneratedValue(generator= "OfferQualCritId")
     @GenericGenerator(
             name="OfferQualCritId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="OfferQualifyingCriteriaXrefImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferQualifyingCriteriaXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferQualifyingCriteriaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferQualifyingCriteriaXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -45,16 +35,30 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_QUAL_CRIT_OFFER_XREF")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
-@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
+@AdminPresentationClass(excludeFromPolymorphism = false,
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
-public class OfferQualifyingCriteriaXrefImpl implements OfferQualifyingCriteriaXref, QuantityBasedRule {
+public class OfferQualifyingCriteriaXrefImpl
+        implements OfferQualifyingCriteriaXref, QuantityBasedRule {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
@@ -69,20 +73,21 @@ public class OfferQualifyingCriteriaXrefImpl implements OfferQualifyingCriteriaX
     }
 
     @Id
-    @GeneratedValue(generator= "OfferQualCritId")
+    @GeneratedValue(generator = "OfferQualCritId")
     @GenericGenerator(
-            name="OfferQualCritId",
-            type= IdOverrideTableGenerator.class,
+            name = "OfferQualCritId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="OfferQualifyingCriteriaXrefImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferQualifyingCriteriaXrefImpl")
+                    @Parameter(name = "segment_value", value = "OfferQualifyingCriteriaXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferQualifyingCriteriaXrefImpl")
             }
     )
     @Column(name = "OFFER_QUAL_CRIT_ID")
     protected Long id;
 
     //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "OFFER_ID")
     @AdminPresentation(excluded = true)
     protected Offer offer;
@@ -177,7 +182,8 @@ public class OfferQualifyingCriteriaXrefImpl implements OfferQualifyingCriteriaX
     }
 
     @Override
-    public <G extends OfferQualifyingCriteriaXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferQualifyingCriteriaXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -187,8 +193,9 @@ public class OfferQualifyingCriteriaXrefImpl implements OfferQualifyingCriteriaX
             cloned.setOffer(offer.createOrRetrieveCopyInstance(context).getClone());
         }
         if (offerItemCriteria != null) {
-            cloned.setOfferItemCriteria(offerItemCriteria.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setOfferItemCriteria(
+                    offerItemCriteria.createOrRetrieveCopyInstance(context).getClone());
         }
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferRuleImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferRuleImpl.java
@@ -10,21 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -37,17 +29,25 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_OFFER_RULE")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferRuleImpl implements OfferRule {
@@ -55,18 +55,19 @@ public class OfferRuleImpl implements OfferRule {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OfferRuleId")
+    @GeneratedValue(generator = "OfferRuleId")
     @GenericGenerator(
-        name="OfferRuleId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferRuleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferRuleImpl")
-        }
+            name = "OfferRuleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferRuleImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferRuleImpl")
+            }
     )
     @Column(name = "OFFER_RULE_ID")
     protected Long id;
-    
+
     @Lob
     @Column(name = "MATCH_RULE", length = Length.LONG32 - 1)
     protected String matchRule;
@@ -121,11 +122,11 @@ public class OfferRuleImpl implements OfferRule {
         if (!getClass().isAssignableFrom(obj.getClass()))
             return false;
         OfferRuleImpl other = (OfferRuleImpl) obj;
-        
+
         if (id != null && other.id != null) {
             return id.equals(other.id);
         }
-        
+
         if (matchRule == null) {
             if (other.matchRule != null)
                 return false;
@@ -135,7 +136,8 @@ public class OfferRuleImpl implements OfferRule {
     }
 
     @Override
-    public <G extends OfferRule> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OfferRule> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferRuleImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferRuleImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.hibernate.Length;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +25,17 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.Length;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -58,7 +58,7 @@ public class OfferRuleImpl implements OfferRule {
     @GeneratedValue(generator= "OfferRuleId")
     @GenericGenerator(
         name="OfferRuleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferRuleImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferRuleImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferTargetCriteriaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferTargetCriteriaXrefImpl.java
@@ -17,23 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.rule.QuantityBasedRule;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,6 +27,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.rule.QuantityBasedRule;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -72,7 +72,7 @@ public class OfferTargetCriteriaXrefImpl implements OfferTargetCriteriaXref, Qua
     @GeneratedValue(generator= "OfferTarCritId")
     @GenericGenerator(
         name="OfferTarCritId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OfferTargetCriteriaXrefImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferTargetCriteriaXrefImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferTargetCriteriaXrefImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferTargetCriteriaXrefImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -45,13 +35,26 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_TAR_CRIT_OFFER_XREF")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blOffers")
-@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOffers")
+@AdminPresentationClass(excludeFromPolymorphism = false,
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class OfferTargetCriteriaXrefImpl implements OfferTargetCriteriaXref, QuantityBasedRule {
@@ -69,20 +72,21 @@ public class OfferTargetCriteriaXrefImpl implements OfferTargetCriteriaXref, Qua
     }
 
     @Id
-    @GeneratedValue(generator= "OfferTarCritId")
+    @GeneratedValue(generator = "OfferTarCritId")
     @GenericGenerator(
-        name="OfferTarCritId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OfferTargetCriteriaXrefImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OfferTargetCriteriaXrefImpl")
-        }
+            name = "OfferTarCritId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OfferTargetCriteriaXrefImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OfferTargetCriteriaXrefImpl")
+            }
     )
     @Column(name = "OFFER_TAR_CRIT_ID")
     protected Long id;
 
     //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "OFFER_ID")
     @AdminPresentation(excluded = true)
     protected Offer offer;
@@ -177,7 +181,8 @@ public class OfferTargetCriteriaXrefImpl implements OfferTargetCriteriaXref, Qua
     }
 
     @Override
-    public <G extends OfferTargetCriteriaXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+    public <G extends OfferTargetCriteriaXref> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context)
             throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -188,7 +193,8 @@ public class OfferTargetCriteriaXrefImpl implements OfferTargetCriteriaXref, Qua
             cloned.setOffer(offer.createOrRetrieveCopyInstance(context).getClone());
         }
         if (offerItemCriteria != null) {
-            cloned.setOfferItemCriteria(offerItemCriteria.createOrRetrieveCopyInstance(context).getClone());
+            cloned.setOfferItemCriteria(
+                    offerItemCriteria.createOrRetrieveCopyInstance(context).getClone());
         }
         return createResponse;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderAdjustmentImpl.java
@@ -17,17 +17,6 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
@@ -55,6 +44,18 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Table(name = "BLC_ORDER_ADJUSTMENT", indexes = {
         @Index(name = "ORDERADJUST_ORDER_INDEX", columnList = "ORDER_ID"),
@@ -66,7 +67,8 @@ import java.math.BigDecimal;
         @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
                 booleanOverrideValue = true))
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "OrderAdjustmentImpl_baseOrderAdjustment")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "OrderAdjustmentImpl_baseOrderAdjustment")
 public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentifiable {
 
     public static final long serialVersionUID = 1L;
@@ -79,7 +81,8 @@ public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentif
             ,
             parameters = {
                     @Parameter(name = "segment_value", value = "OrderAdjustmentImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.OrderAdjustmentImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OrderAdjustmentImpl")
             }
     )
     @Column(name = "ORDER_ADJUSTMENT_ID")
@@ -121,7 +124,8 @@ public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentif
         this.offer = offer;
         this.reason = reason;
         if (offer != null) {
-            this.isFutureCredit = OfferAdjustmentType.FUTURE_CREDIT.equals(offer.getAdjustmentType());
+            this.isFutureCredit =
+                    OfferAdjustmentType.FUTURE_CREDIT.equals(offer.getAdjustmentType());
         }
     }
 
@@ -180,7 +184,9 @@ public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentif
 
     @Override
     public Money getValue() {
-        return value == null ? null : BroadleafCurrencyUtils.getMoney(value, getOrder().getCurrency());
+        return value == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(value, getOrder().getCurrency());
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderAdjustmentImpl.java
@@ -10,17 +10,29 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -43,18 +55,6 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Table(name = "BLC_ORDER_ADJUSTMENT", indexes = {
         @Index(name = "ORDERADJUST_ORDER_INDEX", columnList = "ORDER_ID"),
@@ -72,14 +72,15 @@ public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentif
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OrderAdjustmentId")
+    @GeneratedValue(generator = "OrderAdjustmentId")
     @GenericGenerator(
-        name="OrderAdjustmentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="OrderAdjustmentImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OrderAdjustmentImpl")
-        }
+            name = "OrderAdjustmentId",
+            type = IdOverrideTableGenerator.class
+            ,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OrderAdjustmentImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.OrderAdjustmentImpl")
+            }
     )
     @Column(name = "ORDER_ADJUSTMENT_ID")
     protected Long id;
@@ -89,33 +90,33 @@ public class OrderAdjustmentImpl implements OrderAdjustment, CurrencyCodeIdentif
     @AdminPresentation(excluded = true)
     protected Order order;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
-    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Offer", order=1000,
+    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Offer", order = 1000,
             prominent = true, gridOrder = 1000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
 
-    @Column(name = "ADJUSTMENT_REASON", nullable=false)
-    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Order_Adjustment_Reason", order=2000)
+    @Column(name = "ADJUSTMENT_REASON", nullable = false)
+    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Order_Adjustment_Reason", order = 2000)
     protected String reason;
 
-    @Column(name = "ADJUSTMENT_VALUE", nullable=false, precision=19, scale=5)
-    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Order_Adjustment_Value", order=3000,
+    @Column(name = "ADJUSTMENT_VALUE", nullable = false, precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OrderAdjustmentImpl_Order_Adjustment_Value", order = 3000,
             fieldType = SupportedFieldType.MONEY, prominent = true,
             gridOrder = 2000)
     protected BigDecimal value = Money.ZERO.getAmount();
 
     @Column(name = "IS_FUTURE_CREDIT")
     @AdminPresentation(friendlyName = "OrderAdjustmentImpl_isFutureCredit", order = 4000,
-            showIfProperty="admin.showIfProperty.offerAdjustmentType")
+            showIfProperty = "admin.showIfProperty.offerAdjustmentType")
     protected Boolean isFutureCredit = false;
 
     @Transient
     protected Offer deproxiedOffer;
 
     @Override
-    public void init(Order order, Offer offer, String reason){
+    public void init(Order order, Offer offer, String reason) {
         this.order = order;
         this.offer = offer;
         this.reason = reason;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemAdjustmentImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
@@ -54,29 +43,44 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_ORDER_ITEM_ADJUSTMENT", indexes = {@Index(name = "OIADJUST_ITEM_INDEX", columnList = "ORDER_ITEM_ID")})
+@Table(name = "BLC_ORDER_ITEM_ADJUSTMENT",
+        indexes = {@Index(name = "OIADJUST_ITEM_INDEX", columnList = "ORDER_ITEM_ID")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "", mergeEntries =
         @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
                 booleanOverrideValue = true))
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "OrderItemAdjustmentImpl_baseOrderItemAdjustment")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "OrderItemAdjustmentImpl_baseOrderItemAdjustment")
 public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCodeIdentifiable {
 
     public static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "OrderItemAdjustmentId")
+    @GeneratedValue(generator = "OrderItemAdjustmentId")
     @GenericGenerator(
-        name="OrderItemAdjustmentId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OrderItemAdjustmentImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OrderItemAdjustmentImpl")
-        }
+            name = "OrderItemAdjustmentId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OrderItemAdjustmentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OrderItemAdjustmentImpl")
+            }
     )
     @Column(name = "ORDER_ITEM_ADJUSTMENT_ID")
     protected Long id;
@@ -86,27 +90,28 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
     @AdminPresentation(excluded = true)
     protected OrderItem orderItem;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Offer", order=1000,
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Offer", order = 1000,
             group = "OrderItemAdjustmentImpl_Description", prominent = true, gridOrder = 1000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
 
-    @Column(name = "ADJUSTMENT_REASON", nullable=false)
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Reason", order=2000)
+    @Column(name = "ADJUSTMENT_REASON", nullable = false)
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Reason",
+            order = 2000)
     protected String reason;
 
-    @Column(name = "ADJUSTMENT_VALUE", nullable=false, precision=19, scale=5)
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Value", order=3000,
+    @Column(name = "ADJUSTMENT_VALUE", nullable = false, precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Value", order = 3000,
             fieldType = SupportedFieldType.MONEY, prominent = true,
             gridOrder = 2000)
     protected BigDecimal value = Money.ZERO.getAmount();
 
     @Column(name = "APPLIED_TO_SALE_PRICE")
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Apply_To_Sale_Price", order=4000)
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Apply_To_Sale_Price", order = 4000)
     protected boolean appliedToSalePrice;
-    
+
     @Transient
     protected Money retailValue;
 
@@ -117,7 +122,7 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
     protected Offer deproxiedOffer;
 
     @Override
-    public void init(OrderItem orderItem, Offer offer, String reason){
+    public void init(OrderItem orderItem, Offer offer, String reason) {
         setOrderItem(orderItem);
         setOffer(offer);
         setReason(reason);
@@ -178,9 +183,11 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
 
     @Override
     public Money getValue() {
-        return value == null ? null : BroadleafCurrencyUtils.getMoney(value, getOrderItem().getOrder().getCurrency());
+        return value == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(value, getOrderItem().getOrder().getCurrency());
     }
-    
+
     @Override
     public void setValue(Money value) {
         this.value = value.getAmount();
@@ -199,7 +206,8 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
     @Override
     public Money getRetailPriceValue() {
         if (retailValue == null) {
-            return BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrderItem().getOrder().getCurrency());
+            return BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO,
+                    getOrderItem().getOrder().getCurrency());
         }
         return this.retailValue;
     }
@@ -212,7 +220,8 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
     @Override
     public Money getSalesPriceValue() {
         if (salesValue == null) {
-            return BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrderItem().getOrder().getCurrency());
+            return BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO,
+                    getOrderItem().getOrder().getCurrency());
         }
         return salesValue;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemAdjustmentImpl.java
@@ -17,10 +17,22 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -42,18 +54,6 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ORDER_ITEM_ADJUSTMENT", indexes = {@Index(name = "OIADJUST_ITEM_INDEX", columnList = "ORDER_ITEM_ID")})
@@ -72,7 +72,7 @@ public class OrderItemAdjustmentImpl implements OrderItemAdjustment, CurrencyCod
     @GeneratedValue(generator= "OrderItemAdjustmentId")
     @GenericGenerator(
         name="OrderItemAdjustmentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderItemAdjustmentImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.offer.domain.OrderItemAdjustmentImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
@@ -17,6 +17,16 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -25,6 +35,7 @@ import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -45,17 +56,6 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ORDER_ITEM_DTL_ADJ")
@@ -75,7 +75,7 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
     @GeneratedValue(generator = "OrderItemPriceDetailAdjustmentId")
     @GenericGenerator(
         name = "OrderItemPriceDetailAdjustmentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name = "segment_value", value = "OrderItemPriceDetailAdjustmentImpl"),
             @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustmentImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OrderItemPriceDetailAdjustmentImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
@@ -56,30 +46,44 @@ import org.hibernate.proxy.HibernateProxy;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ORDER_ITEM_DTL_ADJ")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
 @AdminPresentationMergeOverrides(
-    {
-        @AdminPresentationMergeOverride(name = "", mergeEntries =
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
-                                            booleanOverrideValue = true))
-    }
+        {
+                @AdminPresentationMergeOverride(name = "", mergeEntries =
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
+                        booleanOverrideValue = true))
+        }
 )
-public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailAdjustment, CurrencyCodeIdentifiable {
+public class OrderItemPriceDetailAdjustmentImpl
+        implements OrderItemPriceDetailAdjustment, CurrencyCodeIdentifiable {
 
     public static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "OrderItemPriceDetailAdjustmentId")
     @GenericGenerator(
-        name = "OrderItemPriceDetailAdjustmentId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name = "segment_value", value = "OrderItemPriceDetailAdjustmentImpl"),
-            @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustmentImpl")
-        }
+            name = "OrderItemPriceDetailAdjustmentId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value",
+                            value = "OrderItemPriceDetailAdjustmentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.OrderItemPriceDetailAdjustmentImpl")
+            }
     )
     @Column(name = "ORDER_ITEM_DTL_ADJ_ID")
     protected Long id;
@@ -89,9 +93,9 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
     @AdminPresentation(excluded = true)
     protected OrderItemPriceDetail orderItemPriceDetail;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
-    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_Offer", order=1000,
+    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_Offer", order = 1000,
             prominent = true, gridOrder = 1000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
@@ -99,27 +103,30 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
     @Column(name = "OFFER_NAME")
     protected String offerName;
 
-    @Column(name = "ADJUSTMENT_REASON", nullable=false)
+    @Column(name = "ADJUSTMENT_REASON", nullable = false)
     @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_reason", order = 1,
             group = "OrderItemPriceDetailAdjustmentImpl_Description")
     protected String reason;
 
-    @Column(name = "ADJUSTMENT_VALUE", nullable=false, precision=19, scale=5)
+    @Column(name = "ADJUSTMENT_VALUE", nullable = false, precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_value", order = 2,
-            group = "OrderItemPriceDetailAdjustmentImpl_Description", fieldType = SupportedFieldType.MONEY, prominent = true)
+            group = "OrderItemPriceDetailAdjustmentImpl_Description",
+            fieldType = SupportedFieldType.MONEY, prominent = true)
     protected BigDecimal value = Money.ZERO.getAmount();
 
     @Column(name = "APPLIED_TO_SALE_PRICE")
-    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_appliedToSalePrice", order = 3,
+    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_appliedToSalePrice",
+            order = 3,
             group = "OrderItemPriceDetailAdjustmentImpl_Description")
     protected boolean appliedToSalePrice;
 
     @Column(name = "IS_FUTURE_CREDIT")
-    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_isFutureCredit", order = 4,
+    @AdminPresentation(friendlyName = "OrderItemPriceDetailAdjustmentImpl_isFutureCredit",
+            order = 4,
             group = "OrderItemPriceDetailAdjustmentImpl_Description",
-            showIfProperty="admin.showIfProperty.offerAdjustmentType")
+            showIfProperty = "admin.showIfProperty.offerAdjustmentType")
     protected Boolean isFutureCredit = false;
-    
+
     @Transient
     protected Money retailValue;
 
@@ -200,7 +207,9 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
         this.offer = offer;
         deproxiedOffer = null;
         if (offer != null) {
-            this.offerName = offer.getMarketingMessage() != null ? offer.getMarketingMessage() : offer.getName();
+            this.offerName = offer.getMarketingMessage() != null
+                    ? offer.getMarketingMessage()
+                    : offer.getName();
         }
     }
 
@@ -228,7 +237,7 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
         }
         return new Money(value, currency, value.scale());
     }
-    
+
     @Override
     public void setValue(Money value) {
         this.value = value.getAmount();
@@ -296,7 +305,9 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
         final int prime = 31;
         int result = 1;
         result = prime * result + ((offer == null) ? 0 : offer.hashCode());
-        result = prime * result + ((orderItemPriceDetail == null) ? 0 : orderItemPriceDetail.hashCode());
+        result = prime * result + ((orderItemPriceDetail == null)
+                ? 0
+                : orderItemPriceDetail.hashCode());
         result = prime * result + ((reason == null) ? 0 : reason.hashCode());
         result = prime * result + ((value == null) ? 0 : value.hashCode());
         result = prime * result + ((isFutureCredit == null) ? 0 : isFutureCredit.hashCode());
@@ -355,7 +366,8 @@ public class OrderItemPriceDetailAdjustmentImpl implements OrderItemPriceDetailA
     }
 
     @Override
-    public <G extends OrderItemPriceDetailAdjustment> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OrderItemPriceDetailAdjustment> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -51,15 +51,18 @@ import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_PRORATED_ORDER_ITEM_ADJUST", indexes = {@Index(name = "POIADJUST_ITEM_INDEX", columnList = "ORDER_ITEM_ID")})
+@Table(name = "BLC_PRORATED_ORDER_ITEM_ADJUST",
+        indexes = {@Index(name = "POIADJUST_ITEM_INDEX", columnList = "ORDER_ITEM_ID")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "", mergeEntries =
         @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
                 booleanOverrideValue = true))
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "OrderItemAdjustmentImpl_baseProratedOrderItemAdjustment")
-public class ProratedOrderItemAdjustmentImpl implements ProratedOrderItemAdjustment, CurrencyCodeIdentifiable {
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "OrderItemAdjustmentImpl_baseProratedOrderItemAdjustment")
+public class ProratedOrderItemAdjustmentImpl
+        implements ProratedOrderItemAdjustment, CurrencyCodeIdentifiable {
 
     public static final long serialVersionUID = 1L;
 
@@ -70,7 +73,8 @@ public class ProratedOrderItemAdjustmentImpl implements ProratedOrderItemAdjustm
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "ProratedOrderItemAdjustmentImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.offer.domain.ProratedOrderItemAdjustmentImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.offer.domain.ProratedOrderItemAdjustmentImpl")
             }
     )
     @Column(name = "PRORATED_ORDER_ITEM_ADJUST_ID")
@@ -81,30 +85,32 @@ public class ProratedOrderItemAdjustmentImpl implements ProratedOrderItemAdjustm
     @AdminPresentation(excluded = true)
     protected OrderItem orderItem;
 
-    @ManyToOne(targetEntity = OfferImpl.class, optional=false)
+    @ManyToOne(targetEntity = OfferImpl.class, optional = false)
     @JoinColumn(name = "OFFER_ID")
     @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Offer", order = 1000,
             group = "OrderItemAdjustmentImpl_Description", prominent = true, gridOrder = 1000)
     @AdminPresentationToOneLookup()
     protected Offer offer;
 
-    @Column(name = "ADJUSTMENT_REASON", nullable=false)
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Reason", order = 2000)
+    @Column(name = "ADJUSTMENT_REASON", nullable = false)
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Reason",
+            order = 2000)
     protected String reason;
 
-    @Column(name = "PRORATED_ADJUSTMENT_VALUE", nullable=false, precision = 19, scale = 5)
+    @Column(name = "PRORATED_ADJUSTMENT_VALUE", nullable = false, precision = 19, scale = 5)
     @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Value", order = 3000,
             fieldType = SupportedFieldType.MONEY, prominent = true,
             gridOrder = 2000)
     protected BigDecimal value = Money.ZERO.getAmount();
 
-    @Column(name = "PRORATED_QUANTITY", nullable=false)
-    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Quantity", order = 4000,
+    @Column(name = "PRORATED_QUANTITY", nullable = false)
+    @AdminPresentation(friendlyName = "OrderItemAdjustmentImpl_Item_Adjustment_Quantity",
+            order = 4000,
             gridOrder = 3000, prominent = true)
     protected int quantity;
 
     @Override
-    public void init(OrderItem orderItem, Offer offer, String reason){
+    public void init(OrderItem orderItem, Offer offer, String reason) {
         this.orderItem = orderItem;
         this.offer = offer;
         this.reason = reason;
@@ -151,7 +157,9 @@ public class ProratedOrderItemAdjustmentImpl implements ProratedOrderItemAdjustm
 
     @Override
     public Money getValue() {
-        return value == null ? null : BroadleafCurrencyUtils.getMoney(value, getOrderItem().getOrder().getCurrency());
+        return value == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(value, getOrderItem().getOrder().getCurrency());
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemFeePriceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemFeePriceImpl.java
@@ -156,7 +156,7 @@ public class BundleOrderItemFeePriceImpl implements BundleOrderItemFeePrice  {
     }
 
     public void checkCloneable(BundleOrderItemFeePrice bundleFeePrice) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = bundleFeePrice.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = bundleFeePrice.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !bundleFeePrice.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
@@ -261,12 +261,8 @@ public class BundleOrderItemFeePriceImpl implements BundleOrderItemFeePrice  {
             return false;
         }
         if (reportingCode == null) {
-            if (other.reportingCode != null) {
-                return false;
-            }
-        } else if (!reportingCode.equals(other.reportingCode)) {
-            return false;
-        }
-        return true;
+            return other.reportingCode == null;
+        } else
+            return reportingCode.equals(other.reportingCode);
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemFeePriceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemFeePriceImpl.java
@@ -17,12 +17,22 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
@@ -35,16 +45,6 @@ import org.hibernate.annotations.Parameter;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -66,7 +66,7 @@ public class BundleOrderItemFeePriceImpl implements BundleOrderItemFeePrice  {
     @GeneratedValue(generator = "BundleOrderItemFeePriceId")
     @GenericGenerator(
         name="BundleOrderItemFeePriceId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="BundleOrderItemFeePriceImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.BundleOrderItemFeePriceImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/BundleOrderItemImpl.java
@@ -392,13 +392,9 @@ public class BundleOrderItemImpl extends OrderItemImpl implements BundleOrderIte
         }
 
         if (name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        } else if (!name.equals(other.name)) {
-            return false;
-        }
-        return true;
+            return other.name == null;
+        } else
+            return name.equals(other.name);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemFeePriceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemFeePriceImpl.java
@@ -17,11 +17,21 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
@@ -35,16 +45,6 @@ import org.hibernate.annotations.Parameter;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -67,7 +67,7 @@ public class DiscreteOrderItemFeePriceImpl implements DiscreteOrderItemFeePrice 
     @GeneratedValue(generator = "DiscreteOrderItemFeePriceId")
     @GenericGenerator(
         name="DiscreteOrderItemFeePriceId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="DiscreteOrderItemFeePriceImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.DiscreteOrderItemFeePriceImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemFeePriceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemFeePriceImpl.java
@@ -143,7 +143,7 @@ public class DiscreteOrderItemFeePriceImpl implements DiscreteOrderItemFeePrice 
     }
 
     public void checkCloneable(DiscreteOrderItemFeePrice discreteFeePrice) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = discreteFeePrice.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = discreteFeePrice.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !discreteFeePrice.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
@@ -243,12 +243,8 @@ public class DiscreteOrderItemFeePriceImpl implements DiscreteOrderItemFeePrice 
             return false;
         }
         if (reportingCode == null) {
-            if (other.reportingCode != null) {
-                return false;
-            }
-        } else if (!reportingCode.equals(other.reportingCode)) {
-            return false;
-        }
-        return true;
+            return other.reportingCode == null;
+        } else
+            return reportingCode.equals(other.reportingCode);
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -443,13 +443,9 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
             return false;
         }
         if (sku == null) {
-            if (other.sku != null) {
-                return false;
-            }
-        } else if (!sku.equals(other.sku)) {
-            return false;
-        }
-        return true;
+            return other.sku == null;
+        } else
+            return sku.equals(other.sku);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupFeeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupFeeImpl.java
@@ -17,11 +17,25 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
@@ -37,20 +51,6 @@ import org.hibernate.annotations.Parameter;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -71,7 +71,7 @@ public class FulfillmentGroupFeeImpl implements FulfillmentGroupFee, CurrencyCod
     @GeneratedValue(generator = "FulfillmentGroupFeeId")
     @GenericGenerator(
         name="FulfillmentGroupFeeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentGroupFeeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.FulfillmentGroupFeeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupFeeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupFeeImpl.java
@@ -162,7 +162,7 @@ public class FulfillmentGroupFeeImpl implements FulfillmentGroupFee, CurrencyCod
     
     @Override
     public Boolean isTaxable() {
-        return feeTaxable == null ? true : feeTaxable;
+        return feeTaxable == null || feeTaxable;
     }
 
     @Override
@@ -264,13 +264,9 @@ public class FulfillmentGroupFeeImpl implements FulfillmentGroupFee, CurrencyCod
             return false;
         }
         if (reportingCode == null) {
-            if (other.reportingCode != null) {
-                return false;
-            }
-        } else if (!reportingCode.equals(other.reportingCode)) {
-            return false;
-        }
-        return true;
+            return other.reportingCode == null;
+        } else
+            return reportingCode.equals(other.reportingCode);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupImpl.java
@@ -767,7 +767,7 @@ public class FulfillmentGroupImpl implements FulfillmentGroup, CurrencyCodeIdent
 
     @Override
     public Boolean getShippingOverride() {
-        return shippingOverride == null ? false : shippingOverride;
+        return shippingOverride != null && shippingOverride;
     }
 
     @Override
@@ -849,13 +849,9 @@ public class FulfillmentGroupImpl implements FulfillmentGroup, CurrencyCodeIdent
             return false;
         }
         if (fulfillmentGroupItems == null) {
-            if (other.fulfillmentGroupItems != null) {
-                return false;
-            }
-        } else if (!fulfillmentGroupItems.equals(other.fulfillmentGroupItems)) {
-            return false;
-        }
-        return true;
+            return other.fulfillmentGroupItems == null;
+        } else
+            return fulfillmentGroupItems.equals(other.fulfillmentGroupItems);
     }
 
     public static class Presentation {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupImpl.java
@@ -17,6 +17,19 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
@@ -25,6 +38,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -54,20 +68,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -133,7 +133,7 @@ public class FulfillmentGroupImpl implements FulfillmentGroup, CurrencyCodeIdent
     @GeneratedValue(generator = "FulfillmentGroupId")
     @GenericGenerator(
         name="FulfillmentGroupId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentGroupImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.FulfillmentGroupImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupItemImpl.java
@@ -261,7 +261,7 @@ public class FulfillmentGroupItemImpl implements FulfillmentGroupItem, Cloneable
     }
 
     public void checkCloneable(FulfillmentGroupItem fulfillmentGroupItem) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = fulfillmentGroupItem.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = fulfillmentGroupItem.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !orderItem.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");
@@ -349,13 +349,9 @@ public class FulfillmentGroupItemImpl implements FulfillmentGroupItem, Cloneable
         }
 
         if (orderItem == null) {
-            if (other.orderItem != null) {
-                return false;
-            }
-        } else if (!orderItem.equals(other.orderItem)) {
-            return false;
-        }
-        return true;
+            return other.orderItem == null;
+        } else
+            return orderItem.equals(other.orderItem);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentGroupItemImpl.java
@@ -17,6 +17,20 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -24,6 +38,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -41,21 +56,6 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -77,7 +77,7 @@ public class FulfillmentGroupItemImpl implements FulfillmentGroupItem, Cloneable
     @GeneratedValue(generator = "FulfillmentGroupItemId")
     @GenericGenerator(
         name="FulfillmentGroupItemId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentGroupItemImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.FulfillmentGroupItemImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/FulfillmentOptionImpl.java
@@ -17,6 +17,14 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -25,6 +33,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -34,15 +43,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -61,7 +61,7 @@ public class FulfillmentOptionImpl implements FulfillmentOption {
     @GeneratedValue(generator= "FulfillmentOptionId")
     @GenericGenerator(
         name="FulfillmentOptionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentOptionImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.FulfillmentOptionImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/GiftWrapOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/GiftWrapOrderItemImpl.java
@@ -76,7 +76,7 @@ public class GiftWrapOrderItemImpl extends DiscreteOrderItemImpl implements Gift
         }
         GiftWrapOrderItem cloned = (GiftWrapOrderItem)createResponse.getClone();
         for(OrderItem entry : wrappedItems){
-            OrderItem clonedEntry = ((OrderItemImpl)entry).createOrRetrieveCopyInstance(context).getClone();
+            OrderItem clonedEntry = entry.createOrRetrieveCopyInstance(context).getClone();
             clonedEntry.setGiftWrapOrderItem(cloned);
             cloned.getWrappedItems().add(clonedEntry);
         }
@@ -112,10 +112,8 @@ public class GiftWrapOrderItemImpl extends DiscreteOrderItemImpl implements Gift
         }
 
         if (wrappedItems == null) {
-            if (other.wrappedItems != null)
-                return false;
-        } else if (!wrappedItems.equals(other.wrappedItems))
-            return false;
-        return true;
+            return other.wrappedItems == null;
+        } else
+            return wrappedItems.equals(other.wrappedItems);
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderAttributeImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
-import org.broadleafcommerce.common.presentation.override.PropertyType;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,6 +27,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
+import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * The Class OrderAttributeImpl
@@ -66,7 +66,7 @@ public class OrderAttributeImpl implements OrderAttribute {
     @GeneratedValue(generator= "OrderAttributeId")
     @GenericGenerator(
         name="OrderAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderAttributeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.OrderAttributeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderImpl.java
@@ -754,7 +754,7 @@ public class OrderImpl implements Order, AdminMainEntity, CurrencyCodeIdentifiab
     
     @Override
     public Boolean getTaxOverride() {
-        return taxOverride == null ? false : taxOverride;
+        return taxOverride != null && taxOverride;
     }
 
     @Override
@@ -839,13 +839,9 @@ public class OrderImpl implements Order, AdminMainEntity, CurrencyCodeIdentifiab
         Date myDateCreated = auditable != null ? auditable.getDateCreated() : null;
         Date otherDateCreated = other.auditable != null ? other.auditable.getDateCreated() : null;
         if (myDateCreated == null) {
-            if (otherDateCreated != null) {
-                return false;
-            }
-        } else if (!myDateCreated.equals(otherDateCreated)) {
-            return false;
-        }
-        return true;
+            return otherDateCreated == null;
+        } else
+            return myDateCreated.equals(otherDateCreated);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderImpl.java
@@ -17,6 +17,27 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyClass;
+import jakarta.persistence.MapKeyJoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.audit.Auditable;
@@ -33,6 +54,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.locale.domain.Locale;
 import org.broadleafcommerce.common.locale.domain.LocaleImpl;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PreviewStatus;
 import org.broadleafcommerce.common.persistence.Previewable;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
@@ -76,28 +98,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.MapKeyClass;
-import jakarta.persistence.MapKeyJoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @EntityListeners(value = {AuditableListener.class, OrderPersistedEntityListener.class})
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -126,7 +126,7 @@ public class OrderImpl implements Order, AdminMainEntity, CurrencyCodeIdentifiab
     @GeneratedValue(generator = "OrderId")
     @GenericGenerator(
         name="OrderId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.OrderImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
@@ -129,7 +129,7 @@ public class OrderItemAttributeImpl implements OrderItemAttribute {
     }
 
     public void checkCloneable(OrderItemAttribute itemAttribute) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = itemAttribute.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = itemAttribute.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") && !itemAttribute.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
             throw new CloneNotSupportedException("Custom extensions and implementations should implement clone in order to guarantee split and merge operations are performed accurately");

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemAttributeImpl.java
@@ -17,20 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.lang.reflect.Method;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,6 +27,20 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.lang.reflect.Method;
 
 /**
  * Arbitrary attributes to add to an order-item.
@@ -62,7 +62,7 @@ public class OrderItemAttributeImpl implements OrderItemAttribute {
     @GeneratedValue(generator= "OrderItemAttributeId")
     @GenericGenerator(
         name="OrderItemAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderItemAttributeImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.catalog.domain.OrderItemAttributeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
@@ -619,7 +619,7 @@ public class OrderItemImpl implements OrderItem, Cloneable, AdminMainEntity, Cur
 
     @Override
     public Boolean isTaxable() {
-        return itemTaxable == null ? true : itemTaxable;
+        return itemTaxable == null || itemTaxable;
     }
 
     @Override
@@ -865,7 +865,7 @@ public class OrderItemImpl implements OrderItem, Cloneable, AdminMainEntity, Cur
     }
 
     public void checkCloneable(OrderItem orderItem) throws CloneNotSupportedException, SecurityException, NoSuchMethodException {
-        Method cloneMethod = orderItem.getClass().getMethod("clone", new Class[]{});
+        Method cloneMethod = orderItem.getClass().getMethod("clone");
         if (cloneMethod.getDeclaringClass().getName().startsWith("org.broadleafcommerce") &&
                 !orderItem.getClass().getName().startsWith("org.broadleafcommerce")) {
             //subclass is not implementing the clone method
@@ -1032,13 +1032,9 @@ public class OrderItemImpl implements OrderItem, Cloneable, AdminMainEntity, Cur
             return false;
         }
         if (parentOrderItem == null) {
-            if (other.parentOrderItem != null) {
-                return false;
-            }
-        } else if (!parentOrderItem.equals(other.parentOrderItem)) {
-            return false;
-        }
-        return true;
+            return other.parentOrderItem == null;
+        } else
+            return parentOrderItem.equals(other.parentOrderItem);
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
@@ -17,6 +17,25 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +51,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.PostLoaderDao;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -69,26 +89,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKey;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-
 @Entity
 @EntityListeners(value = {AuditableListener.class})
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -121,7 +121,7 @@ public class OrderItemImpl implements OrderItem, Cloneable, AdminMainEntity, Cur
     @GeneratedValue(generator = "OrderItemId")
     @GenericGenerator(
         name="OrderItemId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderItemImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.OrderItemImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemPriceDetailImpl.java
@@ -17,6 +17,17 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,6 +40,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.client.AddMethodType;
@@ -50,18 +62,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 
 @Entity
@@ -90,7 +90,7 @@ public class OrderItemPriceDetailImpl implements OrderItemPriceDetail, CurrencyC
     @GeneratedValue(generator = "OrderItemPriceDetailId")
     @GenericGenerator(
         name="OrderItemPriceDetailId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderItemPriceDetailImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.OrderItemPriceDetailImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemQualifierImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemQualifierImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
-import org.broadleafcommerce.common.persistence.PostLoaderDao;
-import org.broadleafcommerce.common.util.HibernateUtils;
-import org.broadleafcommerce.core.offer.domain.Offer;
-import org.broadleafcommerce.core.offer.domain.OfferImpl;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.proxy.HibernateProxy;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,6 +27,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.broadleafcommerce.common.persistence.DefaultPostLoaderDao;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.persistence.PostLoaderDao;
+import org.broadleafcommerce.common.util.HibernateUtils;
+import org.broadleafcommerce.core.offer.domain.Offer;
+import org.broadleafcommerce.core.offer.domain.OfferImpl;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.proxy.HibernateProxy;
 
 @Entity
 @Table(name = "BLC_ITEM_OFFER_QUALIFIER")
@@ -54,7 +54,7 @@ public class OrderItemQualifierImpl implements OrderItemQualifier {
     @GeneratedValue(generator = "OrderItemQualifierId")
     @GenericGenerator(
         name = "OrderItemQualifierId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name = "segment_value", value = "OrderItemQualifierImpl"),
             @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.order.domain.OrderItemQualifierImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemQualifierImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemQualifierImpl.java
@@ -158,9 +158,9 @@ public class OrderItemQualifierImpl implements OrderItemQualifier {
             if (other.orderItem != null) return false;
         } else if (!orderItem.equals(other.orderItem)) return false;
         if (quantity == null) {
-            if (other.quantity != null) return false;
-        } else if (!quantity.equals(other.quantity)) return false;
-        return true;
+            return other.quantity == null;
+        } else
+            return quantity.equals(other.quantity);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderLockImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderLockImpl.java
@@ -58,11 +58,7 @@ public class OrderLockImpl implements OrderLock {
 
     @Override
     public Boolean getLocked() {
-        if (locked == null || locked == 'N') {
-            return false;
-        } else {
-            return true;
-        }
+        return locked != null && locked != 'N';
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderMultishipOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderMultishipOptionImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.profile.core.domain.Address;
-import org.broadleafcommerce.profile.core.domain.AddressImpl;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +27,15 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.profile.core.domain.Address;
+import org.broadleafcommerce.profile.core.domain.AddressImpl;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -49,7 +49,7 @@ public class OrderMultishipOptionImpl implements OrderMultishipOption {
     @GeneratedValue(generator = "OrderMultishipOptionId")
     @GenericGenerator(
         name="OrderMultishipOptionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderMultishipOptionImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.OrderMultishipOptionImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/PersonalMessageImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/PersonalMessageImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -32,6 +24,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -45,7 +45,7 @@ public class PersonalMessageImpl implements PersonalMessage {
     @GeneratedValue(generator = "PersonalMessageId")
     @GenericGenerator(
         name="PersonalMessageId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="PersonalMessageImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.domain.PersonalMessageImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/PersonalMessageImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/PersonalMessageImpl.java
@@ -169,10 +169,8 @@ public class PersonalMessageImpl implements PersonalMessage {
         } else if (!messageFrom.equals(other.messageFrom))
             return false;
         if (messageTo == null) {
-            if (other.messageTo != null)
-                return false;
-        } else if (!messageTo.equals(other.messageTo))
-            return false;
-        return true;
+            return other.messageTo == null;
+        } else
+            return messageTo.equals(other.messageTo);
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/TaxDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/TaxDetailImpl.java
@@ -17,23 +17,6 @@
  */
 package org.broadleafcommerce.core.order.domain;
 
-import org.broadleafcommerce.common.config.domain.AbstractModuleConfiguration;
-import org.broadleafcommerce.common.config.domain.ModuleConfiguration;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
-import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
-import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +26,23 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.config.domain.AbstractModuleConfiguration;
+import org.broadleafcommerce.common.config.domain.ModuleConfiguration;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
+import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -57,7 +57,7 @@ public class TaxDetailImpl implements TaxDetail {
     @GeneratedValue(generator = "TaxDetailId")
     @GenericGenerator(
         name="TaxDetailId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="TaxDetailImpl"),
             @Parameter(name="increment_size", value="150"),

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentPriceBandImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentPriceBandImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.core.order.fulfillment.domain;
 
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +26,16 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 /**
  * 
@@ -57,7 +57,7 @@ public class FulfillmentPriceBandImpl extends FulfillmentBandImpl implements Ful
     @GeneratedValue(generator= "FulfillmentPriceBandId")
     @GenericGenerator(
         name="FulfillmentPriceBandId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentPriceBandImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.fulfillment.domain.FulfillmentPriceBandImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentWeightBandImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/fulfillment/domain/FulfillmentWeightBandImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.core.order.fulfillment.domain;
 
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
-import org.broadleafcommerce.common.util.WeightUnitOfMeasureType;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -39,6 +26,19 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
+import org.broadleafcommerce.common.util.WeightUnitOfMeasureType;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
 
 /**
  * 
@@ -60,7 +60,7 @@ public class FulfillmentWeightBandImpl extends FulfillmentBandImpl implements Fu
     @GeneratedValue(generator= "FulfillmentWeightBandId")
     @GenericGenerator(
         name="FulfillmentWeightBandId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="FulfillmentWeightBandImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.order.fulfillment.domain.FulfillmentWeightBandImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
@@ -10,26 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.payment.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -73,6 +60,20 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ORDER_PAYMENT", indexes = {
@@ -104,7 +105,8 @@ import java.util.List;
                         booleanOverrideValue = true)
         })
 })
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "OrderPaymentImpl_baseOrderPayment")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "OrderPaymentImpl_baseOrderPayment")
 @SQLDelete(sql = "UPDATE BLC_ORDER_PAYMENT SET ARCHIVED = 'Y' WHERE ORDER_PAYMENT_ID = ?")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
@@ -116,12 +118,13 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     @Id
     @GeneratedValue(generator = "OrderPaymentId")
     @GenericGenerator(
-        name="OrderPaymentId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="OrderPaymentImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.OrderPaymentImpl")
-        }
+            name = "OrderPaymentId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "OrderPaymentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.payment.domain.OrderPaymentImpl")
+            }
     )
     @Column(name = "ORDER_PAYMENT_ID")
     protected Long id;
@@ -131,13 +134,14 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     @AdminPresentation(excluded = true)
     protected Order order;
 
-    @ManyToOne(targetEntity = AddressImpl.class, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    @ManyToOne(targetEntity = AddressImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "ADDRESS_ID")
     protected Address billingAddress;
 
-    @Column(name = "AMOUNT", precision=19, scale=5)
-    @AdminPresentation(friendlyName = "OrderPaymentImpl_Payment_Amount", order=2000, gridOrder = 2000, prominent=true,
-            fieldType=SupportedFieldType.MONEY)
+    @Column(name = "AMOUNT", precision = 19, scale = 5)
+    @AdminPresentation(friendlyName = "OrderPaymentImpl_Payment_Amount", order = 2000,
+            gridOrder = 2000, prominent = true,
+            fieldType = SupportedFieldType.MONEY)
     protected BigDecimal amount;
 
     @Column(name = "REFERENCE_NUMBER")
@@ -145,29 +149,34 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     protected String referenceNumber;
 
     @Column(name = "PAYMENT_TYPE", nullable = false)
-    @AdminPresentation(friendlyName = "OrderPaymentImpl_Payment_Type", order=3000, gridOrder = 3000, prominent=true,
-            fieldType= SupportedFieldType.BROADLEAF_ENUMERATION,
-            broadleafEnumeration="org.broadleafcommerce.common.payment.PaymentType")
-    protected String type;
-    
-    @Column(name = "GATEWAY_TYPE")
-    @AdminPresentation(friendlyName = "OrderPaymentImpl_Gateway_Type", order=1000, gridOrder = 1000, prominent=true,
+    @AdminPresentation(friendlyName = "OrderPaymentImpl_Payment_Type", order = 3000,
+            gridOrder = 3000, prominent = true,
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-            broadleafEnumeration="org.broadleafcommerce.common.payment.PaymentGatewayType")
+            broadleafEnumeration = "org.broadleafcommerce.common.payment.PaymentType")
+    protected String type;
+
+    @Column(name = "GATEWAY_TYPE")
+    @AdminPresentation(friendlyName = "OrderPaymentImpl_Gateway_Type", order = 1000,
+            gridOrder = 1000, prominent = true,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.payment.PaymentGatewayType")
     protected String gatewayType;
 
-    @OneToMany(mappedBy = "orderPayment", targetEntity = PaymentTransactionImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
+    @OneToMany(mappedBy = "orderPayment", targetEntity = PaymentTransactionImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Where(clause = "archived != 'Y'")
-    @AdminPresentationCollection(friendlyName="OrderPaymentImpl_Details",
+    @AdminPresentationCollection(friendlyName = "OrderPaymentImpl_Details",
             tab = Presentation.Tab.Name.Log, tabOrder = Presentation.Tab.Order.Log)
     protected List<PaymentTransaction> transactions = new ArrayList<PaymentTransaction>();
 
     @Embedded
     protected ArchiveStatus archiveStatus = new ArchiveStatus();
-    
+
     @Override
     public Money getAmount() {
-        return amount == null ? null : BroadleafCurrencyUtils.getMoney(amount, getOrder().getCurrency());
+        return amount == null
+                ? null
+                : BroadleafCurrencyUtils.getMoney(amount, getOrder().getCurrency());
     }
 
     @Override
@@ -224,7 +233,7 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     public void setType(PaymentType type) {
         this.type = type == null ? null : type.getType();
     }
-    
+
     @Override
     public PaymentGatewayType getGatewayType() {
         return PaymentGatewayType.getInstance(gatewayType);
@@ -244,7 +253,7 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     public void setTransactions(List<PaymentTransaction> transactions) {
         this.transactions = transactions;
     }
-    
+
     @Override
     public void addTransaction(PaymentTransaction transaction) {
         getTransactions().add(transaction);
@@ -273,9 +282,9 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
 
     @Override
     public PaymentTransaction getAuthorizeTransaction() {
-        for (PaymentTransaction tx : getTransactions()){
+        for (PaymentTransaction tx : getTransactions()) {
             if (PaymentTransactionType.AUTHORIZE.equals(tx.getType())
-                    || PaymentTransactionType.AUTHORIZE_AND_CAPTURE.equals(tx.getType())){
+                    || PaymentTransactionType.AUTHORIZE_AND_CAPTURE.equals(tx.getType())) {
                 return tx;
             }
         }
@@ -285,19 +294,19 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     @Override
     public Money getTransactionAmountForType(PaymentTransactionType type) {
         Money amount = BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrder().getCurrency());
-        for (PaymentTransaction tx : getTransactions()){
+        for (PaymentTransaction tx : getTransactions()) {
             if (type.equals(tx.getType())) {
                 amount = amount.add(tx.getAmount());
             }
         }
         return amount;
     }
-    
+
     @Override
     public Money getSuccessfulTransactionAmountForType(PaymentTransactionType type) {
         Money amount = BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrder().getCurrency());
-        for (PaymentTransaction tx : getTransactions()){
-            if (type.equals(tx.getType()) && tx.getSuccess()){
+        for (PaymentTransaction tx : getTransactions()) {
+            if (type.equals(tx.getType()) && tx.getSuccess()) {
                 amount = amount.add(tx.getAmount());
             }
         }
@@ -311,16 +320,17 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
             return null;
         }
 
-        OrderPaymentStatusService svc = ctx.getBean("blOrderPaymentStatusService", OrderPaymentStatusService.class);
+        OrderPaymentStatusService svc =
+                ctx.getBean("blOrderPaymentStatusService", OrderPaymentStatusService.class);
         return svc.determineOrderPaymentStatus(this);
     }
 
     @Override
     public boolean isConfirmed() {
-        for (PaymentTransaction tx : getTransactions()){
+        for (PaymentTransaction tx : getTransactions()) {
             if ((PaymentTransactionType.AUTHORIZE_AND_CAPTURE.equals(tx.getType()) ||
                     PaymentTransactionType.AUTHORIZE.equals(tx.getType()))
-                    && tx.getSuccess()){
+                    && tx.getSuccess()) {
                 return true;
             }
         }
@@ -347,16 +357,16 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
         }
         return null;
     }
-    
+
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -371,17 +381,17 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     public boolean isActive() {
         return 'Y' != getArchived();
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (obj != null && getClass().isAssignableFrom(obj.getClass())) {
             OrderPaymentImpl that = (OrderPaymentImpl) obj;
             return new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.referenceNumber, that.referenceNumber)
-                .append(this.type, that.type)
-                .append(this.archiveStatus, that.archiveStatus)
-                .build();
+                    .append(this.id, that.id)
+                    .append(this.referenceNumber, that.referenceNumber)
+                    .append(this.type, that.type)
+                    .append(this.archiveStatus, that.archiveStatus)
+                    .build();
         }
         return false;
     }
@@ -389,21 +399,24 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(referenceNumber)
-            .append(type)
-            .append(archiveStatus)
-            .build();
+                .append(referenceNumber)
+                .append(type)
+                .append(archiveStatus)
+                .build();
     }
 
     @Override
-    public <G extends OrderPayment> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends OrderPayment> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
         OrderPayment cloned = createResponse.getClone();
         //some payment types will not have a billing address, e.g. cash on delivery
-        cloned.setBillingAddress(billingAddress == null ? null : billingAddress.createOrRetrieveCopyInstance(context).getClone());
+        cloned.setBillingAddress(billingAddress == null
+                ? null
+                : billingAddress.createOrRetrieveCopyInstance(context).getClone());
         cloned.setReferenceNumber(referenceNumber);
         cloned.setAmount(amount == null ? null : new Money(amount));
         cloned.setOrder(order);
@@ -412,7 +425,8 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
         cloned.setArchived(getArchived());
         for (PaymentTransaction transaction : transactions) {
             if (transaction.isActive()) {
-                PaymentTransaction cpt = transaction.createOrRetrieveCopyInstance(context).getClone();
+                PaymentTransaction cpt =
+                        transaction.createOrRetrieveCopyInstance(context).getClone();
                 cpt.setOrderPayment(cloned);
                 cloned.getTransactions().add(cpt);
             }
@@ -429,6 +443,7 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
                 public static final String Advanced = "PaymentInfoImpl_Advanced_Tab";
             }
 
+
             public static class Order {
                 public static final int Address = 2000;
                 public static final int Log = 4000;
@@ -436,15 +451,18 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
             }
         }
 
+
         public static class Group {
             public static class Name {
                 public static final String Items = "PaymentInfoImpl_Items";
             }
 
+
             public static class Order {
                 public static final int Items = 1000;
             }
         }
+
 
         public static class FieldOrder {
             public static final int REFNUMBER = 3000;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/OrderPaymentImpl.java
@@ -17,6 +17,19 @@
  */
 package org.broadleafcommerce.core.payment.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -32,6 +45,7 @@ import org.broadleafcommerce.common.payment.PaymentGatewayType;
 import org.broadleafcommerce.common.payment.PaymentTransactionType;
 import org.broadleafcommerce.common.payment.PaymentType;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -58,20 +72,6 @@ import org.springframework.context.ApplicationContext;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -117,7 +117,7 @@ public class OrderPaymentImpl implements OrderPayment, CurrencyCodeIdentifiable 
     @GeneratedValue(generator = "OrderPaymentId")
     @GenericGenerator(
         name="OrderPaymentId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="OrderPaymentImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.OrderPaymentImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentLogImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentLogImpl.java
@@ -305,12 +305,8 @@ public class PaymentLogImpl implements PaymentLog {
             return false;
         }
         if (userName == null) {
-            if (other.userName != null) {
-                return false;
-            }
-        } else if (!userName.equals(other.userName)) {
-            return false;
-        }
-        return true;
+            return other.userName == null;
+        } else
+            return userName.equals(other.userName);
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentLogImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentLogImpl.java
@@ -17,21 +17,6 @@
  */
 package org.broadleafcommerce.core.payment.domain;
 
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
-import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
-import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
-import org.broadleafcommerce.common.money.Money;
-import org.broadleafcommerce.common.payment.PaymentLogEventType;
-import org.broadleafcommerce.common.payment.PaymentTransactionType;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.math.BigDecimal;
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -44,6 +29,21 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
+import org.broadleafcommerce.common.currency.domain.BroadleafCurrencyImpl;
+import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
+import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.payment.PaymentLogEventType;
+import org.broadleafcommerce.common.payment.PaymentTransactionType;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.math.BigDecimal;
+import java.util.Date;
 
 /**
  * @deprecated - payment logs should now be captured as raw responses in Payment Transaction line items
@@ -67,7 +67,7 @@ public class PaymentLogImpl implements PaymentLog {
     @GeneratedValue(generator = "PaymentLogId")
     @GenericGenerator(
         name="PaymentLogId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="PaymentLogImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.PaymentLogImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentTransactionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentTransactionImpl.java
@@ -17,12 +17,27 @@
  */
 package org.broadleafcommerce.core.payment.domain;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.payment.PaymentTransactionType;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -42,21 +57,6 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.Table;
 
 /**
  * @author Jerry Ocanas (jocanas)
@@ -80,7 +80,7 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     @GeneratedValue(generator = "PaymentTransactionId")
     @GenericGenerator(
         name="PaymentTransactionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="PaymentTransactionImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.PaymentTransactionImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentTransactionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/PaymentTransactionImpl.java
@@ -10,27 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.payment.domain;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapKeyColumn;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
@@ -58,19 +44,35 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Table;
+
 /**
  * @author Jerry Ocanas (jocanas)
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_ORDER_PAYMENT_TRANSACTION")
-@SQLDelete(sql="UPDATE BLC_ORDER_PAYMENT_TRANSACTION SET ARCHIVED = 'Y' WHERE PAYMENT_TRANSACTION_ID = ?")
+@SQLDelete(
+        sql = "UPDATE BLC_ORDER_PAYMENT_TRANSACTION SET ARCHIVED = 'Y' WHERE PAYMENT_TRANSACTION_ID = ?")
 @AdminPresentationMergeOverrides(
-    {
-        @AdminPresentationMergeOverride(name = "", mergeEntries =
-            @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
-                                            booleanOverrideValue = true))
-    }
+        {
+                @AdminPresentationMergeOverride(name = "", mergeEntries =
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.READONLY,
+                        booleanOverrideValue = true))
+        }
 )
 public class PaymentTransactionImpl implements PaymentTransaction {
 
@@ -79,12 +81,13 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     @Id
     @GeneratedValue(generator = "PaymentTransactionId")
     @GenericGenerator(
-        name="PaymentTransactionId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="PaymentTransactionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.PaymentTransactionImpl")
-        }
+            name = "PaymentTransactionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PaymentTransactionImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.payment.domain.PaymentTransactionImpl")
+            }
     )
     @Column(name = "PAYMENT_TRANSACTION_ID")
     protected Long id;
@@ -97,38 +100,41 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     protected String type;
 
     @Column(name = "TRANSACTION_AMOUNT")
-    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Amount", fieldType = SupportedFieldType.MONEY,
-        prominent = true, gridOrder = 2000)
+    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Amount",
+            fieldType = SupportedFieldType.MONEY,
+            prominent = true, gridOrder = 2000)
     protected BigDecimal amount;
 
     @Column(name = "DATE_RECORDED")
-    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Date", prominent = true, gridOrder = 3000)
+    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Date", prominent = true,
+            gridOrder = 3000)
     protected Date date;
-    
+
     @Column(name = "CUSTOMER_IP_ADDRESS", nullable = true)
-    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Payment_IP_Address", order=4000)
+    @AdminPresentation(friendlyName = "PaymentTransactionImpl_Payment_IP_Address", order = 4000)
     protected String customerIpAddress;
 
     @Lob
     @Column(name = "RAW_RESPONSE", length = Length.LONG32 - 1)
     @AdminPresentation(friendlyName = "PaymentTransactionImpl_Raw_Response")
     protected String rawResponse;
-    
+
     @Column(name = "SUCCESS")
     @AdminPresentation(friendlyName = "PaymentTransactionImpl_Success")
     protected Boolean success = true;
-    
+
     @Embedded
     protected ArchiveStatus archiveStatus = new ArchiveStatus();
-    
+
     @ManyToOne(targetEntity = OrderPaymentImpl.class, optional = false)
     @JoinColumn(name = "ORDER_PAYMENT")
     @AdminPresentation(excluded = true)
     protected OrderPayment orderPayment;
 
     /**
-     * Necessary for operations on a payment that require something to have happened beforehand. For instance, an AUTHORIZE
-     * would not have a parent but a CAPTURE must have an AUTHORIZE parent and a REFUND must have a CAPTURE parent
+     * Necessary for operations on a payment that require something to have happened beforehand. For
+     * instance, an AUTHORIZE would not have a parent but a CAPTURE must have an AUTHORIZE parent
+     * and a REFUND must have a CAPTURE parent
      */
     @ManyToOne(targetEntity = PaymentTransactionImpl.class)
     @JoinColumn(name = "PARENT_TRANSACTION")
@@ -137,12 +143,15 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     protected PaymentTransaction parentTransaction;
 
     @ElementCollection
-    @CollectionTable(name="BLC_TRANS_ADDITNL_FIELDS", joinColumns=@JoinColumn(name="PAYMENT_TRANSACTION_ID"))
-    @MapKeyColumn(name="FIELD_NAME")
-    @Column(name="FIELD_VALUE", length = Length.LONG32 - 1)
+    @CollectionTable(name = "BLC_TRANS_ADDITNL_FIELDS",
+            joinColumns = @JoinColumn(name = "PAYMENT_TRANSACTION_ID"))
+    @MapKeyColumn(name = "FIELD_NAME")
+    @Column(name = "FIELD_VALUE", length = Length.LONG32 - 1)
     @BatchSize(size = 50)
-    @AdminPresentationMap(friendlyName = "PaymentTransactionImpl_Additional_Fields", isSimpleValue = UnspecifiedBooleanType.TRUE,
-        forceFreeFormKeys = true, keyPropertyFriendlyName = "PaymentTransactionImpl_Additional_Fields_Name"
+    @AdminPresentationMap(friendlyName = "PaymentTransactionImpl_Additional_Fields",
+            isSimpleValue = UnspecifiedBooleanType.TRUE,
+            forceFreeFormKeys = true,
+            keyPropertyFriendlyName = "PaymentTransactionImpl_Additional_Fields_Name"
     )
     protected Map<String, String> additionalFields = new HashMap<String, String>();
 
@@ -173,7 +182,7 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     public void setOrderPayment(OrderPayment orderPayment) {
         this.orderPayment = orderPayment;
     }
-    
+
     @Override
     public PaymentTransaction getParentTransaction() {
         return parentTransaction;
@@ -196,7 +205,9 @@ public class PaymentTransactionImpl implements PaymentTransaction {
 
     @Override
     public Money getAmount() {
-        return amount == null ? BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrderPayment().getCurrency()) : BroadleafCurrencyUtils.getMoney(amount, getOrderPayment().getCurrency());
+        return amount == null
+                ? BroadleafCurrencyUtils.getMoney(BigDecimal.ZERO, getOrderPayment().getCurrency())
+                : BroadleafCurrencyUtils.getMoney(amount, getOrderPayment().getCurrency());
     }
 
     @Override
@@ -215,7 +226,7 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     public void setDate(Date date) {
         this.date = date;
     }
-    
+
     @Override
     public String getCustomerIpAddress() {
         return customerIpAddress;
@@ -225,17 +236,17 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     public void setCustomerIpAddress(String customerIpAddress) {
         this.customerIpAddress = customerIpAddress;
     }
-    
+
     @Override
     public String getRawResponse() {
         return rawResponse;
     }
-    
+
     @Override
     public void setRawResponse(String rawResponse) {
         this.rawResponse = rawResponse;
     }
-    
+
     @Override
     public Boolean getSuccess() {
         return success;
@@ -245,7 +256,7 @@ public class PaymentTransactionImpl implements PaymentTransaction {
     public void setSuccess(Boolean success) {
         this.success = success;
     }
-    
+
     @Override
     public Map<String, String> getAdditionalFields() {
         return additionalFields;
@@ -258,7 +269,7 @@ public class PaymentTransactionImpl implements PaymentTransaction {
 
     @Override
     public boolean isSaveToken() {
-        return saveToken == null ? false : saveToken;
+        return saveToken != null && saveToken;
     }
 
     @Override
@@ -268,13 +279,13 @@ public class PaymentTransactionImpl implements PaymentTransaction {
 
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -292,7 +303,8 @@ public class PaymentTransactionImpl implements PaymentTransaction {
 
 
     @Override
-    public <G extends PaymentTransaction> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends PaymentTransaction> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -308,8 +320,8 @@ public class PaymentTransactionImpl implements PaymentTransaction {
         cloned.setSuccess(success);
         cloned.setType(PaymentTransactionType.getInstance(type));
 
-        for(Map.Entry<String, String> entry : additionalFields.entrySet()){
-            cloned.getAdditionalFields().put(entry.getKey(),entry.getValue());
+        for (Map.Entry<String, String> entry : additionalFields.entrySet()) {
+            cloned.getAdditionalFields().put(entry.getKey(), entry.getValue());
         }
         return createResponse;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/BankAccountPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/BankAccountPaymentImpl.java
@@ -10,12 +10,18 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.payment.domain.secure;
+
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,26 +32,22 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 /**
- * 
  * @author jfischer
- *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_BANK_ACCOUNT_PAYMENT", indexes = {@Index(name = "BANKACCOUNT_INDEX", columnList = "REFERENCE_NUMBER")})
+@Table(name = "BLC_BANK_ACCOUNT_PAYMENT",
+        indexes = {@Index(name = "BANKACCOUNT_INDEX", columnList = "REFERENCE_NUMBER")})
 public class BankAccountPaymentImpl implements BankAccountPayment {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * Rather than constructing directly, use {@link SecureOrderPaymentService#create(org.broadleafcommerce.core.payment.service.type.PaymentType)}
+     * Rather than constructing directly, use
+     * {@link
+     * SecureOrderPaymentService#create(org.broadleafcommerce.core.payment.service.type.PaymentType)}
      * so that the appropriate {@link EncryptionModule} can be hooked up to this entity
      */
     protected BankAccountPaymentImpl() {
@@ -59,23 +61,24 @@ public class BankAccountPaymentImpl implements BankAccountPayment {
     @Id
     @GeneratedValue(generator = "BankPaymentId")
     @GenericGenerator(
-            name="BankPaymentId",
-            type= IdOverrideTableGenerator.class,
+            name = "BankPaymentId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                @Parameter(name="segment_value", value="BankAccountPaymentImpl"),
-                @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.BankAccountPaymentInfoImpl")
+                    @Parameter(name = "segment_value", value = "BankAccountPaymentImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.payment.domain.BankAccountPaymentInfoImpl")
             }
-        )
+    )
     @Column(name = "PAYMENT_ID")
     protected Long id;
 
-    @Column(name = "REFERENCE_NUMBER", nullable=false)
+    @Column(name = "REFERENCE_NUMBER", nullable = false)
     protected String referenceNumber;
 
-    @Column(name = "ACCOUNT_NUMBER", nullable=false)
+    @Column(name = "ACCOUNT_NUMBER", nullable = false)
     protected String accountNumber;
 
-    @Column(name = "ROUTING_NUMBER", nullable=false)
+    @Column(name = "ROUTING_NUMBER", nullable = false)
     protected String routingNumber;
 
     @Override
@@ -163,11 +166,9 @@ public class BankAccountPaymentImpl implements BankAccountPayment {
         } else if (!referenceNumber.equals(other.referenceNumber))
             return false;
         if (routingNumber == null) {
-            if (other.routingNumber != null)
-                return false;
-        } else if (!routingNumber.equals(other.routingNumber))
-            return false;
-        return true;
+            return other.routingNumber == null;
+        } else
+            return routingNumber.equals(other.routingNumber);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/BankAccountPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/BankAccountPaymentImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.core.payment.domain.secure;
 
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +26,11 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -60,7 +60,7 @@ public class BankAccountPaymentImpl implements BankAccountPayment {
     @GeneratedValue(generator = "BankPaymentId")
     @GenericGenerator(
             name="BankPaymentId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                 @Parameter(name="segment_value", value="BankAccountPaymentImpl"),
                 @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.BankAccountPaymentInfoImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/CreditCardPaymentInfoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/CreditCardPaymentInfoImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.core.payment.domain.secure;
 
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +26,11 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -60,7 +60,7 @@ public class CreditCardPaymentInfoImpl implements CreditCardPayment {
     @GeneratedValue(generator = "CreditCardPaymentId")
     @GenericGenerator(
             name="CreditCardPaymentId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                 @Parameter(name="segment_value", value="CreditCardPaymentInfoImpl"),
                 @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.CreditCardPaymentInfoImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/CreditCardPaymentInfoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/CreditCardPaymentInfoImpl.java
@@ -17,6 +17,12 @@
  */
 package org.broadleafcommerce.core.payment.domain.secure;
 
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -26,11 +32,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 /**
  * 
@@ -244,11 +245,9 @@ public class CreditCardPaymentInfoImpl implements CreditCardPayment {
         } else if (!pan.equals(other.pan))
             return false;
         if (referenceNumber == null) {
-            if (other.referenceNumber != null)
-                return false;
-        } else if (!referenceNumber.equals(other.referenceNumber))
-            return false;
-        return true;
+            return other.referenceNumber == null;
+        } else
+            return referenceNumber.equals(other.referenceNumber);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/GiftCardPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/GiftCardPaymentImpl.java
@@ -17,11 +17,6 @@
  */
 package org.broadleafcommerce.core.payment.domain.secure;
 
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +26,11 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -57,7 +57,7 @@ public class GiftCardPaymentImpl implements GiftCardPayment {
     @GeneratedValue(generator = "GiftCardPaymentId")
     @GenericGenerator(
             name="GiftCardPaymentId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                 @Parameter(name="segment_value", value="GiftCardPaymentImpl"),
                 @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.GiftCardPaymentInfoImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/GiftCardPaymentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/payment/domain/secure/GiftCardPaymentImpl.java
@@ -10,12 +10,18 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.payment.domain.secure;
+
+import org.broadleafcommerce.common.encryption.EncryptionModule;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,11 +32,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import org.broadleafcommerce.common.encryption.EncryptionModule;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.core.payment.service.SecureOrderPaymentService;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -56,13 +57,13 @@ public class GiftCardPaymentImpl implements GiftCardPayment {
     @Id
     @GeneratedValue(generator = "GiftCardPaymentId")
     @GenericGenerator(
-            name="GiftCardPaymentId",
-            type= IdOverrideTableGenerator.class,
+            name = "GiftCardPaymentId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                @Parameter(name="segment_value", value="GiftCardPaymentImpl"),
-                @Parameter(name="entity_name", value="org.broadleafcommerce.core.payment.domain.GiftCardPaymentInfoImpl")
+                    @Parameter(name = "segment_value", value = "GiftCardPaymentImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.payment.domain.GiftCardPaymentInfoImpl")
             }
-        )
+    )
     @Column(name = "PAYMENT_ID")
     protected Long id;
 
@@ -160,11 +161,9 @@ public class GiftCardPaymentImpl implements GiftCardPayment {
         } else if (!pin.equals(other.pin))
             return false;
         if (referenceNumber == null) {
-            if (other.referenceNumber != null)
-                return false;
-        } else if (!referenceNumber.equals(other.referenceNumber))
-            return false;
-        return true;
+            return other.referenceNumber == null;
+        } else
+            return referenceNumber.equals(other.referenceNumber);
     }
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/domain/PromotionMessageImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/domain/PromotionMessageImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.core.promotionMessage.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -31,6 +43,7 @@ import org.broadleafcommerce.common.locale.domain.LocaleImpl;
 import org.broadleafcommerce.common.media.domain.Media;
 import org.broadleafcommerce.common.media.domain.MediaImpl;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
 import org.broadleafcommerce.common.presentation.ConfigurationItem;
@@ -50,19 +63,6 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
 
 import java.util.Date;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "BLC_PROMOTION_MESSAGE", indexes = {@Index(name = "PROMOTION_MESSAGE_NAME_INDEX", columnList = "NAME")})
@@ -122,7 +122,7 @@ public class PromotionMessageImpl implements PromotionMessage, AdminMainEntity, 
     @GeneratedValue(generator= "PromotionMessageId")
     @GenericGenerator(
         name="PromotionMessageId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="PromotionMessageImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.promotionMessage.domain.PromotionMessageImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/dto/service/PromotionMessageDTOService.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/dto/service/PromotionMessageDTOService.java
@@ -34,7 +34,7 @@ public interface PromotionMessageDTOService {
      * @param promotionMessages
      * @return the converted map of {@link PromotionMessageDTO}s
      */
-    public Map<String, List<PromotionMessageDTO>> convertPromotionMessagesToDTOs(Set<PromotionMessage> promotionMessages);
+    Map<String, List<PromotionMessageDTO>> convertPromotionMessagesToDTOs(Set<PromotionMessage> promotionMessages);
 
     /**
      * Converts {@link PromotionMessage}s to {@link PromotionMessageDTO}s.
@@ -43,6 +43,6 @@ public interface PromotionMessageDTOService {
      * @param offer
      * @return the converted map of {@link PromotionMessageDTO}s
      */
-    public Map<String, List<PromotionMessageDTO>> convertPromotionMessagesToDTOs(Set<PromotionMessage> promotionMessages, Offer offer);
+    Map<String, List<PromotionMessageDTO>> convertPromotionMessagesToDTOs(Set<PromotionMessage> promotionMessages, Offer offer);
 
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.io.Serializable;
-import java.util.Date;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -37,6 +27,16 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.io.Serializable;
+import java.util.Date;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -47,7 +47,7 @@ public class RatingDetailImpl implements RatingDetail, Serializable {
     @GeneratedValue(generator = "RatingDetailId")
     @GenericGenerator(
         name="RatingDetailId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="RatingDetailImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.RatingDetailImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingDetailImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -38,20 +28,33 @@ import org.hibernate.annotations.Parameter;
 import java.io.Serializable;
 import java.util.Date;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_RATING_DETAIL", indexes = {@Index(name = "RATING_CUSTOMER_INDEX", columnList = "CUSTOMER_ID")})
+@Table(name = "BLC_RATING_DETAIL",
+        indexes = {@Index(name = "RATING_CUSTOMER_INDEX", columnList = "CUSTOMER_ID")})
 public class RatingDetailImpl implements RatingDetail, Serializable {
 
     @Id
     @GeneratedValue(generator = "RatingDetailId")
     @GenericGenerator(
-        name="RatingDetailId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="RatingDetailImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.RatingDetailImpl")
-        }
+            name = "RatingDetailId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "RatingDetailImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.rating.domain.RatingDetailImpl")
+            }
     )
     @Column(name = "RATING_DETAIL_ID")
     private Long id;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/RatingSummaryImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -48,7 +48,8 @@ import jakarta.persistence.Table;
         @Index(name = "RATINGSUMM_ITEM_INDEX", columnList = "ITEM_ID"),
         @Index(name = "RATINGSUMM_TYPE_INDEX", columnList = "RATING_TYPE")
 })
-@AdminPresentationClass(friendlyName = "RatingSummary", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@AdminPresentationClass(friendlyName = "RatingSummary",
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 public class RatingSummaryImpl implements RatingSummary, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -56,12 +57,13 @@ public class RatingSummaryImpl implements RatingSummary, Serializable {
     @Id
     @GeneratedValue(generator = "RatingSummaryId")
     @GenericGenerator(
-        name="RatingSummaryId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="RatingSummaryImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.RatingSummaryImpl")
-        }
+            name = "RatingSummaryId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "RatingSummaryImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.rating.domain.RatingSummaryImpl")
+            }
     )
     @Column(name = "RATING_SUMMARY_ID")
     protected Long id;
@@ -72,20 +74,22 @@ public class RatingSummaryImpl implements RatingSummary, Serializable {
 
     @Column(name = "RATING_TYPE", nullable = false)
     @AdminPresentation(friendlyName = "RatingSummary_ratingType",
-        prominent = true,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.RatingType")
+            prominent = true,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.RatingType")
     protected String ratingTypeStr;
 
     @Column(name = "AVERAGE_RATING", nullable = false)
     @AdminPresentation(friendlyName = "RatingSummary_averageRating", prominent = true)
     protected Double averageRating = 0.0;
 
-    @OneToMany(mappedBy = "ratingSummary", targetEntity = RatingDetailImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "ratingSummary", targetEntity = RatingDetailImpl.class,
+            cascade = {CascadeType.ALL})
     @AdminPresentationCollection(friendlyName = "RatingSummary_ratings")
     protected List<RatingDetail> ratings = new ArrayList<RatingDetail>();
 
-    @OneToMany(mappedBy = "ratingSummary", targetEntity = ReviewDetailImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "ratingSummary", targetEntity = ReviewDetailImpl.class,
+            cascade = {CascadeType.ALL})
     @AdminPresentationCollection(friendlyName = "RatingSummary_reviews")
     protected List<ReviewDetail> reviews = new ArrayList<ReviewDetail>();
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
@@ -10,26 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
@@ -48,6 +35,20 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_REVIEW_DETAIL", indexes = {
@@ -56,7 +57,8 @@ import java.util.List;
         @Index(name = "REVIEWDETAIL_RATING_INDEX", columnList = "RATING_DETAIL_ID"),
         @Index(name = "REVIEWDETAIL_STATUS_INDEX", columnList = "REVIEW_STATUS")
 })
-@AdminPresentationClass(friendlyName = "ReviewDetail", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@AdminPresentationClass(friendlyName = "ReviewDetail",
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 public class ReviewDetailImpl implements ReviewDetail, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -64,12 +66,13 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
     @Id
     @GeneratedValue(generator = "ReviewDetailId")
     @GenericGenerator(
-        name="ReviewDetailId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ReviewDetailImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.ReviewDetailImpl")
-        }
+            name = "ReviewDetailId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ReviewDetailImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.rating.domain.ReviewDetailImpl")
+            }
     )
     @Column(name = "REVIEW_DETAIL_ID")
     private Long id;
@@ -90,9 +93,9 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
 
     @Column(name = "REVIEW_STATUS", nullable = false)
     @AdminPresentation(friendlyName = "ReviewDetail_status",
-        prominent = true,
-        fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-        broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.ReviewStatusType")
+            prominent = true,
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.core.rating.service.type.ReviewStatusType")
     protected String reviewStatus;
 
     @Column(name = "HELPFUL_COUNT", nullable = false)
@@ -107,7 +110,8 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
     @JoinColumn(name = "RATING_SUMMARY_ID")
     protected RatingSummary ratingSummary;
 
-    @OneToMany(mappedBy = "reviewDetail", targetEntity = ReviewFeedbackImpl.class, cascade = {CascadeType.ALL})
+    @OneToMany(mappedBy = "reviewDetail", targetEntity = ReviewFeedbackImpl.class,
+            cascade = {CascadeType.ALL})
     @AdminPresentationCollection(friendlyName = "ReviewDetail_feedback")
     protected List<ReviewFeedback> reviewFeedback;
 
@@ -119,7 +123,11 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
 
     public ReviewDetailImpl() {}
 
-    public ReviewDetailImpl(Customer customer, Date reivewSubmittedDate, RatingDetail ratingDetail, String reviewText, RatingSummary ratingSummary) {
+    public ReviewDetailImpl(Customer customer,
+            Date reivewSubmittedDate,
+            RatingDetail ratingDetail,
+            String reviewText,
+            RatingSummary ratingSummary) {
         super();
         this.customer = customer;
         this.reivewSubmittedDate = reivewSubmittedDate;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewDetailImpl.java
@@ -17,6 +17,20 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -33,20 +47,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -65,7 +65,7 @@ public class ReviewDetailImpl implements ReviewDetail, Serializable {
     @GeneratedValue(generator = "ReviewDetailId")
     @GenericGenerator(
         name="ReviewDetailId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ReviewDetailImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.ReviewDetailImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.core.rating.domain;
 
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.io.Serializable;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +27,15 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.io.Serializable;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -51,7 +51,7 @@ public class ReviewFeedbackImpl implements ReviewFeedback, Serializable {
     @GeneratedValue(generator = "ReviewFeedbackId")
     @GenericGenerator(
         name="ReviewFeedbackId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ReviewFeedbackImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.ReviewFeedbackImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/domain/ReviewFeedbackImpl.java
@@ -10,12 +10,22 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.rating.domain;
+
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
+import org.broadleafcommerce.profile.core.domain.Customer;
+import org.broadleafcommerce.profile.core.domain.CustomerImpl;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,15 +37,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
-import org.broadleafcommerce.profile.core.domain.Customer;
-import org.broadleafcommerce.profile.core.domain.CustomerImpl;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
-import java.io.Serializable;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -50,19 +51,20 @@ public class ReviewFeedbackImpl implements ReviewFeedback, Serializable {
     @Id
     @GeneratedValue(generator = "ReviewFeedbackId")
     @GenericGenerator(
-        name="ReviewFeedbackId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ReviewFeedbackImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.rating.domain.ReviewFeedbackImpl")
-        }
+            name = "ReviewFeedbackId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ReviewFeedbackImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.rating.domain.ReviewFeedbackImpl")
+            }
     )
     @Column(name = "REVIEW_FEEDBACK_ID")
     protected Long id;
 
     @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
-    @AdminPresentation(friendlyName="ReviewFeedback_customer")
+    @AdminPresentation(friendlyName = "ReviewFeedback_customer")
     @AdminPresentationToOneLookup
     protected Customer customer;
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
@@ -17,11 +17,22 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -34,17 +45,6 @@ import org.hibernate.annotations.Parameter;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -65,7 +65,7 @@ public class CategoryExcludedSearchFacetImpl implements CategoryExcludedSearchFa
     @GeneratedValue(generator = "CategoryExcludedSearchFacetId")
     @GenericGenerator(
         name="CategoryExcludedSearchFacetId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategoryExcludedSearchFacetImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.CategoryExcludedSearchFacetImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategoryExcludedSearchFacetImpl.java
@@ -136,9 +136,9 @@ public class CategoryExcludedSearchFacetImpl implements CategoryExcludedSearchFa
 
         if (sequence != null ? !sequence.equals(that.sequence) : that.sequence != null) return false;
         if (category != null ? !category.equals(that.category) : that.category != null) return false;
-        if (searchFacet != null ? !searchFacet.equals(that.searchFacet) : that.searchFacet != null) return false;
-
-        return true;
+        return searchFacet != null
+                ? searchFacet.equals(that.searchFacet)
+                : that.searchFacet == null;
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
@@ -17,6 +17,16 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -24,6 +34,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -35,17 +46,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -67,7 +67,7 @@ public class CategorySearchFacetImpl implements CategorySearchFacet {
     @GeneratedValue(generator = "CategorySearchFacetId")
     @GenericGenerator(
         name="CategorySearchFacetId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="CategorySearchFacetImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.CategorySearchFacetImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/CategorySearchFacetImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -47,44 +37,57 @@ import org.hibernate.annotations.Parameter;
 
 import java.math.BigDecimal;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CAT_SEARCH_FACET_XREF")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG)
 })
 public class CategorySearchFacetImpl implements CategorySearchFacet {
-    
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "CategorySearchFacetId")
     @GenericGenerator(
-        name="CategorySearchFacetId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="CategorySearchFacetImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.CategorySearchFacetImpl")
-        }
+            name = "CategorySearchFacetId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CategorySearchFacetImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.CategorySearchFacetImpl")
+            }
     )
     @Column(name = "CATEGORY_SEARCH_FACET_ID")
     protected Long id;
-    
+
     @ManyToOne(targetEntity = CategoryImpl.class, cascade = CascadeType.REFRESH)
     @JoinColumn(name = "CATEGORY_ID")
     @AdminPresentation(excluded = true)
     protected Category category;
-    
+
     @ManyToOne(targetEntity = SearchFacetImpl.class)
     @JoinColumn(name = "SEARCH_FACET_ID")
     protected SearchFacet searchFacet;
-    
+
     @Column(name = "SEQUENCE")
     @AdminPresentation(friendlyName = "CategorySearchFacetImpl_sequence")
     protected BigDecimal sequence;
@@ -128,29 +131,30 @@ public class CategorySearchFacetImpl implements CategorySearchFacet {
     public void setSequence(BigDecimal sequence) {
         this.sequence = sequence;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (obj != null && getClass().isAssignableFrom(obj.getClass())) {
             CategorySearchFacetImpl other = (CategorySearchFacetImpl) obj;
             return new EqualsBuilder()
-                .append(category, other.category)
-                .append(searchFacet, other.searchFacet)
-                .build();
+                    .append(category, other.category)
+                    .append(searchFacet, other.searchFacet)
+                    .build();
         }
         return false;
     }
-    
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-            .append(category)
-            .append(searchFacet)
-            .toHashCode();
+                .append(category)
+                .append(searchFacet)
+                .toHashCode();
     }
 
     @Override
-    public <G extends CategorySearchFacet> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CategorySearchFacet> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -45,9 +37,19 @@ import org.hibernate.annotations.Parameter;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_FIELD", indexes = {@Index(name = "ENTITY_TYPE_INDEX", columnList = "ENTITY_TYPE")})
+@Table(name = "BLC_FIELD",
+        indexes = {@Index(name = "ENTITY_TYPE_INDEX", columnList = "ENTITY_TYPE")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
@@ -65,11 +67,13 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "FieldImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.search.domain.FieldImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.FieldImpl")
             }
     )
     @Column(name = "FIELD_ID")
-    @AdminPresentation(friendlyName = "FieldImpl_ID", group = "FieldImpl_general", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "FieldImpl_ID", group = "FieldImpl_general",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     // This is a broadleaf enumeration
@@ -156,7 +160,8 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
 
     @Override
     public void setOverrideGeneratedPropertyName(Boolean overrideGeneratedPropertyName) {
-        this.overrideGeneratedPropertyName = overrideGeneratedPropertyName != null && overrideGeneratedPropertyName;
+        this.overrideGeneratedPropertyName =
+                overrideGeneratedPropertyName != null && overrideGeneratedPropertyName;
     }
 
     @Override
@@ -192,13 +197,15 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
     @Deprecated
     @Override
     public List<SearchConfig> getSearchConfigs() {
-        throw new UnsupportedOperationException("The default Field implementation does not support search configs");
+        throw new UnsupportedOperationException(
+                "The default Field implementation does not support search configs");
     }
 
     @Deprecated
     @Override
     public void setSearchConfigs(List<SearchConfig> searchConfigs) {
-        throw new UnsupportedOperationException("The default Field implementation does not support search configs");
+        throw new UnsupportedOperationException(
+                "The default Field implementation does not support search configs");
     }
 
     @Override
@@ -207,7 +214,8 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
     }
 
     @Override
-    public <G extends Field> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws
+    public <G extends Field> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws
             CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
@@ -235,7 +243,8 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
         }
         Field other = (Field) obj;
 
-        return getEntityType().getType().equals(other.getEntityType().getType()) && getPropertyName().equals(other.getPropertyName());
+        return getEntityType().getType().equals(other.getEntityType().getType())
+                && getPropertyName().equals(other.getPropertyName());
 
     }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/FieldImpl.java
@@ -10,13 +10,21 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -25,6 +33,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -35,15 +44,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.util.List;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -61,17 +61,17 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
     @Id
     @GeneratedValue(generator = "FieldId")
     @GenericGenerator(
-        name="FieldId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="FieldImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.FieldImpl")
-        }
+            name = "FieldId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "FieldImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.search.domain.FieldImpl")
+            }
     )
     @Column(name = "FIELD_ID")
-    @AdminPresentation(friendlyName = "FieldImpl_ID", group = "FieldImpl_general",visibility=VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "FieldImpl_ID", group = "FieldImpl_general", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
+
     // This is a broadleaf enumeration
     @Column(name = "ENTITY_TYPE", nullable = false)
     @AdminPresentation(friendlyName = "FieldImpl_EntityType",
@@ -82,7 +82,7 @@ public class FieldImpl implements Field, FieldAdminPresentation, AdminMainEntity
             defaultValue = "org.broadleafcommerce.core.catalog.domain.ProductImpl",
             requiredOverride = RequiredOverride.REQUIRED)
     protected String entityType;
-    
+
     @Column(name = "FRIENDLY_NAME")
     @AdminPresentation(friendlyName = "FieldImpl_friendlyName",
             group = GroupName.General, order = FieldOrder.FRIENDLY_NAME,

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -25,6 +37,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -39,19 +52,6 @@ import org.hibernate.annotations.Where;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 /**
  * @author Chad Harchar (charchar)
@@ -72,7 +72,7 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
     @GeneratedValue(generator = "IndexFieldId")
     @GenericGenerator(
             name="IndexFieldId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="IndexFieldImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.IndexFieldImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldImpl.java
@@ -10,25 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -53,36 +41,52 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
 /**
  * @author Chad Harchar (charchar)
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_INDEX_FIELD", indexes = {@Index(name = "INDEX_FIELD_SEARCHABLE_INDEX", columnList = "SEARCHABLE")})
+@Table(name = "BLC_INDEX_FIELD",
+        indexes = {@Index(name = "INDEX_FIELD_SEARCHABLE_INDEX", columnList = "SEARCHABLE")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.ARCHIVE_ONLY)
 })
-public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdminPresentation, AdminMainEntity {
+public class IndexFieldImpl
+        implements IndexField, Serializable, IndexFieldAdminPresentation, AdminMainEntity {
 
     private static final long serialVersionUID = 2915813511754425605L;
 
     @Id
     @GeneratedValue(generator = "IndexFieldId")
     @GenericGenerator(
-            name="IndexFieldId",
-            type= IdOverrideTableGenerator.class,
+            name = "IndexFieldId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="IndexFieldImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.IndexFieldImpl")
+                    @Parameter(name = "segment_value", value = "IndexFieldImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.IndexFieldImpl")
             }
     )
     @Column(name = "INDEX_FIELD_ID")
     @AdminPresentation(friendlyName = "IndexFieldImpl_ID", group = "IndexFieldImpl_description",
-            visibility= VisibilityEnum.HIDDEN_ALL)
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
+
     @Column(name = "SEARCHABLE")
     @AdminPresentation(friendlyName = "IndexFieldImpl_searchable",
             defaultValue = "false",
@@ -91,14 +95,17 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
             tooltip = "IndexFieldImpl_searchable_tooltip")
     protected Boolean searchable;
 
-    @ManyToOne(optional=false, targetEntity = FieldImpl.class)
+    @ManyToOne(optional = false, targetEntity = FieldImpl.class)
     @JoinColumn(name = "FIELD_ID")
-    @AdminPresentation(friendlyName = "IndexFieldImpl_field", order = 1000, group = GroupName.General,
+    @AdminPresentation(friendlyName = "IndexFieldImpl_field", order = 1000,
+            group = GroupName.General,
             prominent = true, gridOrder = 1000)
-    @AdminPresentationToOneLookup(lookupDisplayProperty = "friendlyName", customCriteria = { "fieldImplOnly" })
+    @AdminPresentationToOneLookup(lookupDisplayProperty = "friendlyName",
+            customCriteria = {"fieldImplOnly"})
     protected Field field;
 
-    @OneToMany(mappedBy = "indexField", targetEntity = IndexFieldTypeImpl.class, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "indexField", targetEntity = IndexFieldTypeImpl.class,
+            cascade = CascadeType.ALL)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
     @BatchSize(size = 50)
     @Where(clause = "(ARCHIVED != 'Y' OR ARCHIVED IS NULL)")
@@ -124,7 +131,7 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
     public void setSearchable(Boolean searchable) {
         this.searchable = searchable;
     }
-    
+
     @Override
     public Field getField() {
         return field;
@@ -146,7 +153,8 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
     }
 
     @Override
-    public <G extends IndexField> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends IndexField> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -154,7 +162,7 @@ public class IndexFieldImpl implements IndexField, Serializable, IndexFieldAdmin
         IndexField cloned = createResponse.getClone();
         cloned.setSearchable(searchable);
         cloned.setField(field);
-        for(IndexFieldType entry : fieldTypes){
+        for (IndexFieldType entry : fieldTypes) {
             cloned.getFieldTypes().add(entry.createOrRetrieveCopyInstance(context).getClone());
         }
 

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
@@ -10,22 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -51,6 +42,16 @@ import org.hibernate.annotations.Parameter;
 
 import java.io.Serializable;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author Nick Crum (ncrum)
  */
@@ -65,22 +66,43 @@ import java.io.Serializable;
 })
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "indexField.field.friendlyName", mergeEntries = {
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = false),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GRIDORDER, intOverrideValue = 3),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "FORM_HIDDEN"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME, overrideValue = "IndexFieldTypeImpl_indexField"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE, overrideValue = "NOT_REQUIRED" )
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                        booleanOverrideValue = false),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.PROMINENT,
+                        booleanOverrideValue = true),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.GRIDORDER,
+                        intOverrideValue = 3),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                        overrideValue = "FORM_HIDDEN"),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                        overrideValue = "IndexFieldTypeImpl_indexField"),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                        overrideValue = "NOT_REQUIRED")
         }),
         @AdminPresentationMergeOverride(name = "indexField.searchable", mergeEntries = {
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = false),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GRIDORDER, intOverrideValue = 3),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "FORM_HIDDEN"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME, overrideValue = "IndexFieldTypeImpl_searchable")
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                        booleanOverrideValue = false),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.PROMINENT,
+                        booleanOverrideValue = true),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.GRIDORDER,
+                        intOverrideValue = 3),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                        overrideValue = "FORM_HIDDEN"),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                        overrideValue = "IndexFieldTypeImpl_searchable")
         })
 })
-@AdminPresentationClass(friendlyName = "IndexFieldTypeImpl_friendly", populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@AdminPresentationClass(friendlyName = "IndexFieldTypeImpl_friendly",
+        populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 public class IndexFieldTypeImpl implements IndexFieldType, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -88,30 +110,34 @@ public class IndexFieldTypeImpl implements IndexFieldType, Serializable {
     @Id
     @GeneratedValue(generator = "IndexFieldTypeId")
     @GenericGenerator(
-            name="IndexFieldTypeId",
-            type= IdOverrideTableGenerator.class,
+            name = "IndexFieldTypeId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="IndexFieldTypeImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.IndexFieldTypeImpl")
+                    @Parameter(name = "segment_value", value = "IndexFieldTypeImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.IndexFieldTypeImpl")
             }
     )
     @Column(name = "INDEX_FIELD_TYPE_ID")
-    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_ID", group = "IndexFieldTypeTypeImpl_description",
-            visibility= VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_ID",
+            group = "IndexFieldTypeTypeImpl_description",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
+
     @Column(name = "FIELD_TYPE")
-    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_fieldType", group = "IndexFieldTypeImpl_description", order = 4, prominent = true, gridOrder = 4,
+    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_fieldType",
+            group = "IndexFieldTypeImpl_description", order = 4, prominent = true, gridOrder = 4,
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
             broadleafEnumeration = "org.broadleafcommerce.core.search.domain.solr.FieldType",
             requiredOverride = RequiredOverride.REQUIRED,
             defaultValue = "t")
     protected String fieldType;
 
-    @ManyToOne(optional=false, targetEntity = IndexFieldImpl.class)
+    @ManyToOne(optional = false, targetEntity = IndexFieldImpl.class)
     @JoinColumn(name = "INDEX_FIELD_ID")
-    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_indexField", group = "IndexFieldTypeImpl_description",
-            order=3, gridOrder = 3, visibility=VisibilityEnum.FORM_HIDDEN)
+    @AdminPresentation(friendlyName = "IndexFieldTypeImpl_indexField",
+            group = "IndexFieldTypeImpl_description",
+            order = 3, gridOrder = 3, visibility = VisibilityEnum.FORM_HIDDEN)
     @AdminPresentationToOneLookup(lookupDisplayProperty = "field.friendlyName")
     protected IndexField indexField;
 
@@ -124,7 +150,7 @@ public class IndexFieldTypeImpl implements IndexFieldType, Serializable {
     public void setId(Long id) {
         this.id = id;
     }
-    
+
     @Override
     public FieldType getFieldType() {
         return FieldType.getInstance(fieldType);
@@ -146,14 +172,16 @@ public class IndexFieldTypeImpl implements IndexFieldType, Serializable {
     }
 
     @Override
-    public <G extends IndexFieldType> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends IndexFieldType> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
         }
         IndexFieldType indexFieldType = createResponse.getClone();
         if (indexField != null) {
-            indexFieldType.setIndexField(indexField.createOrRetrieveCopyInstance(context).getClone());
+            indexFieldType.setIndexField(
+                    indexField.createOrRetrieveCopyInstance(context).getClone());
         }
 
         if (fieldType != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/IndexFieldTypeImpl.java
@@ -17,11 +17,21 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -40,16 +50,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.io.Serializable;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 /**
  * @author Nick Crum (ncrum)
@@ -89,7 +89,7 @@ public class IndexFieldTypeImpl implements IndexFieldType, Serializable {
     @GeneratedValue(generator = "IndexFieldTypeId")
     @GenericGenerator(
             name="IndexFieldTypeId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="IndexFieldTypeImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.IndexFieldTypeImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
@@ -17,16 +17,6 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,6 +27,16 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * @author Jeff Fischer
@@ -57,7 +57,7 @@ public class RequiredFacetImpl implements RequiredFacet {
     @GeneratedValue(generator= "RequiredFacetId")
     @GenericGenerator(
         name="RequiredFacetId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="RequiredFacetImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.RequiredFacetImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/RequiredFacetImpl.java
@@ -10,23 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
@@ -38,6 +28,17 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 /**
  * @author Jeff Fischer
  */
@@ -46,31 +47,35 @@ import org.hibernate.annotations.Parameter;
 @Table(name = "BLC_SEARCH_FACET_XREF")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
-        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG, skipOverlaps=true)
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX,
+                skipOverlaps = true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_CATALOG,
+                skipOverlaps = true)
 })
 public class RequiredFacetImpl implements RequiredFacet {
 
     protected static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "RequiredFacetId")
+    @GeneratedValue(generator = "RequiredFacetId")
     @GenericGenerator(
-        name="RequiredFacetId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="RequiredFacetImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.RequiredFacetImpl")
-        }
+            name = "RequiredFacetId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "RequiredFacetImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.RequiredFacetImpl")
+            }
     )
     @Column(name = "ID")
     protected Long id;
 
-    @ManyToOne(targetEntity = SearchFacetImpl.class, optional = false, cascade = CascadeType.REFRESH)
+    @ManyToOne(targetEntity = SearchFacetImpl.class, optional = false,
+            cascade = CascadeType.REFRESH)
     @JoinColumn(name = "SEARCH_FACET_ID")
     protected SearchFacet searchFacet;
 
-    @ManyToOne(targetEntity = SearchFacetImpl.class, optional=false)
+    @ManyToOne(targetEntity = SearchFacetImpl.class, optional = false)
     @JoinColumn(name = "REQUIRED_FACET_ID", referencedColumnName = "SEARCH_FACET_ID")
     protected SearchFacet requiredFacet;
 
@@ -105,7 +110,8 @@ public class RequiredFacetImpl implements RequiredFacet {
     }
 
     @Override
-    public <G extends RequiredFacet> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends RequiredFacet> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -117,6 +123,6 @@ public class RequiredFacetImpl implements RequiredFacet {
         if (searchFacet != null) {
             cloned.setSearchFacet(searchFacet);
         }
-        return  createResponse;
+        return createResponse;
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -285,7 +285,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable, AdminMainEnti
 
     @Override
     public Boolean getRequiresAllDependentFacets() {
-        return requiresAllDependentFacets == null ? false : requiresAllDependentFacets;
+        return requiresAllDependentFacets != null && requiresAllDependentFacets;
     }
 
     @Override

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import com.google.common.base.Strings;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -26,6 +38,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationAdornedTargetCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
@@ -44,23 +57,9 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Where;
 
-import com.google.common.base.Strings;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 
 @Entity
@@ -98,7 +97,7 @@ public class SearchFacetImpl implements SearchFacet, Serializable, AdminMainEnti
     @GeneratedValue(generator = "SearchFacetId")
     @GenericGenerator(
         name="SearchFacetId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SearchFacetImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchFacetImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -57,20 +57,35 @@ import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_SEARCH_FACET_RANGE", indexes = {@Index(name = "SEARCH_FACET_INDEX", columnList = "SEARCH_FACET_ID")})
+@Table(name = "BLC_SEARCH_FACET_RANGE",
+        indexes = {@Index(name = "SEARCH_FACET_INDEX", columnList = "SEARCH_FACET_ID")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @AdminPresentationMergeOverrides(value = {
         @AdminPresentationMergeOverride(
                 name = "priceList.friendlyName",
                 mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME, overrideValue = "PriceListImpl_Friendly_Name"),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = false),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.ORDER, intOverrideValue = 1),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GRIDORDER, intOverrideValue = 1),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = "SearchFacetRangeImpl_Description"),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "FORM_HIDDEN")
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                                overrideValue = "PriceListImpl_Friendly_Name"),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                                booleanOverrideValue = false),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.ORDER,
+                                intOverrideValue = 1),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.GRIDORDER,
+                                intOverrideValue = 1),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.GROUP,
+                                overrideValue = "SearchFacetRangeImpl_Description"),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.PROMINENT,
+                                booleanOverrideValue = true),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                                overrideValue = "FORM_HIDDEN")
                 }
         )
 })
@@ -90,7 +105,8 @@ public class SearchFacetRangeImpl implements SearchFacetRange, Serializable {
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "SearchFacetRangeImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.search.domain.SearchFacetRangeImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.SearchFacetRangeImpl")
             })
     @Column(name = "SEARCH_FACET_RANGE_ID")
     protected Long id;
@@ -101,17 +117,21 @@ public class SearchFacetRangeImpl implements SearchFacetRange, Serializable {
     protected SearchFacet searchFacet = new SearchFacetImpl();
 
     @Column(name = "MIN_VALUE", precision = 19, scale = 5, nullable = false)
-    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_minValue", order = 3, gridOrder = 10, group = "SearchFacetRangeImpl_Description", prominent = true)
+    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_minValue", order = 3, gridOrder = 10,
+            group = "SearchFacetRangeImpl_Description", prominent = true)
     protected BigDecimal minValue;
 
     @Column(name = "MAX_VALUE", precision = 19, scale = 5)
-    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_maxValue", order = 4, gridOrder = 11, group = "SearchFacetRangeImpl_Description", prominent = true, validationConfigurations = {
-            @ValidationConfiguration(
-                    validationImplementation = "blMaxGreaterThanMinValidator",
-                    configurationItems = {
-                            @ConfigurationItem(itemName = "otherField", itemValue = "minValue")
-                    })
-    })
+    @AdminPresentation(friendlyName = "SearchFacetRangeImpl_maxValue", order = 4, gridOrder = 11,
+            group = "SearchFacetRangeImpl_Description", prominent = true,
+            validationConfigurations = {
+                    @ValidationConfiguration(
+                            validationImplementation = "blMaxGreaterThanMinValidator",
+                            configurationItems = {
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "minValue")
+                            })
+            })
     protected BigDecimal maxValue;
 
     @Override
@@ -177,7 +197,8 @@ public class SearchFacetRangeImpl implements SearchFacetRange, Serializable {
     }
 
     @Override
-    public <G extends SearchFacetRange> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends SearchFacetRange> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchInterceptImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchInterceptImpl.java
@@ -10,16 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.core.search.redirect.domain.SearchRedirectImpl;
 import org.hibernate.annotations.Cache;
@@ -28,31 +25,36 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
 
 /**
  * @deprecated Replaced in functionality by {@link SearchRedirectImpl}
  */
 @Deprecated
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
 public class SearchInterceptImpl implements SearchIntercept {
-    
+
     @Id
     @GeneratedValue(generator = "SearchInterceptId")
     @GenericGenerator(
-        name="SearchInterceptId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SearchInterceptImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchInterceptImpl")
-        }
+            name = "SearchInterceptId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SearchInterceptImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.SearchInterceptImpl")
+            }
     )
     @Column(name = "SEARCH_INTERCEPT_ID")
     protected Long id;
-    
+
     @Column(name = "TERM")
-    @Index(name="SEARCHINTERCEPT_TERM_INDEX", columnNames={"TERM"})
+    @Index(name = "SEARCHINTERCEPT_TERM_INDEX", columnNames = {"TERM"})
     private String term;
-    
+
     @Column(name = "REDIRECT")
     private String redirect;
 
@@ -63,6 +65,7 @@ public class SearchInterceptImpl implements SearchIntercept {
     public String getTerm() {
         return term;
     }
+
     /* (non-Javadoc)
      * @see org.broadleafcommerce.core.search.domain.SearchIntercept#setTerm(java.lang.String)
      */
@@ -70,6 +73,7 @@ public class SearchInterceptImpl implements SearchIntercept {
     public void setTerm(String term) {
         this.term = term;
     }
+
     /* (non-Javadoc)
      * @see org.broadleafcommerce.core.search.domain.SearchIntercept#getRedirect()
      */
@@ -77,6 +81,7 @@ public class SearchInterceptImpl implements SearchIntercept {
     public String getRedirect() {
         return redirect;
     }
+
     /* (non-Javadoc)
      * @see org.broadleafcommerce.core.search.domain.SearchIntercept#setRedirect(java.lang.String)
      */
@@ -84,9 +89,11 @@ public class SearchInterceptImpl implements SearchIntercept {
     public void setRedirect(String redirect) {
         this.redirect = redirect;
     }
+
     public Long getId() {
         return id;
     }
+
     public void setId(Long id) {
         this.id = id;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchInterceptImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchInterceptImpl.java
@@ -17,16 +17,16 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.core.search.redirect.domain.SearchRedirectImpl;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
 
 
 /**
@@ -40,7 +40,7 @@ public class SearchInterceptImpl implements SearchIntercept {
     @GeneratedValue(generator = "SearchInterceptId")
     @GenericGenerator(
         name="SearchInterceptId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SearchInterceptImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchInterceptImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
@@ -17,18 +17,18 @@
  */
 package org.broadleafcommerce.core.search.domain;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import org.apache.commons.lang3.StringUtils;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Table(name = "BLC_SEARCH_SYNONYM")
@@ -39,7 +39,7 @@ public class SearchSynonymImpl implements SearchSynonym {
     @GeneratedValue(generator = "SearchSynonymId")
     @GenericGenerator(
         name="SearchSynonymId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SearchSynonymImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchSynonymImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchSynonymImpl.java
@@ -10,18 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.hibernate.annotations.Cache;
@@ -30,52 +25,64 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Parameter;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
 @Entity
 @Table(name = "BLC_SEARCH_SYNONYM")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 public class SearchSynonymImpl implements SearchSynonym {
-    
+
     @Id
     @GeneratedValue(generator = "SearchSynonymId")
     @GenericGenerator(
-        name="SearchSynonymId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SearchSynonymImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.domain.SearchSynonymImpl")
-        }
+            name = "SearchSynonymId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SearchSynonymImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.domain.SearchSynonymImpl")
+            }
     )
     @Column(name = "SEARCH_SYNONYM_ID")
     private Long id;
-    
+
     @Column(name = "TERM")
-    @Index(name="SEARCHSYNONYM_TERM_INDEX", columnNames={"TERM"})
+    @Index(name = "SEARCHSYNONYM_TERM_INDEX", columnNames = {"TERM"})
     private String term;
-    
+
     @Column(name = "SYNONYMS")
     private String synonyms;
-    
+
     public Long getId() {
         return id;
     }
+
     public void setId(Long id) {
         this.id = id;
     }
+
     @Override
     public String getTerm() {
         return term;
     }
+
     @Override
     public void setTerm(String term) {
         this.term = term;
     }
+
     @Override
     public String[] getSynonyms() {
         return synonyms.split("\\|");
     }
+
     @Override
     public void setSynonyms(String[] synonyms) {
         this.synonyms = StringUtils.join(synonyms, '|');
     }
-    
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
@@ -10,22 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.search.redirect.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
@@ -47,53 +38,67 @@ import org.hibernate.annotations.Parameter;
 
 import java.util.Date;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
 /**
  * @author priyeshpatel
- * 
  */
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_SEARCH_INTERCEPT", indexes = {@Index(name = "SEARCH_ACTIVE_INDEX", columnList = "ACTIVE_START_DATE, ACTIVE_END_DATE")})
+@Table(name = "BLC_SEARCH_INTERCEPT", indexes = {
+        @Index(name = "SEARCH_ACTIVE_INDEX", columnList = "ACTIVE_START_DATE, ACTIVE_END_DATE")})
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blSearchElements")
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.AUDITABLE_ONLY)
 })
-public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable, AdminMainEntity, SearchRedirectAdminPresentation {
-    
+public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable, AdminMainEntity,
+        SearchRedirectAdminPresentation {
+
     private static final long serialVersionUID = 1L;
-    
+
     @Transient
     private static final Log LOG = LogFactory.getLog(SearchRedirectImpl.class);
-    
+
     @Id
     @GeneratedValue(generator = "SearchRedirectID")
     @GenericGenerator(
-        name="SearchRedirectID",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="SearchRedirectImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.redirect.domain.SearchRedirectImpl")
-        }
+            name = "SearchRedirectID",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "SearchRedirectImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.search.redirect.domain.SearchRedirectImpl")
+            }
     )
     @Column(name = "SEARCH_REDIRECT_ID")
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
-    
+
     @Column(name = "PRIORITY")
     @AdminPresentation(excluded = true)
     protected Integer searchPriority;
 
-    @AdminPresentation(friendlyName = "SearchRedirectImpl_searchTerm", order = 1000, group = GroupName.General, prominent = true, groupOrder = 1, defaultValue = "")
+    @AdminPresentation(friendlyName = "SearchRedirectImpl_searchTerm", order = 1000,
+            group = GroupName.General, prominent = true, groupOrder = 1, defaultValue = "")
     @Column(name = "SEARCH_TERM", nullable = false)
     protected String searchTerm;
-    
+
     @Column(name = "URL", nullable = false)
-    @AdminPresentation(friendlyName = "SearchRedirectImpl_url", order = 2000, group = GroupName.General, prominent = true, groupOrder = 1, defaultValue = "")
+    @AdminPresentation(friendlyName = "SearchRedirectImpl_url", order = 2000,
+            group = GroupName.General, prominent = true, groupOrder = 1, defaultValue = "")
     protected String url;
 
     /** The active start date. */
-    @Column(name = "ACTIVE_START_DATE" )
+    @Column(name = "ACTIVE_START_DATE")
     @AdminPresentation(friendlyName = "SkuImpl_Sku_Start_Date",
             order = 3000, group = GroupName.Dates,
             tooltip = "skuStartDateTooltip", groupOrder = 1,
@@ -110,11 +115,12 @@ public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable,
                     @ValidationConfiguration(
                             validationImplementation = "blAfterStartDateValidator",
                             configurationItems = {
-                                    @ConfigurationItem(itemName = "otherField", itemValue = "activeStartDate")
+                                    @ConfigurationItem(itemName = "otherField",
+                                            itemValue = "activeStartDate")
                             })
             })
     protected Date activeEndDate;
-    
+
     @Override
     public Date getActiveStartDate() {
         return activeStartDate;
@@ -164,7 +170,7 @@ public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable,
     public void setUrl(String url) {
         this.url = url;
     }
-    
+
     @Override
     public Integer getSearchPriority() {
         return searchPriority;
@@ -178,13 +184,16 @@ public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable,
     @Override
     public boolean isActive() {
         Long date = SystemTime.asMillis(true);
-        boolean isNullActiveStartDateActive = BLCSystemProperty.resolveBooleanSystemProperty("searchRedirect.is.null.activeStartDate.active");
+        boolean isNullActiveStartDateActive = BLCSystemProperty.resolveBooleanSystemProperty(
+                "searchRedirect.is.null.activeStartDate.active");
 
         boolean isActive;
         if (isNullActiveStartDateActive) {
-            isActive = (getActiveStartDate() == null || getActiveStartDate().getTime() <= date) && (getActiveEndDate() == null || getActiveEndDate().getTime() > date);
+            isActive = (getActiveStartDate() == null || getActiveStartDate().getTime() <= date) && (
+                    getActiveEndDate() == null || getActiveEndDate().getTime() > date);
         } else {
-            isActive = (getActiveStartDate() != null && getActiveStartDate().getTime() <= date) && (getActiveEndDate() == null || getActiveEndDate().getTime() > date);
+            isActive = (getActiveStartDate() != null && getActiveStartDate().getTime() <= date) && (
+                    getActiveEndDate() == null || getActiveEndDate().getTime() > date);
         }
 
         if (LOG.isDebugEnabled() && !isActive) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/redirect/domain/SearchRedirectImpl.java
@@ -17,12 +17,22 @@
  */
 package org.broadleafcommerce.core.search.redirect.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.ConfigurationItem;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
@@ -36,16 +46,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
 import java.util.Date;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 
 /**
  * @author priyeshpatel
@@ -70,7 +70,7 @@ public class SearchRedirectImpl implements SearchRedirect, java.io.Serializable,
     @GeneratedValue(generator = "SearchRedirectID")
     @GenericGenerator(
         name="SearchRedirectID",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="SearchRedirectImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.core.search.redirect.domain.SearchRedirectImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
@@ -17,7 +17,19 @@
  */
 package org.broadleafcommerce.core.store.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -31,18 +43,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "BLC_STORE")
@@ -58,7 +58,7 @@ public class StoreImpl implements Store {
     @GeneratedValue(generator= "StoreId")
     @GenericGenerator(
             name="StoreId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="StoreImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.core.store.domain.StoreImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/store/domain/StoreImpl.java
@@ -10,24 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.store.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
@@ -44,24 +33,38 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
 @Table(name = "BLC_STORE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStoreElements")
-@SQLDelete(sql="UPDATE BLC_STORE SET ARCHIVED = 'Y' WHERE STORE_ID = ?")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "StoreImpl_baseStore")
+@SQLDelete(sql = "UPDATE BLC_STORE SET ARCHIVED = 'Y' WHERE STORE_ID = ?")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "StoreImpl_baseStore")
 @Inheritance(strategy = InheritanceType.JOINED)
 public class StoreImpl implements Store {
 
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(generator= "StoreId")
+    @GeneratedValue(generator = "StoreId")
     @GenericGenerator(
-            name="StoreId",
-            type= IdOverrideTableGenerator.class,
+            name = "StoreId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="StoreImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.core.store.domain.StoreImpl")
+                    @Parameter(name = "segment_value", value = "StoreImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.core.store.domain.StoreImpl")
             }
     )
     @Column(name = "STORE_ID", nullable = false)
@@ -74,7 +77,7 @@ public class StoreImpl implements Store {
             prominent = true, gridOrder = 1, columnWidth = "200px",
             requiredOverride = RequiredOverride.REQUIRED)
     protected String name;
-    
+
     @Column(name = "STORE_NUMBER")
     @AdminPresentation(friendlyName = "StoreImpl_Store_Number")
     protected String storeNumber;
@@ -94,17 +97,19 @@ public class StoreImpl implements Store {
     @Column(name = "LATITUDE")
     @AdminPresentation(friendlyName = "StoreImpl_lat", order = Presentation.FieldOrder.LATITUDE,
             tab = Presentation.Tab.Name.Advanced, tabOrder = Presentation.Tab.Order.Advanced,
-            group = Presentation.Group.Name.Geocoding, groupOrder = Presentation.Group.Order.Geocoding,
+            group = Presentation.Group.Name.Geocoding,
+            groupOrder = Presentation.Group.Order.Geocoding,
             gridOrder = 9, columnWidth = "200px")
     protected Double latitude;
 
     @Column(name = "LONGITUDE")
     @AdminPresentation(friendlyName = "StoreImpl_lng", order = Presentation.FieldOrder.LONGITUDE,
             tab = Presentation.Tab.Name.Advanced, tabOrder = Presentation.Tab.Order.Advanced,
-            group = Presentation.Group.Name.Geocoding, groupOrder = Presentation.Group.Order.Geocoding,
+            group = Presentation.Group.Name.Geocoding,
+            groupOrder = Presentation.Group.Order.Geocoding,
             gridOrder = 10, columnWidth = "200px")
     protected Double longitude;
-    
+
     @Embedded
     protected ArchiveStatus archiveStatus = new ArchiveStatus();
 
@@ -157,7 +162,7 @@ public class StoreImpl implements Store {
     public void setLatitude(Double latitude) {
         this.latitude = latitude;
     }
-    
+
     @Override
     public String getStoreNumber() {
         return storeNumber;
@@ -190,13 +195,13 @@ public class StoreImpl implements Store {
 
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -209,7 +214,7 @@ public class StoreImpl implements Store {
 
     @Override
     public boolean isActive() {
-        return 'Y'!=getArchived();
+        return 'Y' != getArchived();
     }
 
     public static class Presentation {
@@ -220,10 +225,12 @@ public class StoreImpl implements Store {
 
             }
 
+
             public static class Order {
                 public static final int Advanced = 7000;
             }
         }
+
 
         public static class Group {
             public static class Name {
@@ -232,12 +239,14 @@ public class StoreImpl implements Store {
                 public static final String Geocoding = "StoreImpl_Store_Geocoding";
             }
 
+
             public static class Order {
                 public static final int General = 1000;
                 public static final int Location = 2000;
                 public static final int Geocoding = 3000;
             }
         }
+
 
         public static class FieldOrder {
             public static final int NAME = 1000;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/domain/CodeTypeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/domain/CodeTypeImpl.java
@@ -10,17 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.core.util.domain;
-
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -30,11 +25,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Table(name = "BLC_CODE_TYPES")
-@Inheritance(strategy=InheritanceType.JOINED)
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE, region="blStandardElements")
+@Inheritance(strategy = InheritanceType.JOINED)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blStandardElements")
 @Deprecated
 public class CodeTypeImpl implements CodeType {
 
@@ -43,20 +43,20 @@ public class CodeTypeImpl implements CodeType {
     @Id
     @GeneratedValue(generator = "CodeTypeId", strategy = GenerationType.TABLE)
     @GenericGenerator(
-        name="CodeTypeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CodeTypeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.core.util.domain.CodeTypeImpl")
-        }
+            name = "CodeTypeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CodeTypeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.core.util.domain.CodeTypeImpl")
+            }
     )
     @Column(name = "CODE_ID")
     protected Long id;
 
-    @Column(name = "CODE_TYPE", nullable=false)
+    @Column(name = "CODE_TYPE", nullable = false)
     protected String codeType;
 
-    @Column(name = "CODE_KEY", nullable=false)
+    @Column(name = "CODE_KEY", nullable = false)
     protected String key;
 
     @Column(name = "CODE_DESC")
@@ -107,7 +107,7 @@ public class CodeTypeImpl implements CodeType {
 
     @Override
     public Boolean isModifiable() {
-        if(modifiable == null)
+        if (modifiable == null)
             return null;
         return modifiable == 'Y' ? Boolean.TRUE : Boolean.FALSE;
     }
@@ -119,7 +119,7 @@ public class CodeTypeImpl implements CodeType {
 
     @Override
     public void setModifiable(Boolean modifiable) {
-        if(modifiable == null) {
+        if (modifiable == null) {
             this.modifiable = null;
         } else {
             this.modifiable = modifiable ? 'Y' : 'N';
@@ -177,6 +177,6 @@ public class CodeTypeImpl implements CodeType {
             return false;
         return true;
     }
-    
-    
+
+
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/domain/CodeTypeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/domain/CodeTypeImpl.java
@@ -171,11 +171,9 @@ public class CodeTypeImpl implements CodeType {
         } else if (!key.equals(other.key))
             return false;
         if (modifiable == null) {
-            if (other.modifiable != null)
-                return false;
-        } else if (!modifiable.equals(other.modifiable))
-            return false;
-        return true;
+            return other.modifiable == null;
+        } else
+            return modifiable.equals(other.modifiable);
     }
 
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
@@ -17,10 +17,23 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.i18n.domain.ISOCountry;
 import org.broadleafcommerce.common.i18n.domain.ISOCountryImpl;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -35,19 +48,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity
 @EntityListeners(value = {TemporalTimestampListener.class})
@@ -113,7 +113,7 @@ public class AddressImpl implements Address {
     @GeneratedValue(generator = "AddressId")
     @GenericGenerator(
         name="AddressId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="AddressImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.AddressImpl")

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
@@ -10,25 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.i18n.domain.ISOCountry;
@@ -48,6 +36,19 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
 @EntityListeners(value = {TemporalTimestampListener.class})
@@ -74,27 +75,33 @@ import org.hibernate.annotations.Parameter;
                         booleanOverrideValue = false),
                 @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.ORDER,
                         intOverrideValue = 1300),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
                         overrideValue = "NOT_REQUIRED"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
                         overrideValue = "PhoneImpl_Primary_Phone")}),
         @AdminPresentationMergeOverride(name = "phoneSecondary.phoneNumber", mergeEntries = {
                 @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
                         booleanOverrideValue = false),
                 @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.ORDER,
                         intOverrideValue = 1400),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
                         overrideValue = "NOT_REQUIRED"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
                         overrideValue = "PhoneImpl_Secondary_Phone")}),
         @AdminPresentationMergeOverride(name = "phoneFax.phoneNumber", mergeEntries = {
                 @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
                         booleanOverrideValue = false),
                 @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.ORDER,
                         intOverrideValue = 1500),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.REQUIREDOVERRIDE,
                         overrideValue = "NOT_REQUIRED"),
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.FRIENDLYNAME,
                         overrideValue = "PhoneImpl_Fax_Phone")}),
         @AdminPresentationMergeOverride(name = "state", mergeEntries =
         @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
@@ -104,7 +111,8 @@ import org.hibernate.annotations.Parameter;
                 booleanOverrideValue = true))
 })
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
-@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE, friendlyName = "AddressImpl_baseAddress")
+@AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE,
+        friendlyName = "AddressImpl_baseAddress")
 public class AddressImpl implements Address {
 
     private static final long serialVersionUID = 1L;
@@ -112,136 +120,168 @@ public class AddressImpl implements Address {
     @Id
     @GeneratedValue(generator = "AddressId")
     @GenericGenerator(
-        name="AddressId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="AddressImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.AddressImpl")
-        }
+            name = "AddressId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "AddressImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.AddressImpl")
+            }
     )
     @Column(name = "ADDRESS_ID")
     protected Long id;
 
     @Column(name = "FULL_NAME")
-    @AdminPresentation(friendlyName = "AddressImpl_Full_Name", order=10, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Full_Name", order = 10,
+            group = "AddressImpl_Address")
     protected String fullName;
 
     @Column(name = "FIRST_NAME")
-    @AdminPresentation(friendlyName = "AddressImpl_First_Name", order=10, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_First_Name", order = 10,
+            group = "AddressImpl_Address")
     protected String firstName;
 
     @Column(name = "LAST_NAME")
-    @AdminPresentation(friendlyName = "AddressImpl_Last_Name", order=20, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Last_Name", order = 20,
+            group = "AddressImpl_Address")
     protected String lastName;
 
     @Column(name = "EMAIL_ADDRESS")
-    @AdminPresentation(friendlyName = "AddressImpl_Email_Address", order=30, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Email_Address", order = 30,
+            group = "AddressImpl_Address")
     protected String emailAddress;
 
     @Column(name = "COMPANY_NAME")
-    @AdminPresentation(friendlyName = "AddressImpl_Company_Name", order=40, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Company_Name", order = 40,
+            group = "AddressImpl_Address")
     protected String companyName;
 
     @Column(name = "ADDRESS_LINE1", nullable = false)
-    @AdminPresentation(friendlyName = "AddressImpl_Address_1", order=50, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Address_1", order = 50,
+            group = "AddressImpl_Address")
     protected String addressLine1;
 
     @Column(name = "ADDRESS_LINE2")
-    @AdminPresentation(friendlyName = "AddressImpl_Address_2", order=60, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Address_2", order = 60,
+            group = "AddressImpl_Address")
     protected String addressLine2;
 
     @Column(name = "ADDRESS_LINE3")
-    @AdminPresentation(friendlyName = "AddressImpl_Address_3", order = 60, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Address_3", order = 60,
+            group = "AddressImpl_Address")
     protected String addressLine3;
 
     @Column(name = "CITY", nullable = false)
-    @AdminPresentation(friendlyName = "AddressImpl_City", order=70, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_City", order = 70, group = "AddressImpl_Address")
     protected String city;
 
     @Column(name = "ISO_COUNTRY_SUB")
-    @AdminPresentation(friendlyName = "AddressImpl_Country_Subdivision", order=110, group = "AddressImpl_Address",
-                        tooltip = "AddressImpl_Country_Subdivision_ToolTip")
+    @AdminPresentation(friendlyName = "AddressImpl_Country_Subdivision", order = 110,
+            group = "AddressImpl_Address",
+            tooltip = "AddressImpl_Country_Subdivision_ToolTip")
     protected String isoCountrySubdivision;
 
     @Column(name = "SUB_STATE_PROV_REG")
-    @AdminPresentation(friendlyName = "AddressImpl_State_Province_Region", order=80, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_State_Province_Region", order = 80,
+            group = "AddressImpl_Address")
     protected String stateProvinceRegion;
 
     @Column(name = "COUNTY")
-    @AdminPresentation(friendlyName = "AddressImpl_County", order=90, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_County", order = 90,
+            group = "AddressImpl_Address")
     protected String county;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = ISOCountryImpl.class)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            targetEntity = ISOCountryImpl.class)
     @JoinColumn(name = "ISO_COUNTRY_ALPHA2")
-    @AdminPresentation(friendlyName = "AddressImpl_Country_Alpha2", order=100, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Country_Alpha2", order = 100,
+            group = "AddressImpl_Address")
     @AdminPresentationToOneLookup
     protected ISOCountry isoCountryAlpha2;
 
     @Column(name = "POSTAL_CODE")
-    @AdminPresentation(friendlyName = "AddressImpl_Postal_Code", order=120, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Postal_Code", order = 120,
+            group = "AddressImpl_Address")
     protected String postalCode;
 
     @Column(name = "ZIP_FOUR")
-    @AdminPresentation(friendlyName = "AddressImpl_Four_Digit_Zip", order=130, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Four_Digit_Zip", order = 130,
+            group = "AddressImpl_Address")
     protected String zipFour;
 
-    @ManyToOne(targetEntity = PhoneImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
+    @ManyToOne(targetEntity = PhoneImpl.class,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
     @JoinColumn(name = "PHONE_PRIMARY_ID")
     protected Phone phonePrimary;
 
-    @ManyToOne(targetEntity = PhoneImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
+    @ManyToOne(targetEntity = PhoneImpl.class,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
     @JoinColumn(name = "PHONE_SECONDARY_ID")
     protected Phone phoneSecondary;
 
-    @ManyToOne(targetEntity = PhoneImpl.class, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
+    @ManyToOne(targetEntity = PhoneImpl.class,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH})
     @JoinColumn(name = "PHONE_FAX_ID")
     protected Phone phoneFax;
 
     @Column(name = "IS_DEFAULT")
-    @AdminPresentation(friendlyName = "AddressImpl_Default_Address", order=160, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Default_Address", order = 160,
+            group = "AddressImpl_Address")
     protected boolean isDefault = false;
 
     @Column(name = "IS_ACTIVE")
-    @AdminPresentation(friendlyName = "AddressImpl_Active_Address", order=170, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Active_Address", order = 170,
+            group = "AddressImpl_Address")
     protected boolean isActive = true;
 
     @Column(name = "IS_BUSINESS")
-    @AdminPresentation(friendlyName = "AddressImpl_Business_Address", order=180, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Business_Address", order = 180,
+            group = "AddressImpl_Address")
     protected boolean isBusiness = false;
 
     /**
-     * Intended to be used to differentiate whether this address is a physical address (e.g. street/house) or a mailing address (e.g. P.O. Box etc..)
+     * Intended to be used to differentiate whether this address is a physical address (e.g.
+     * street/house) or a mailing address (e.g. P.O. Box etc..)
      */
     @Column(name = "IS_STREET")
-    @AdminPresentation(friendlyName = "AddressImpl_Street_Address", order=220, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Street_Address", order = 220,
+            group = "AddressImpl_Address")
     protected boolean isStreet = false;
 
     /**
-     * Intended to be used to differentiate whether this address is a physical address (e.g. street/house) or a mailing address (e.g. P.O. Box etc..)
+     * Intended to be used to differentiate whether this address is a physical address (e.g.
+     * street/house) or a mailing address (e.g. P.O. Box etc..)
      */
     @Column(name = "IS_MAILING")
-    @AdminPresentation(friendlyName = "AddressImpl_Mailing_Address", order=230, group = "AddressImpl_Address")
+    @AdminPresentation(friendlyName = "AddressImpl_Mailing_Address", order = 230,
+            group = "AddressImpl_Address")
     protected boolean isMailing = false;
 
     /**
-     * This is intented to be used for address verification integrations and should not be modifiable in the admin
+     * This is intented to be used for address verification integrations and should not be
+     * modifiable in the admin
      */
     @Column(name = "TOKENIZED_ADDRESS")
-    @AdminPresentation(friendlyName = "AddressImpl_Tokenized_Address", order=190, group = "AddressImpl_Address", visibility=VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AddressImpl_Tokenized_Address", order = 190,
+            group = "AddressImpl_Address", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String tokenizedAddress;
-    
+
     /**
-     * This is intented to be used for address verification integrations and should not be modifiable in the admin
+     * This is intented to be used for address verification integrations and should not be
+     * modifiable in the admin
      */
     @Column(name = "STANDARDIZED")
-    @AdminPresentation(friendlyName = "AddressImpl_Standardized", order=200, group = "AddressImpl_Address", visibility=VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AddressImpl_Standardized", order = 200,
+            group = "AddressImpl_Address", visibility = VisibilityEnum.HIDDEN_ALL)
     protected Boolean standardized = Boolean.FALSE;
 
     /**
-     * This is intented to be used for address verification integrations and should not be modifiable in the admin
+     * This is intented to be used for address verification integrations and should not be
+     * modifiable in the admin
      */
     @Column(name = "VERIFICATION_LEVEL")
-    @AdminPresentation(friendlyName = "AddressImpl_Verification_Level", order=210, group = "AddressImpl_Address", visibility=VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "AddressImpl_Verification_Level", order = 210,
+            group = "AddressImpl_Address", visibility = VisibilityEnum.HIDDEN_ALL)
     protected String verificationLevel;
 
     @Column(name = "PRIMARY_PHONE")
@@ -486,7 +526,7 @@ public class AddressImpl implements Address {
     public Phone getPhonePrimary() {
         Phone legacyPhone = new PhoneImpl();
         legacyPhone.setPhoneNumber(this.primaryPhone);
-        return (phonePrimary == null && this.primaryPhone !=null)? legacyPhone : phonePrimary;
+        return (phonePrimary == null && this.primaryPhone != null) ? legacyPhone : phonePrimary;
     }
 
     @Override
@@ -498,7 +538,9 @@ public class AddressImpl implements Address {
     public Phone getPhoneSecondary() {
         Phone legacyPhone = new PhoneImpl();
         legacyPhone.setPhoneNumber(this.secondaryPhone);
-        return (phoneSecondary == null && this.secondaryPhone !=null)? legacyPhone : phoneSecondary;
+        return (phoneSecondary == null && this.secondaryPhone != null)
+                ? legacyPhone
+                : phoneSecondary;
     }
 
     @Override
@@ -510,7 +552,7 @@ public class AddressImpl implements Address {
     public Phone getPhoneFax() {
         Phone legacyPhone = new PhoneImpl();
         legacyPhone.setPhoneNumber(this.fax);
-        return (phoneFax == null && this.fax != null)? legacyPhone : phoneFax;
+        return (phoneFax == null && this.fax != null) ? legacyPhone : phoneFax;
     }
 
     @Override
@@ -660,13 +702,18 @@ public class AddressImpl implements Address {
         result = prime * result + ((firstName == null) ? 0 : firstName.hashCode());
         result = prime * result + ((lastName == null) ? 0 : lastName.hashCode());
         result = prime * result + ((postalCode == null) ? 0 : postalCode.hashCode());
-        result = prime * result + ((isoCountrySubdivision == null) ? 0 : isoCountrySubdivision.hashCode());
-        result = prime * result + ((stateProvinceRegion == null) ? 0 : stateProvinceRegion.hashCode());
+        result = prime * result + ((isoCountrySubdivision == null)
+                ? 0
+                : isoCountrySubdivision.hashCode());
+        result = prime * result + ((stateProvinceRegion == null)
+                ? 0
+                : stateProvinceRegion.hashCode());
         return result;
     }
 
     @Override
-    public <G extends Address> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Address> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context)
+            throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
@@ -10,20 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
@@ -32,6 +25,14 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -45,18 +46,20 @@ public class ChallengeQuestionImpl implements ChallengeQuestion {
     @Id
     @GeneratedValue(generator = "ChallengeQuestionId")
     @GenericGenerator(
-        name="ChallengeQuestionId",
-        type= IdOverrideTableGenerator.class,
-        parameters = {
-            @Parameter(name="segment_value", value="ChallengeQuestionImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.ChallengeQuestionImpl")
-        }
+            name = "ChallengeQuestionId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "ChallengeQuestionImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.ChallengeQuestionImpl")
+            }
     )
     @Column(name = "QUESTION_ID")
     protected Long id;
 
-    @Column(name = "QUESTION", nullable=false)
-    @AdminPresentation(friendlyName = "ChallengeQuestionImpl_Challenge_Question", translatable = true, group = "ChallengeQuestionImpl_Customer")
+    @Column(name = "QUESTION", nullable = false)
+    @AdminPresentation(friendlyName = "ChallengeQuestionImpl_Challenge_Question",
+            translatable = true, group = "ChallengeQuestionImpl_Customer")
     protected String question;
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/ChallengeQuestionImpl.java
@@ -17,14 +17,6 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -32,6 +24,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -46,7 +46,7 @@ public class ChallengeQuestionImpl implements ChallengeQuestion {
     @GeneratedValue(generator = "ChallengeQuestionId")
     @GenericGenerator(
         name="ChallengeQuestionId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        type= IdOverrideTableGenerator.class,
         parameters = {
             @Parameter(name="segment_value", value="ChallengeQuestionImpl"),
             @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.ChallengeQuestionImpl")

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountryImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountryImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -50,8 +50,9 @@ public class CountryImpl implements Country, AdminMainEntity {
     @Column(name = "ABBREVIATION")
     protected String abbreviation;
 
-    @Column(name = "NAME", nullable=false)
-    @AdminPresentation(friendlyName = "CountryImpl_Country", order=12, group = "CountryImpl_Address", prominent = true, translatable = true)
+    @Column(name = "NAME", nullable = false)
+    @AdminPresentation(friendlyName = "CountryImpl_Country", order = 12,
+            group = "CountryImpl_Address", prominent = true, translatable = true)
     protected String name;
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
@@ -17,18 +17,6 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
-import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +24,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 /**
  * @author Elbert Bautista (elbertbautista)
@@ -56,7 +56,7 @@ public class CountrySubdivisionCategoryImpl implements CountrySubdivisionCategor
     @GeneratedValue(generator = "CountrySubdivisionCategoryId")
     @GenericGenerator(
             name="CountrySubdivisionCategoryId",
-            strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type= IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name="segment_value", value="CountrySubdivisionCategoryImpl"),
                     @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CountrySubdivisionCategoryImpl")

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionCategoryImpl.java
@@ -10,20 +10,13 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
@@ -36,6 +29,14 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 
 /**
  * @author Elbert Bautista (elbertbautista)
@@ -55,18 +56,20 @@ public class CountrySubdivisionCategoryImpl implements CountrySubdivisionCategor
     @Id
     @GeneratedValue(generator = "CountrySubdivisionCategoryId")
     @GenericGenerator(
-            name="CountrySubdivisionCategoryId",
-            type= IdOverrideTableGenerator.class,
+            name = "CountrySubdivisionCategoryId",
+            type = IdOverrideTableGenerator.class,
             parameters = {
-                    @Parameter(name="segment_value", value="CountrySubdivisionCategoryImpl"),
-                    @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CountrySubdivisionCategoryImpl")
+                    @Parameter(name = "segment_value", value = "CountrySubdivisionCategoryImpl"),
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CountrySubdivisionCategoryImpl")
             }
     )
     @Column(name = "COUNTRY_SUB_CAT_ID")
     protected Long id;
 
-    @Column(name = "NAME", nullable=false)
-    @AdminPresentation(friendlyName = "CountrySubdivisionCategoryImpl_Name", order=1, prominent = true, translatable = true)
+    @Column(name = "NAME", nullable = false)
+    @AdminPresentation(friendlyName = "CountrySubdivisionCategoryImpl_Name", order = 1,
+            prominent = true, translatable = true)
     protected String name;
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CountrySubdivisionImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -61,18 +61,22 @@ public class CountrySubdivisionImpl implements CountrySubdivision, AdminMainEnti
     protected String abbreviation;
 
     @Column(name = "NAME", nullable = false)
-    @AdminPresentation(friendlyName = "CountrySubdivisionImpl_Name", order=9, group = "CountrySubdivisionImpl_Address", prominent = true, translatable = true)
+    @AdminPresentation(friendlyName = "CountrySubdivisionImpl_Name", order = 9,
+            group = "CountrySubdivisionImpl_Address", prominent = true, translatable = true)
     protected String name;
 
     @Column(name = "ALT_ABBREVIATION")
-    @AdminPresentation(friendlyName = "CountrySubdivisionImpl_AltAbbreviation", order=10, group = "CountrySubdivisionImpl_Address", prominent = true)
+    @AdminPresentation(friendlyName = "CountrySubdivisionImpl_AltAbbreviation", order = 10,
+            group = "CountrySubdivisionImpl_Address", prominent = true)
     protected String alternateAbbreviation;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = CountryImpl.class, optional = false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CountryImpl.class,
+            optional = false)
     @JoinColumn(name = "COUNTRY")
     protected Country country;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = CountrySubdivisionCategoryImpl.class)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            targetEntity = CountrySubdivisionCategoryImpl.class)
     @JoinColumn(name = "COUNTRY_SUB_CAT")
     protected CountrySubdivisionCategory category;
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAddressImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAddressImpl.java
@@ -10,30 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.persistence.ArchiveStatus;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.AdminPresentationClass;
-import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
-import org.broadleafcommerce.common.presentation.override.PropertyType;
-import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
-import org.hibernate.annotations.SQLDelete;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -48,6 +30,24 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
+import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @EntityListeners(value = {TemporalTimestampListener.class, CustomerAddressPersistedEntityListener.class})
@@ -71,27 +71,27 @@ public class CustomerAddressImpl implements CustomerAddress {
     @Id
     @GeneratedValue(generator = "CustomerAddressId")
     @GenericGenerator(
-        name="CustomerAddressId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CustomerAddressImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CustomerAddressImpl")
-        }
+            name = "CustomerAddressId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CustomerAddressImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerAddressImpl")
+            }
     )
     @Column(name = "CUSTOMER_ADDRESS_ID")
     protected Long id;
 
     @Column(name = "ADDRESS_NAME")
-    @AdminPresentation(friendlyName = "CustomerAddressImpl_Address_Name", order=1,
+    @AdminPresentation(friendlyName = "CustomerAddressImpl_Address_Name", order = 1,
             group = "CustomerAddressImpl_Identification", groupOrder = 1, prominent = true, gridOrder = 1)
     protected String addressName;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional=false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected Customer customer;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH}, targetEntity = AddressImpl.class, optional=false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH}, targetEntity = AddressImpl.class, optional = false)
     @JoinColumn(name = "ADDRESS_ID")
     protected Address address;
 
@@ -140,20 +140,20 @@ public class CustomerAddressImpl implements CustomerAddress {
 
     @Override
     public String toString() {
-        return (addressName == null) 
+        return (addressName == null)
                 ? address.getFirstName() + " - " + address.getAddressLine1()
                 : addressName;
     }
 
     @Override
     public Character getArchived() {
-       ArchiveStatus temp;
-       if (archiveStatus == null) {
-           temp = new ArchiveStatus();
-       } else {
-           temp = archiveStatus;
-       }
-       return temp.getArchived();
+        ArchiveStatus temp;
+        if (archiveStatus == null) {
+            temp = new ArchiveStatus();
+        } else {
+            temp = archiveStatus;
+        }
+        return temp.getArchived();
     }
 
     @Override
@@ -166,7 +166,7 @@ public class CustomerAddressImpl implements CustomerAddress {
 
     @Override
     public boolean isActive() {
-        return 'Y'!=getArchived();
+        return 'Y' != getArchived();
     }
 
     @Override
@@ -203,7 +203,7 @@ public class CustomerAddressImpl implements CustomerAddress {
         } else if (!address.equals(other.address)) {
             return false;
         }
-        
+
         if (addressName == null) {
             if (other.addressName != null) {
                 return false;
@@ -211,7 +211,7 @@ public class CustomerAddressImpl implements CustomerAddress {
         } else if (!addressName.equals(other.addressName)) {
             return false;
         }
-        
+
         if (customer == null) {
             if (other.customer != null) {
                 return false;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAddressImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAddressImpl.java
@@ -17,19 +17,6 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
@@ -49,18 +36,37 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.SQLDelete;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
 @Entity
-@EntityListeners(value = {TemporalTimestampListener.class, CustomerAddressPersistedEntityListener.class})
+@EntityListeners(
+        value = {TemporalTimestampListener.class, CustomerAddressPersistedEntityListener.class})
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name = "BLC_CUSTOMER_ADDRESS", indexes = {@Index(name = "CUSTOMERADDRESS_ADDRESS_INDEX", columnList = "ADDRESS_ID")})
+@Table(name = "BLC_CUSTOMER_ADDRESS",
+        indexes = {@Index(name = "CUSTOMERADDRESS_ADDRESS_INDEX", columnList = "ADDRESS_ID")})
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "blCustomerElements")
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "address.firstName", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                booleanOverrideValue = true)),
         @AdminPresentationMergeOverride(name = "address.lastName", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED, booleanOverrideValue = true)),
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.EXCLUDED,
+                booleanOverrideValue = true)),
         @AdminPresentationMergeOverride(name = "address.addressLine1", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true))
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT,
+                booleanOverrideValue = true))
 })
 @AdminPresentationClass(populateToOneFields = PopulateToOneFieldsEnum.TRUE)
 @SQLDelete(sql = "UPDATE BLC_CUSTOMER_ADDRESS SET ARCHIVED = 'Y' WHERE CUSTOMER_ADDRESS_ID = ?")
@@ -75,7 +81,8 @@ public class CustomerAddressImpl implements CustomerAddress {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerAddressImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerAddressImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CustomerAddressImpl")
             }
     )
     @Column(name = "CUSTOMER_ADDRESS_ID")
@@ -83,15 +90,18 @@ public class CustomerAddressImpl implements CustomerAddress {
 
     @Column(name = "ADDRESS_NAME")
     @AdminPresentation(friendlyName = "CustomerAddressImpl_Address_Name", order = 1,
-            group = "CustomerAddressImpl_Identification", groupOrder = 1, prominent = true, gridOrder = 1)
+            group = "CustomerAddressImpl_Identification", groupOrder = 1, prominent = true,
+            gridOrder = 1)
     protected String addressName;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional = false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected Customer customer;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH}, targetEntity = AddressImpl.class, optional = false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH},
+            targetEntity = AddressImpl.class, optional = false)
     @JoinColumn(name = "ADDRESS_ID")
     protected Address address;
 
@@ -224,7 +234,8 @@ public class CustomerAddressImpl implements CustomerAddress {
 
 
     @Override
-    public <G extends CustomerAddress> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CustomerAddress> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
@@ -10,22 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,42 +26,62 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
-@Table(name="BLC_CUSTOMER_ATTRIBUTE")
+@Table(name = "BLC_CUSTOMER_ATTRIBUTE")
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
 public class CustomerAttributeImpl implements CustomerAttribute {
 
-    /** The Constant serialVersionUID. */
+    /**
+     * The Constant serialVersionUID.
+     */
     private static final long serialVersionUID = 1L;
 
-    /** The id. */
+    /**
+     * The id.
+     */
     @Id
-    @GeneratedValue(generator= "CustomerAttributeId")
+    @GeneratedValue(generator = "CustomerAttributeId")
     @GenericGenerator(
-        name="CustomerAttributeId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CustomerAttributeImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CustomerAttributeImpl")
-        }
+            name = "CustomerAttributeId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CustomerAttributeImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerAttributeImpl")
+            }
     )
     @Column(name = "CUSTOMER_ATTR_ID")
     protected Long id;
-    
-    /** The name. */
-    @Column(name = "NAME", nullable=false)
+
+    /**
+     * The name.
+     */
+    @Column(name = "NAME", nullable = false)
     @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
     protected String name;
 
-    /** The value. */
+    /**
+     * The value.
+     */
     @Column(name = "VALUE")
-    @AdminPresentation(friendlyName = "CustomerAttributeImpl_Attribute_Value", order=2, group = "ProductAttributeImpl_Description", prominent=true)
+    @AdminPresentation(friendlyName = "CustomerAttributeImpl_Attribute_Value", order = 2, group = "ProductAttributeImpl_Description", prominent = true)
     protected String value;
-  
-    /** The customer. */
-    @ManyToOne(targetEntity = CustomerImpl.class, optional=false)
+
+    /**
+     * The customer.
+     */
+    @ManyToOne(targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     protected Customer customer;
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerAttributeImpl.java
@@ -17,15 +17,6 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import org.broadleafcommerce.common.copy.CreateResponse;
 import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
@@ -36,6 +27,16 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -58,7 +59,8 @@ public class CustomerAttributeImpl implements CustomerAttribute {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerAttributeImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerAttributeImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CustomerAttributeImpl")
             }
     )
     @Column(name = "CUSTOMER_ATTR_ID")
@@ -75,7 +77,8 @@ public class CustomerAttributeImpl implements CustomerAttribute {
      * The value.
      */
     @Column(name = "VALUE")
-    @AdminPresentation(friendlyName = "CustomerAttributeImpl_Attribute_Value", order = 2, group = "ProductAttributeImpl_Description", prominent = true)
+    @AdminPresentation(friendlyName = "CustomerAttributeImpl_Attribute_Value", order = 2,
+            group = "ProductAttributeImpl_Description", prominent = true)
     protected String value;
 
     /**
@@ -182,7 +185,8 @@ public class CustomerAttributeImpl implements CustomerAttribute {
     }
 
     @Override
-    public <G extends CustomerAttribute> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CustomerAttribute> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerForgotPasswordSecurityTokenImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerForgotPasswordSecurityTokenImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -34,13 +34,14 @@ import jakarta.persistence.TemporalType;
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CUSTOMER_PASSWORD_TOKEN")
-public class CustomerForgotPasswordSecurityTokenImpl implements CustomerForgotPasswordSecurityToken {
+public class CustomerForgotPasswordSecurityTokenImpl
+        implements CustomerForgotPasswordSecurityToken {
     private static final long serialVersionUID = 1L;
-    
+
     @Id
     @Column(name = "PASSWORD_TOKEN", nullable = false)
     protected String token;
-    
+
     @Column(name = "CREATE_DATE", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)
     protected Date createDate;
@@ -48,10 +49,10 @@ public class CustomerForgotPasswordSecurityTokenImpl implements CustomerForgotPa
     @Column(name = "TOKEN_USED_DATE")
     @Temporal(TemporalType.TIMESTAMP)
     protected Date tokenUsedDate;
-    
+
     @Column(name = "CUSTOMER_ID", nullable = false)
     protected Long customerId;
-    
+
     @Column(name = "TOKEN_USED_FLAG", nullable = false)
     protected boolean tokenUsedFlag;
 
@@ -97,13 +98,17 @@ public class CustomerForgotPasswordSecurityTokenImpl implements CustomerForgotPa
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass())) return false;
+        if (this == o)
+            return true;
+        if (o == null)
+            return false;
+        if (!getClass().isAssignableFrom(o.getClass()))
+            return false;
 
         CustomerForgotPasswordSecurityTokenImpl that = (CustomerForgotPasswordSecurityTokenImpl) o;
 
-        if (token != null ? !token.equals(that.token) : that.token != null) return false;
+        if (token != null ? !token.equals(that.token) : that.token != null)
+            return false;
 
         return true;
     }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -80,26 +80,32 @@ import jakarta.persistence.Transient;
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "auditable.dateCreated", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerAdminPresentation.GroupName.Audit)),
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP,
+                overrideValue = CustomerAdminPresentation.GroupName.Audit)),
         @AdminPresentationMergeOverride(name = "auditable.createdBy", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerAdminPresentation.GroupName.Audit)),
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP,
+                overrideValue = CustomerAdminPresentation.GroupName.Audit)),
         @AdminPresentationMergeOverride(name = "auditable.dateUpdated", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerAdminPresentation.GroupName.Audit)),
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP,
+                overrideValue = CustomerAdminPresentation.GroupName.Audit)),
         @AdminPresentationMergeOverride(name = "auditable.updatedBy", mergeEntries =
-        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerAdminPresentation.GroupName.Audit))
+        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP,
+                overrideValue = CustomerAdminPresentation.GroupName.Audit))
 })
 @DirectCopyTransform({
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.PREVIEW),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE),
         @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.ARCHIVE_ONLY)
 })
-public class CustomerImpl implements Customer, AdminMainEntity, Previewable, CustomerAdminPresentation {
+public class CustomerImpl
+        implements Customer, AdminMainEntity, Previewable, CustomerAdminPresentation {
 
     private static final long serialVersionUID = 1L;
 
     @Id
     @Column(name = "CUSTOMER_ID")
-    @AdminPresentation(friendlyName = "CustomerImpl_Customer_Id", visibility = VisibilityEnum.HIDDEN_ALL)
+    @AdminPresentation(friendlyName = "CustomerImpl_Customer_Id",
+            visibility = VisibilityEnum.HIDDEN_ALL)
     protected Long id;
 
     @Embedded
@@ -156,16 +162,16 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
     /**
      * <p>
-     *     If true, this customer must go through a reset password flow.
+     * If true, this customer must go through a reset password flow.
      * </p>
      * <p>
-     *     During a site conversion or security breach or a matter of routine security policy,
-     *     it may be necessary to require users to change their password. This property will
-     *     not allow a user whose credentials are managed within Broadleaf to login until
-     *     they have reset their password.
+     * During a site conversion or security breach or a matter of routine security policy, it may be
+     * necessary to require users to change their password. This property will not allow a user
+     * whose credentials are managed within Broadleaf to login until they have reset their
+     * password.
      * </p>
      * <p>
-     *     Used by blUserDetailsService.
+     * Used by blUserDetailsService.
      * </p>
      */
     @Column(name = "PASSWORD_CHANGE_REQUIRED")
@@ -191,10 +197,11 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
     @ManyToOne(targetEntity = LocaleImpl.class)
     @JoinColumn(name = "LOCALE_CODE")
     @AdminPresentation(friendlyName = "CustomerImpl_Customer_Locale",
-        excluded = true, visibility = VisibilityEnum.GRID_HIDDEN)
+            excluded = true, visibility = VisibilityEnum.GRID_HIDDEN)
     protected Locale customerLocale;
 
-    @OneToMany(mappedBy = "customer", targetEntity = CustomerAttributeImpl.class, cascade = { CascadeType.ALL }, orphanRemoval = true)
+    @OneToMany(mappedBy = "customer", targetEntity = CustomerAttributeImpl.class,
+            cascade = {CascadeType.ALL}, orphanRemoval = true)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @MapKey(name = "name")
     @BatchSize(size = 50)
@@ -204,8 +211,10 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
             keyPropertyFriendlyName = "ProductAttributeImpl_Attribute_Name")
     protected Map<String, CustomerAttribute> customerAttributes = new HashMap<>();
 
-    @OneToMany(mappedBy = "customer", targetEntity = CustomerAddressImpl.class, cascade = { CascadeType.ALL })
-    @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
+    @OneToMany(mappedBy = "customer", targetEntity = CustomerAddressImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @Where(clause = "archived != 'Y'")
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Addresses",
@@ -213,16 +222,20 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
             addType = AddMethodType.PERSIST)
     protected List<CustomerAddress> customerAddresses = new ArrayList<>();
 
-    @OneToMany(mappedBy = "customer", targetEntity = CustomerPhoneImpl.class, cascade = { CascadeType.ALL })
-    @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
+    @OneToMany(mappedBy = "customer", targetEntity = CustomerPhoneImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Phones",
             group = GroupName.ContactInfo, order = FieldOrder.PHONES,
             addType = AddMethodType.PERSIST)
     protected List<CustomerPhone> customerPhones = new ArrayList<>();
 
-    @OneToMany(mappedBy = "customer", targetEntity = CustomerPaymentImpl.class, cascade = { CascadeType.ALL })
-    @Cascade(value = { org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
+    @OneToMany(mappedBy = "customer", targetEntity = CustomerPaymentImpl.class,
+            cascade = {CascadeType.ALL})
+    @Cascade(value = {org.hibernate.annotations.CascadeType.ALL,
+            org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
     @BatchSize(size = 50)
     @AdminPresentationCollection(friendlyName = "CustomerImpl_Customer_Payments",
@@ -581,7 +594,8 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
     }
 
     @Override
-    public <G extends Customer> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends Customer> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;
@@ -598,7 +612,8 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
         }
         for (Map.Entry<String, CustomerAttribute> entry : customerAttributes.entrySet()) {
-            CustomerAttribute clonedEntry = entry.getValue().createOrRetrieveCopyInstance(context).getClone();
+            CustomerAttribute clonedEntry =
+                    entry.getValue().createOrRetrieveCopyInstance(context).getClone();
             clonedEntry.setCustomer(cloned);
             cloned.getCustomerAttributes().put(entry.getKey(), clonedEntry);
         }
@@ -644,7 +659,8 @@ public class CustomerImpl implements Customer, AdminMainEntity, Previewable, Cus
 
     @Override
     public boolean isTaxExempt() {
-        return isTaxExempt != null && isTaxExempt != false &&  StringUtils.isNotEmpty(taxExemptionCode);
+        return isTaxExempt != null && isTaxExempt != false && StringUtils.isNotEmpty(
+                taxExemptionCode);
     }
 
 }

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -59,22 +59,33 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@EntityListeners(value = {TemporalTimestampListener.class, CustomerPaymentPersistedEntityListener.class})
+@EntityListeners(
+        value = {TemporalTimestampListener.class, CustomerPaymentPersistedEntityListener.class})
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CUSTOMER_PAYMENT",
-        uniqueConstraints = @UniqueConstraint(name = "CSTMR_PAY_UNIQUE_CNSTRNT", columnNames = {"CUSTOMER_ID", "PAYMENT_TOKEN"}),
+        uniqueConstraints = @UniqueConstraint(name = "CSTMR_PAY_UNIQUE_CNSTRNT",
+                columnNames = {"CUSTOMER_ID", "PAYMENT_TOKEN"}),
         indexes = {@Index(name = "CUSTOMERPAYMENT_TYPE_INDEX", columnList = "PAYMENT_TYPE")}
 )
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blOrderElements")
 @AdminPresentationMergeOverrides(
         {
-                @AdminPresentationMergeOverride(name = "billingAddress.addressLine1", mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GRIDORDER, intOverrideValue = 3000)
-                }),
+                @AdminPresentationMergeOverride(name = "billingAddress.addressLine1",
+                        mergeEntries = {
+                                @AdminPresentationMergeEntry(
+                                        propertyType = PropertyType.AdminPresentation.PROMINENT,
+                                        booleanOverrideValue = true),
+                                @AdminPresentationMergeEntry(
+                                        propertyType = PropertyType.AdminPresentation.GRIDORDER,
+                                        intOverrideValue = 3000)
+                        }),
                 @AdminPresentationMergeOverride(name = "billingAddress.", mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.TAB, overrideValue = CustomerPaymentAdminPresentation.TabName.BillingAddress),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.TABORDER, intOverrideValue = CustomerPaymentAdminPresentation.TabOrder.BillingAddress)
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.TAB,
+                                overrideValue = CustomerPaymentAdminPresentation.TabName.BillingAddress),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.TABORDER,
+                                intOverrideValue = CustomerPaymentAdminPresentation.TabOrder.BillingAddress)
                 })
         })
 public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdminPresentation {
@@ -88,17 +99,20 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerPaymentImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerPaymentImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CustomerPaymentImpl")
             })
     @Column(name = "CUSTOMER_PAYMENT_ID")
     protected Long id;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = CustomerImpl.class, optional = false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected Customer customer;
 
-    @ManyToOne(cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH }, targetEntity = AddressImpl.class, optional = true)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH},
+            targetEntity = AddressImpl.class, optional = true)
     @JoinColumn(name = "ADDRESS_ID")
     protected Address billingAddress;
 
@@ -111,17 +125,17 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
     @Column(name = "PAYMENT_TYPE")
     @AdminPresentation(friendlyName = "CustomerPaymentImpl_Payment_Type",
             group = GroupName.Payment, order = FieldOrder.PAYMENT_TYPE,
-            fieldType= SupportedFieldType.BROADLEAF_ENUMERATION,
-            broadleafEnumeration="org.broadleafcommerce.common.payment.PaymentType",
-            prominent=true, gridOrder = 1000)
+            fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
+            broadleafEnumeration = "org.broadleafcommerce.common.payment.PaymentType",
+            prominent = true, gridOrder = 1000)
     protected String paymentType;
 
     @Column(name = "GATEWAY_TYPE")
     @AdminPresentation(friendlyName = "CustomerPaymentImpl_Gateway_Type",
             group = GroupName.Payment, order = FieldOrder.PAYMENT_GATEWAY_TYPE,
             fieldType = SupportedFieldType.BROADLEAF_ENUMERATION,
-            broadleafEnumeration="org.broadleafcommerce.common.payment.PaymentGatewayType",
-            prominent=true, gridOrder = 2000)
+            broadleafEnumeration = "org.broadleafcommerce.common.payment.PaymentGatewayType",
+            prominent = true, gridOrder = 2000)
     protected String paymentGatewayType;
 
     @Column(name = "IS_DEFAULT")
@@ -130,7 +144,8 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
     protected boolean isDefault = false;
 
     @ElementCollection
-    @CollectionTable(name = "BLC_CUSTOMER_PAYMENT_FIELDS", joinColumns = @JoinColumn(name = "CUSTOMER_PAYMENT_ID"))
+    @CollectionTable(name = "BLC_CUSTOMER_PAYMENT_FIELDS",
+            joinColumns = @JoinColumn(name = "CUSTOMER_PAYMENT_ID"))
     @MapKeyColumn(name = "FIELD_NAME", nullable = false)
     @Column(name = "FIELD_VALUE", length = Length.LONG32 - 1)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCustomerElements")
@@ -187,8 +202,11 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
         }
 
         //support legacy customer payments that may have stored the type on the additional fields map
-        return !additionalFields.containsKey(PaymentAdditionalFieldType.PAYMENT_TYPE.getType()) ? null :
-                PaymentType.getInstance(additionalFields.get(PaymentAdditionalFieldType.PAYMENT_TYPE.getType()));
+        return !additionalFields.containsKey(PaymentAdditionalFieldType.PAYMENT_TYPE.getType())
+                ? null
+                :
+                        PaymentType.getInstance(additionalFields.get(
+                                PaymentAdditionalFieldType.PAYMENT_TYPE.getType()));
     }
 
     @Override
@@ -227,7 +245,8 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
     }
 
     @Override
-    public <G extends CustomerPayment> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CustomerPayment> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPhoneImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPhoneImpl.java
@@ -17,6 +17,18 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
+import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -30,39 +42,42 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
-import org.broadleafcommerce.common.presentation.override.PropertyType;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @EntityListeners(value = {CustomerPhonePersistedEntityListener.class})
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_CUSTOMER_PHONE",
-        uniqueConstraints = @UniqueConstraint(name = "CSTMR_PHONE_UNIQUE_CNSTRNT", columnNames = {"CUSTOMER_ID", "PHONE_NAME"}),
+        uniqueConstraints = @UniqueConstraint(name = "CSTMR_PHONE_UNIQUE_CNSTRNT",
+                columnNames = {"CUSTOMER_ID", "PHONE_NAME"}),
         indexes = {@Index(name = "CUSTPHONE_PHONE_INDEX", columnList = "PHONE_ID")}
 )
 @AdminPresentationMergeOverrides(
         {
                 @AdminPresentationMergeOverride(name = "phone.phoneNumber", mergeEntries = {
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerPhoneAdminPresentation.GroupName.PhoneInfo),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.ORDER, intOverrideValue = 2000),
-                        @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.PROMINENT, booleanOverrideValue = true)}),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.GROUP,
+                                overrideValue = CustomerPhoneAdminPresentation.GroupName.PhoneInfo),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.ORDER,
+                                intOverrideValue = 2000),
+                        @AdminPresentationMergeEntry(
+                                propertyType = PropertyType.AdminPresentation.PROMINENT,
+                                booleanOverrideValue = true)}),
                 @AdminPresentationMergeOverride(name = "phone.isDefault", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP, overrideValue = CustomerPhoneAdminPresentation.GroupName.Defaults)),
+                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.GROUP,
+                        overrideValue = CustomerPhoneAdminPresentation.GroupName.Defaults)),
                 @AdminPresentationMergeOverride(name = "phone.countryCode", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                        overrideValue = "HIDDEN_ALL")),
                 @AdminPresentationMergeOverride(name = "phone.extension", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL")),
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                        overrideValue = "HIDDEN_ALL")),
                 @AdminPresentationMergeOverride(name = "phone.isActive", mergeEntries =
-                @AdminPresentationMergeEntry(propertyType = PropertyType.AdminPresentation.VISIBILITY, overrideValue = "HIDDEN_ALL"))
+                @AdminPresentationMergeEntry(
+                        propertyType = PropertyType.AdminPresentation.VISIBILITY,
+                        overrideValue = "HIDDEN_ALL"))
         }
 )
 public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPresentation {
@@ -76,7 +91,8 @@ public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPrese
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerPhoneImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerPhoneImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CustomerPhoneImpl")
             }
     )
     @Column(name = "CUSTOMER_PHONE_ID")
@@ -88,7 +104,8 @@ public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPrese
             groupOrder = 1, prominent = true, gridOrder = 1)
     protected String phoneName;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional = false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected Customer customer;
@@ -180,7 +197,8 @@ public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPrese
     }
 
     @Override
-    public <G extends CustomerPhone> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+    public <G extends CustomerPhone> CreateResponse<G> createOrRetrieveCopyInstance(
+            MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {
             return createResponse;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPhoneImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPhoneImpl.java
@@ -10,23 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
-
-import org.broadleafcommerce.common.copy.CreateResponse;
-import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
-import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
-import org.broadleafcommerce.common.presentation.override.PropertyType;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -41,6 +30,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeEntry;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverride;
+import org.broadleafcommerce.common.presentation.override.AdminPresentationMergeOverrides;
+import org.broadleafcommerce.common.presentation.override.PropertyType;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @EntityListeners(value = {CustomerPhonePersistedEntityListener.class})
@@ -72,12 +72,12 @@ public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPrese
     @Id
     @GeneratedValue(generator = "CustomerPhoneId")
     @GenericGenerator(
-        name="CustomerPhoneId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CustomerPhoneImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CustomerPhoneImpl")
-        }
+            name = "CustomerPhoneId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CustomerPhoneImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerPhoneImpl")
+            }
     )
     @Column(name = "CUSTOMER_PHONE_ID")
     protected Long id;
@@ -88,12 +88,12 @@ public class CustomerPhoneImpl implements CustomerPhone, CustomerPhoneAdminPrese
             groupOrder = 1, prominent = true, gridOrder = 1)
     protected String phoneName;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional=false)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, targetEntity = CustomerImpl.class, optional = false)
     @JoinColumn(name = "CUSTOMER_ID")
     @AdminPresentation(excluded = true, visibility = VisibilityEnum.HIDDEN_ALL)
     protected Customer customer;
 
-    @ManyToOne(cascade = CascadeType.ALL, targetEntity = PhoneImpl.class, optional=false)
+    @ManyToOne(cascade = CascadeType.ALL, targetEntity = PhoneImpl.class, optional = false)
     @JoinColumn(name = "PHONE_ID")
     protected Phone phone;
 

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
@@ -10,16 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
-
-import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,6 +28,10 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @EntityListeners(value = {TemporalTimestampListener.class})
@@ -47,12 +47,12 @@ public class CustomerRoleImpl implements CustomerRole {
     @Id
     @GeneratedValue(generator = "CustomerRoleId")
     @GenericGenerator(
-        name="CustomerRoleId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="CustomerRoleImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.CustomerRoleImpl")
-        }
+            name = "CustomerRoleId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "CustomerRoleImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerRoleImpl")
+            }
     )
     @Column(name = "CUSTOMER_ROLE_ID")
     protected Long id;

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerRoleImpl.java
@@ -17,6 +17,11 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -28,10 +33,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @EntityListeners(value = {TemporalTimestampListener.class})
@@ -51,7 +52,8 @@ public class CustomerRoleImpl implements CustomerRole {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerRoleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.CustomerRoleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.CustomerRoleImpl")
             }
     )
     @Column(name = "CUSTOMER_ROLE_ID")

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/PhoneImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/PhoneImpl.java
@@ -17,6 +17,13 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -24,12 +31,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
-import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -46,18 +47,21 @@ public class PhoneImpl implements Phone {
             type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PhoneImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.PhoneImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.PhoneImpl")
             }
     )
     @Column(name = "PHONE_ID")
     protected Long id;
 
     @Column(name = "COUNTRY_CODE")
-    @AdminPresentation(friendlyName = "PhoneImpl_Country_Code", order = 1, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Country_Code", order = 1,
+            group = "PhoneImpl_Phone")
     protected String countryCode;
 
     @Column(name = "PHONE_NUMBER", nullable = false)
-    @AdminPresentation(friendlyName = "PhoneImpl_Phone_Number", order = 2, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Phone_Number", order = 2,
+            group = "PhoneImpl_Phone")
     protected String phoneNumber;
 
     @Column(name = "EXTENSION")
@@ -65,11 +69,13 @@ public class PhoneImpl implements Phone {
     protected String extension;
 
     @Column(name = "IS_DEFAULT")
-    @AdminPresentation(friendlyName = "PhoneImpl_Default_Phone", order = 4, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Default_Phone", order = 4,
+            group = "PhoneImpl_Phone")
     protected boolean isDefault = false;
 
     @Column(name = "IS_ACTIVE")
-    @AdminPresentation(friendlyName = "PhoneImpl_Active_Phone", order = 5, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Active_Phone", order = 5,
+            group = "PhoneImpl_Phone")
     protected boolean isActive = true;
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/PhoneImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/PhoneImpl.java
@@ -10,18 +10,12 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
 package org.broadleafcommerce.profile.core.domain;
-
-import org.broadleafcommerce.common.presentation.AdminPresentation;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -30,6 +24,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -42,34 +42,34 @@ public class PhoneImpl implements Phone {
     @Id
     @GeneratedValue(generator = "PhoneId")
     @GenericGenerator(
-        name="PhoneId",
-        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
-        parameters = {
-            @Parameter(name="segment_value", value="PhoneImpl"),
-            @Parameter(name="entity_name", value="org.broadleafcommerce.profile.core.domain.PhoneImpl")
-        }
+            name = "PhoneId",
+            type = IdOverrideTableGenerator.class,
+            parameters = {
+                    @Parameter(name = "segment_value", value = "PhoneImpl"),
+                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.PhoneImpl")
+            }
     )
     @Column(name = "PHONE_ID")
     protected Long id;
 
     @Column(name = "COUNTRY_CODE")
-    @AdminPresentation(friendlyName = "PhoneImpl_Country_Code", order=1, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Country_Code", order = 1, group = "PhoneImpl_Phone")
     protected String countryCode;
 
-    @Column(name = "PHONE_NUMBER", nullable=false)
-    @AdminPresentation(friendlyName = "PhoneImpl_Phone_Number", order=2, group = "PhoneImpl_Phone")
+    @Column(name = "PHONE_NUMBER", nullable = false)
+    @AdminPresentation(friendlyName = "PhoneImpl_Phone_Number", order = 2, group = "PhoneImpl_Phone")
     protected String phoneNumber;
 
     @Column(name = "EXTENSION")
-    @AdminPresentation(friendlyName = "PhoneImpl_Extension", order=3, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Extension", order = 3, group = "PhoneImpl_Phone")
     protected String extension;
 
     @Column(name = "IS_DEFAULT")
-    @AdminPresentation(friendlyName = "PhoneImpl_Default_Phone", order=4, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Default_Phone", order = 4, group = "PhoneImpl_Phone")
     protected boolean isDefault = false;
 
     @Column(name = "IS_ACTIVE")
-    @AdminPresentation(friendlyName = "PhoneImpl_Active_Phone", order=5, group = "PhoneImpl_Phone")
+    @AdminPresentation(friendlyName = "PhoneImpl_Active_Phone", order = 5, group = "PhoneImpl_Phone")
     protected boolean isActive = true;
 
     @Override

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/RoleImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/RoleImpl.java
@@ -10,7 +10,7 @@
  * the Broadleaf End User License Agreement (EULA), Version 1.1
  * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
  * shall apply.
- * 
+ *
  * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
@@ -49,14 +49,15 @@ public class RoleImpl implements Role {
             strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
             parameters = {
                     @Parameter(name = "segment_value", value = "RoleImpl"),
-                    @Parameter(name = "entity_name", value = "org.broadleafcommerce.profile.core.domain.RoleImpl")
+                    @Parameter(name = "entity_name",
+                            value = "org.broadleafcommerce.profile.core.domain.RoleImpl")
             }
     )
     @Column(name = "ROLE_ID")
     protected Long id;
 
     @Column(name = "ROLE_NAME", nullable = false)
-    @AdminPresentation(friendlyName = "rolesTitle",prominent = true)
+    @AdminPresentation(friendlyName = "rolesTitle", prominent = true)
     protected String roleName;
 
     @Override


### PR DESCRIPTION
Related to: https://github.com/BroadleafCommerce/QA/issues/4999

property strategy was replaced with type:

before: strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator"

after: type= IdOverrideTableGenerator.class

