### PR TITLE
Introduce cache for FieldManager isPersistenceClass, just as performance optimization

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +60,8 @@ public class FieldManager {
     protected EntityConfiguration entityConfiguration;
     protected EntityManager entityManager;
     protected List<SortableValue> middleFields = new ArrayList<SortableValue>(5);
+
+    protected Set<Class> persistentClasses = new HashSet<>();
 
     public FieldManager(EntityConfiguration entityConfiguration, EntityManager entityManager) {
         this.entityConfiguration = entityConfiguration;
@@ -252,16 +255,18 @@ public class FieldManager {
     }
 
     protected boolean isPersistentClass(Class entityClass) {
-        if (entityManager != null) {
+        if (entityManager != null && persistentClasses.isEmpty()) {
             Set<EntityType<?>> managedEntities = entityManager.getMetamodel().getEntities();
+            boolean found = false;
             for (EntityType managedEntity : managedEntities) {
                 if (managedEntity.getJavaType().equals(entityClass)) {
-                    return true;
+                    found = true;
                 }
+                persistentClasses.add(managedEntity.getJavaType());
             }
+            return found;
         }
-
-        return false;
+        return !persistentClasses.isEmpty() && persistentClasses.contains(entityClass);
     }
 
     protected Object handleMapFieldExtraction(Object bean, String fieldName, Class<?> componentClass, Object value,

--- a/common/src/main/resources/bl-common-applicationContext.xml
+++ b/common/src/main/resources/bl-common-applicationContext.xml
@@ -67,6 +67,11 @@
                             <value>org\.terracotta.*</value>
                             <value>java.*</value>
                             <value>com\.fasterxml.*</value>
+                            <value>com\.mysql.*</value>
+                            <value>org\.antlr.*</value>
+                            <value>net\.bytebuddy.*</value>
+                            <value>org\.owasp.*</value>
+                            <value>org\.htmlunit.*</value>
                         </array>
                     </property>
                 </bean>


### PR DESCRIPTION
- Introduce cache for FieldManager isPersistenceClass, just as performance optimization
- Add more packages to exclusions so Hibernate class transformers will not attempt to parse those classes

Fixes: BroadleafCommerce/QA#5061