### PR TITLE
Fix that our XssRequestWrapper works as expected when trying to use ESAPI to clean input

### DIFF
--- a/common/src/main/resources/esapi/ESAPI.properties
+++ b/common/src/main/resources/esapi/ESAPI.properties
@@ -563,4 +563,4 @@ Validator.HtmlValidationAction=throw
 # You don't have to configure the filename here, but in that case the code will keep looking for antisamy-esapi.xml.
 # This is the default behaviour of ESAPI.
 #
-#Validator.HtmlValidationConfigurationFile=antisamy-esapi.xml
+Validator.HtmlValidationConfigurationFile=antisamy-myspace.xml


### PR DESCRIPTION
- Fix that our XssRequestWrapper works as expected when trying to use ESAPI to clean input. Specify correct config file in ESAPI.properties. After we have deleted antisamy-esapi.xml this becomes required

Fixes: BroadleafCommerce/QA#5042