### PR TITLE
Update the GEB lib

### DIFF
--- a/admin/broadleaf-admin-functional-tests/src/main/groovy/GebConfig.groovy
+++ b/admin/broadleaf-admin-functional-tests/src/main/groovy/GebConfig.groovy
@@ -22,6 +22,8 @@ import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeDriverService
 import org.openqa.selenium.firefox.FirefoxDriver
 
+import groovy.ant.AntBuilder
+
 println 'Loading default Broadleaf GebConfig'
 // Use the FirefoxDriver by default
 driver = { new FirefoxDriver() }

--- a/admin/broadleaf-admin-functional-tests/src/main/groovy/org/broadleafcommerce/browsertest/page/TopLevelEntity.groovy
+++ b/admin/broadleaf-admin-functional-tests/src/main/groovy/org/broadleafcommerce/browsertest/page/TopLevelEntity.groovy
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.browsertest.page
 
 
-import geb.navigator.NonEmptyNavigator
+import geb.navigator.DefaultNavigator
 
 /**
  * Represents a top-level entity page like viewing a list of Categories at '/admin/category' or viewing a list of Prodcuts
@@ -48,7 +48,7 @@ class TopLevelEntity extends AdminPage {
         $('#sideMenu .blc-module .content a', text: contains(containingText))
     }
     
-    def findSectionLink(String containingText, NonEmptyNavigator containingModule) {
+    def findSectionLink(String containingText, DefaultNavigator containingModule) {
         containingModule.closest('.blc-module').find('.content a', text: contains(containingText))
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <maven.source.plugin.version>2.4</maven.source.plugin.version>
-        <geb.version>1.0</geb.version>
+        <geb.version>7.0</geb.version>
         <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
         <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
         <selenium.version>4.8.1</selenium.version>
@@ -980,7 +980,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.5</version>
+                <version>1.14.8</version>
             </dependency>
 
             <!--Scheduling Libraries -->


### PR DESCRIPTION
**A Brief Overview**
Upgrade the lib. Also `geb.navigator.NonEmptyNavigator` has been renamed to ``geb.navigator.DefaultNavigator` so changed it.

**Link to QA**
https://github.com/BroadleafCommerce/QA/issues/5080