### PR TITLE
Add compareTo method for dates to use in thymeleaf templates

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/BLCDateUtils.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/BLCDateUtils.java
@@ -107,4 +107,14 @@ public class BLCDateUtils {
         return dateFormat.format(date);
     }
 
+    /**
+     * Method to solve problem with thymeleaf if you somehow have java.sql.Timestamp if will not allow call methods for this class
+     * @param date1 - the first date to compare
+     * @param date2 - the second date to compare
+     * @return result of date1.compareTo(date2)
+     */
+    public static int compareTo(Date date1, Date date2){
+        return date1.compareTo(date2);
+    }
+
 }


### PR DESCRIPTION
- Add compareTo method for dates, to be used in thymeleaf templates as sometimes date in fact can be java.sql.Timestamp and thymeleaf forbids method invocation from this package/type

Fixes: BroadleafCommerce/QA#5051