### PR TITLE
Fix to prevent a user to use his session to manipulate entities in other site (5.2)

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/remote/AdminSecurityServiceRemote.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/remote/AdminSecurityServiceRemote.java
@@ -72,7 +72,7 @@ import javax.annotation.Resource;
 @Service("blAdminSecurityRemoteService")
 public class AdminSecurityServiceRemote implements AdminSecurityService, SecurityVerifier {
     
-    private static final String ANONYMOUS_USER_NAME = "anonymousUser";
+    public static final String ANONYMOUS_USER_NAME = "anonymousUser";
     private static final Log LOG = LogFactory.getLog(AdminSecurityServiceRemote.class);
     
     @Resource(name="blAdminSecurityService")

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestFilter.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestFilter.java
@@ -117,7 +117,9 @@ public class BroadleafAdminRequestFilter extends AbstractBroadleafAdminRequestFi
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         } catch (StaleStateServiceException e) {
             //catch state change attempts from a stale page
-            forwardToConflictDestination(request,response);
+            forwardToConflictDestination(request, response);
+        } catch (SecurityException e){
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         } finally {
             requestProcessor.postProcess(new ServletWebRequest(request, response));
         }

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestProcessor.java
@@ -49,8 +49,11 @@ import org.broadleafcommerce.common.web.ValidateProductionChangesState;
 import org.broadleafcommerce.openadmin.server.security.domain.AdminUser;
 import org.broadleafcommerce.openadmin.server.security.remote.SecurityVerifier;
 import org.broadleafcommerce.openadmin.server.security.service.AdminSecurityService;
+import org.broadleafcommerce.openadmin.server.security.service.user.AdminUserDetails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.WebRequest;
 
@@ -61,6 +64,8 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import javax.annotation.Resource;
+
+import static org.broadleafcommerce.openadmin.server.security.remote.AdminSecurityServiceRemote.ANONYMOUS_USER_NAME;
 
 
 /**
@@ -164,7 +169,17 @@ public class BroadleafAdminRequestProcessor extends AbstractBroadleafWebRequestP
 
         AdminUser adminUser = adminRemoteSecurityService.getPersistentAdminUser();
         if (adminUser != null) {
-            brc.setAdminUserId(adminUser.getId());
+            AdminUserDetails principal = (AdminUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            if (principal.getId().equals(adminUser.getId())) {
+                brc.setAdminUserId(adminUser.getId());
+            } else {
+                throw new SecurityException();
+            }
+        } else {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && !auth.getName().equals(ANONYMOUS_USER_NAME)) {
+                throw new SecurityException();
+            }
         }
 
         prepareSandBox(request, brc);


### PR DESCRIPTION
**A Brief Overview**
- Fix to prevent a user to use his session to manipulate entities in other site

Fixes: BroadleafCommerce/QA#5050