### PR TITLE
Pass entity to PopulateValueRequest so it can be used in field persistence providers if needed

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/ProductUrlFieldPersistenceProvider.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/ProductUrlFieldPersistenceProvider.java
@@ -47,7 +47,7 @@ public class ProductUrlFieldPersistenceProvider extends FieldPersistenceProvider
             Product product = (Product) instance;
 
             ExtensionResultHolder<String> holder = new ExtensionResultHolder<>();
-            ExtensionResultStatusType result = extensionManager.getProxy().modifyUrl(val, product, holder);
+            ExtensionResultStatusType result = extensionManager.getProxy().modifyUrl(val, product, request.getEntity(), holder);
 
             if (ExtensionResultStatusType.HANDLED == result) {
                 product.setUrl(holder.getResult());

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/extension/ProductUrlFieldPersistenceProviderExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/extension/ProductUrlFieldPersistenceProviderExtensionHandler.java
@@ -21,8 +21,9 @@ import org.broadleafcommerce.common.extension.ExtensionHandler;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.core.catalog.domain.Product;
+import org.broadleafcommerce.openadmin.dto.Entity;
 
 public interface ProductUrlFieldPersistenceProviderExtensionHandler extends ExtensionHandler {
 
-    ExtensionResultStatusType modifyUrl(String url, Product product, ExtensionResultHolder<String> holder);
+    ExtensionResultStatusType modifyUrl(String url, Product product, Entity entity, ExtensionResultHolder<String> holder);
 }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -396,7 +396,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
 
                     if (attemptToPopulateValue(property, fieldManager, instance, setId, metadata, entity, value)) {
                         boolean isValid = true;
-                        PopulateValueRequest request = new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd());
+                        PopulateValueRequest request = new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd(), entity);
                         handled = false;
                         boolean required = metadata.getRequiredOverride() != null ? metadata.getRequiredOverride() : BooleanUtils.isTrue(metadata.getRequired());
                         if (value != null) {
@@ -428,7 +428,7 @@ public class BasicPersistenceModule implements PersistenceModule, RecordHelper, 
                                     if (value == null) {
                                         property.setIsDirty(true);
                                     }
-                                    defaultFieldPersistenceProvider.populateValue(new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd()), instance);
+                                    defaultFieldPersistenceProvider.populateValue(new PopulateValueRequest(setId, fieldManager, property, metadata, returnType, value, persistenceManager, this, entity.isPreAdd(), entity), instance);
                                     if (value == null) {
                                         fieldManager.setFieldValue(instance, property.getName(), null);
                                     }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/request/PopulateValueRequest.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/request/PopulateValueRequest.java
@@ -18,6 +18,7 @@
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider.request;
 
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
+import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.Property;
 import org.broadleafcommerce.openadmin.server.service.persistence.PersistenceManager;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.DataFormatProvider;
@@ -39,8 +40,9 @@ public class PopulateValueRequest {
     private final PersistenceManager persistenceManager;
     private final DataFormatProvider dataFormatProvider;
     private final Boolean isPreAdd;
+    private final Entity entity;
 
-    public PopulateValueRequest(Boolean setId, FieldManager fieldManager, Property property, BasicFieldMetadata metadata, Class<?> returnType, String requestedValue, PersistenceManager persistenceManager, DataFormatProvider dataFormatProvider, Boolean isPreAdd) {
+    public PopulateValueRequest(Boolean setId, FieldManager fieldManager, Property property, BasicFieldMetadata metadata, Class<?> returnType, String requestedValue, PersistenceManager persistenceManager, DataFormatProvider dataFormatProvider, Boolean isPreAdd, Entity entity) {
         this.setId = setId;
         this.fieldManager = fieldManager;
         this.property = property;
@@ -50,6 +52,7 @@ public class PopulateValueRequest {
         this.persistenceManager = persistenceManager;
         this.dataFormatProvider = dataFormatProvider;
         this.isPreAdd = isPreAdd;
+        this.entity = entity;
     }
 
     public Boolean getSetId() {
@@ -86,5 +89,9 @@ public class PopulateValueRequest {
 
     public Boolean getPreAdd() {
         return isPreAdd != null && isPreAdd;
+    }
+
+    public Entity getEntity() {
+        return entity;
     }
 }


### PR DESCRIPTION
- Pass entity to PopulateValueRequest so it can be used in field persistence providers if needed

Fixes: BroadleafCommerce/QA#5063