### PR TITLE
Fix for fulfillment locations creation

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
@@ -360,7 +360,13 @@ public class BasicFieldPersistenceProvider extends FieldPersistenceProviderAdapt
                     if (origDispVal != null) {
                         prop.setOriginalDisplayValue(String.valueOf(origDispVal));
                         Session session = populateValueRequest.getPersistenceManager().getDynamicEntityDao().getStandardEntityManager().unwrap(Session.class);
-                        String originalValueFromSession = String.valueOf(session.getIdentifier(origInstanceValue));
+                        String originalValueFromSession;
+                        if (session.contains(origInstanceValue)) {
+                            originalValueFromSession = String.valueOf(session.getIdentifier(origInstanceValue));
+                        } else {
+                            //can be that instance was constructed by spring and not fetched from the DB
+                            originalValueFromSession = String.valueOf(session.getIdentifier(session.getReference(origInstanceValue)));
+                        }
                         prop.setOriginalValue(originalValueFromSession);
                     }
 


### PR DESCRIPTION
- Fix for fulfillment locations creation. When address is created as a spring bean it has IsoCountry populated from spring xml context and it was not attached to hibernate session

Fixes: BroadleafCommerce/QA#5075