### PR TITLE
Updated deprecated design in @GenericGenerator for Hibernate 6 

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateFieldGroupXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/domain/PageTemplateFieldGroupXrefImpl.java
@@ -26,6 +26,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.hibernate.annotations.Cache;
@@ -63,7 +64,7 @@ public class PageTemplateFieldGroupXrefImpl implements PageTemplateFieldGroupXre
     @GeneratedValue(generator = "PageTemplateFieldGroupXrefId")
     @GenericGenerator(
             name = "PageTemplateFieldGroupXrefId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "PageTemplateFieldGroupXrefImpl"),
                     @Parameter(name = "entity_name",

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldXrefImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/structure/domain/StructuredContentFieldXrefImpl.java
@@ -24,6 +24,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -45,7 +46,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "BLC_SC_FLD_MAP")
@@ -65,7 +65,7 @@ public class StructuredContentFieldXrefImpl
     @GeneratedValue(generator = "StructuredContentFieldXrefId")
     @GenericGenerator(
             name = "StructuredContentFieldXrefId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "StructuredContentFieldXrefImpl"),
                     @Parameter(name = "entity_name",

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/domain/URLHandlerImpl.java
@@ -27,6 +27,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -46,7 +47,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
-
 
 /**
  * @author priyeshpatel
@@ -70,7 +70,7 @@ public class URLHandlerImpl implements URLHandler, Locatable, AdminMainEntity, P
     @GeneratedValue(generator = "URLHandlerID")
     @GenericGenerator(
             name = "URLHandlerID",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "URLHandlerImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.cms.url.domain.URLHandlerImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/config/domain/AbstractModuleConfiguration.java
+++ b/common/src/main/java/org/broadleafcommerce/common/config/domain/AbstractModuleConfiguration.java
@@ -24,6 +24,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
@@ -72,7 +73,7 @@ public abstract class AbstractModuleConfiguration implements ModuleConfiguration
     @GeneratedValue(generator = "ModuleConfigurationId")
     @GenericGenerator(
             name = "ModuleConfigurationId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "ModuleConfigurationImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.config.domain" +

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/domain/TranslationImpl.java
@@ -15,7 +15,6 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.common.i18n.domain;
 
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -24,6 +23,7 @@ import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
@@ -65,7 +65,7 @@ public class TranslationImpl implements Serializable, Translation {
     @GeneratedValue(generator = "TranslationId")
     @GenericGenerator(
             name = "TranslationId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "TranslationImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.i18n.domain.TranslationImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/domain/CatalogImpl.java
@@ -15,7 +15,6 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.common.site.domain;
 
 import org.apache.commons.logging.Log;
@@ -26,6 +25,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
@@ -75,7 +75,7 @@ public class CatalogImpl implements Catalog, AdminMainEntity {
     @GeneratedValue(generator = "CatalogId")
     @GenericGenerator(
             name = "CatalogId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CatalogImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.site.domain.CatalogImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapGeneratorConfigurationImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapGeneratorConfigurationImpl.java
@@ -15,12 +15,12 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.common.sitemap.domain;
 
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -60,7 +60,7 @@ public class SiteMapGeneratorConfigurationImpl implements SiteMapGeneratorConfig
     @GeneratedValue(generator = "GeneratorConfigurationId")
     @GenericGenerator(
             name = "GeneratorConfigurationId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "SiteMapGeneratorConfigurationImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.sitemap.domain.SiteMapGeneratorConfigurationImpl")

--- a/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapUrlEntryImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/sitemap/domain/SiteMapUrlEntryImpl.java
@@ -15,9 +15,9 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.common.sitemap.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -52,7 +52,7 @@ public class SiteMapUrlEntryImpl implements SiteMapUrlEntry {
     @GeneratedValue(generator = "URLEntryId")
     @GenericGenerator(
             name = "URLEntryId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "SiteMapURLEntryImpl"),
                     @Parameter(name = "entity_name", value = "org.broadleafcommerce.common.sitemap.domain.SiteMapURLEntryImpl")

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -32,6 +32,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.media.domain.Media;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.persistence.ArchiveStatus;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.persistence.Status;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationAdornedTargetCollection;
@@ -187,7 +188,7 @@ public class ProductImpl
     @GeneratedValue(generator = "ProductId")
     @GenericGenerator(
             name = "ProductId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "ProductImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionValueImpl.java
@@ -24,6 +24,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMe
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.RequiredOverride;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -69,7 +70,7 @@ public class ProductOptionValueImpl
     @GeneratedValue(generator = "ProductOptionValueId")
     @GenericGenerator(
             name = "ProductOptionValueId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "ProductOptionValueImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -36,6 +36,7 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.media.domain.Media;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationCollection;
 import org.broadleafcommerce.common.presentation.AdminPresentationDataDrivenEnumeration;
@@ -164,7 +165,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
     @GeneratedValue(generator = "SkuId")
     @GenericGenerator(
             name = "SkuId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "SkuImpl"),
                     @Parameter(name = "entity_name",
@@ -1089,7 +1090,7 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         //we just migrate the call from the List to the internal Set representation. This is in response
         //to https://github.com/BroadleafCommerce/BroadleafCommerce/issues/917.
         return (List<ProductOptionValue>) Proxy.newProxyInstance(getClass().getClassLoader(),
-                new Class<?>[] {List.class}, new InvocationHandler() {
+                new Class<?>[]{List.class}, new InvocationHandler() {
                     @Override
                     public Object invoke(Object proxy, Method method, Object[] args)
                             throws Throwable {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/ProratedOrderItemAdjustmentImpl.java
@@ -20,6 +20,7 @@ package org.broadleafcommerce.core.offer.domain;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.currency.util.CurrencyCodeIdentifiable;
 import org.broadleafcommerce.common.money.Money;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
@@ -70,7 +71,7 @@ public class ProratedOrderItemAdjustmentImpl
     @GeneratedValue(generator = "ProratedOrderItemAdjustmentId")
     @GenericGenerator(
             name = "ProratedOrderItemAdjustmentId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "ProratedOrderItemAdjustmentImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/domain/SearchFacetRangeImpl.java
@@ -15,7 +15,6 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.core.search.domain;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -25,6 +24,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
 import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.presentation.ConfigurationItem;
@@ -102,7 +102,7 @@ public class SearchFacetRangeImpl implements SearchFacetRange, Serializable {
     @GeneratedValue(generator = "SearchFacetRangeId")
     @GenericGenerator(
             name = "SearchFacetRangeId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "SearchFacetRangeImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/CustomerPaymentImpl.java
@@ -15,7 +15,6 @@
  * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
  * #L%
  */
-
 package org.broadleafcommerce.profile.core.domain;
 
 import org.broadleafcommerce.common.copy.CreateResponse;
@@ -23,6 +22,7 @@ import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
 import org.broadleafcommerce.common.payment.PaymentAdditionalFieldType;
 import org.broadleafcommerce.common.payment.PaymentGatewayType;
 import org.broadleafcommerce.common.payment.PaymentType;
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationMap;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
@@ -96,7 +96,7 @@ public class CustomerPaymentImpl implements CustomerPayment, CustomerPaymentAdmi
     @GeneratedValue(generator = "CustomerPaymentId")
     @GenericGenerator(
             name = "CustomerPaymentId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "CustomerPaymentImpl"),
                     @Parameter(name = "entity_name",

--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/RoleImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/RoleImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.profile.core.domain;
 
+import org.broadleafcommerce.common.persistence.IdOverrideTableGenerator;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
 import org.broadleafcommerce.common.time.domain.TemporalTimestampListener;
@@ -46,7 +47,7 @@ public class RoleImpl implements Role {
     @GeneratedValue(generator = "RoleId")
     @GenericGenerator(
             name = "RoleId",
-            strategy = "org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+            type = IdOverrideTableGenerator.class,
             parameters = {
                     @Parameter(name = "segment_value", value = "RoleImpl"),
                     @Parameter(name = "entity_name",


### PR DESCRIPTION
**A Brief Overview**
property strategy was replaced with type:

before: strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator"

after: type= IdOverrideTableGenerator.class

**Link to QA issue**
[QA-4999](https://github.com/BroadleafCommerce/QA/issues/4999)
