### PR TITLE
Remove animal sniffer plugin

### DIFF
--- a/admin/broadleaf-admin-functional-tests/pom.xml
+++ b/admin/broadleaf-admin-functional-tests/pom.xml
@@ -56,13 +56,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -235,27 +235,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.23</version>
-                <executions>
-                    <execution>
-                        <id>sniff</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <spring.boot.version>3.0.7</spring.boot.version>
         <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.24</lombok.version>
-        <maven.source.plugin.version>2.4</maven.source.plugin.version>
+        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <geb.version>1.0</geb.version>
         <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
         <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
@@ -507,7 +507,7 @@
                                 <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
-                                    <goal>test-jar-no-fork</goal>
+                                    <goal>test-jar</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
**A Brief Overview**
Remove animal sniffer plugin because there are no new signature for JDK 17.


**QA Link**
https://github.com/BroadleafCommerce/QA/issues/4936
