### PR TITLE
Fix to prevent a user to use his session to manipulate entities in other site

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/remote/AdminSecurityServiceRemote.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/remote/AdminSecurityServiceRemote.java
@@ -74,7 +74,7 @@ import javax.annotation.Resource;
 @Service("blAdminSecurityRemoteService")
 public class AdminSecurityServiceRemote implements AdminSecurityService, SecurityVerifier {
     
-    private static final String ANONYMOUS_USER_NAME = "anonymousUser";
+    public static final String ANONYMOUS_USER_NAME = "anonymousUser";
     private static final Log LOG = LogFactory.getLog(AdminSecurityServiceRemote.class);
     
     @Resource(name="blAdminSecurityService")

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestFilter.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestFilter.java
@@ -117,7 +117,9 @@ public class BroadleafAdminRequestFilter extends AbstractBroadleafAdminRequestFi
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         } catch (StaleStateServiceException e) {
             //catch state change attempts from a stale page
-            forwardToConflictDestination(request,response);
+            forwardToConflictDestination(request, response);
+        } catch (SecurityException e){
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         } finally {
             requestProcessor.postProcess(new ServletWebRequest(request, response));
         }


### PR DESCRIPTION
- Fix to prevent a user to use his session to manipulate entities in other site

Fixes: BroadleafCommerce/QA#5050