### PR TITLE
escape percent symbol in filters

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -470,6 +470,7 @@ public abstract class AdminAbstractController extends BroadleafAbstractControlle
                         } catch (Exception e) {
                             LOG.info("Could not decode value", e);
                         }
+                        decoded = decoded.replace("%","\\%");
                         if (decoded.contains(FILTER_VALUE_SEPARATOR)) {
                             String[] vs = decoded.split(FILTER_VALUE_SEPARATOR_REGEX);
                             for (String v : vs) {


### PR DESCRIPTION
- escape percent symbol

Fixes: BroadleafCommerce/QA#5020