### PR TITLE
Upgrade of closure-compiler-unshaded

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -420,5 +420,13 @@
             <groupId>com.googlecode.htmlcompressor</groupId>
             <artifactId>htmlcompressor</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.broadleafcommerce.common.resource.service;
 
+import com.google.common.io.CharStreams;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -96,7 +97,7 @@ public class GoogleClosureJavascriptMinificationServiceImpl implements Javascrip
     @Override
     public void minifyJs(String filename, Reader reader, Writer writer) throws ResourceMinificationException {
         try {
-            SourceFile input = SourceFile.fromReader(filename, reader);
+            SourceFile input = SourceFile.fromCode(filename, CharStreams.toString(reader));
             String compiled = compileJs(input, filename);
             writer.write(compiled);
         } catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <broadleaf-presentation.version>1.3.5-GA</broadleaf-presentation.version>
         <hsqldb.database.starter.version>2.3.4-GA</hsqldb.database.starter.version>
-        <closure.compiler.version>v20210505</closure.compiler.version>
+        <closure.compiler.version>v20200830</closure.compiler.version>
         <hibernate.version>5.4.33.Final</hibernate.version>
         <hibernate-validator.version>6.1.7.Final</hibernate-validator.version>
         <javax.version>2.3.1</javax.version>


### PR DESCRIPTION
**A Brief Overview**
Upgrade of closure-compiler-unshaded to version v20230802

https://github.com/BroadleafCommerce/QA/issues/5039
