### PR TITLE
Upgrade snappy-java to 1.1.10.4 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -944,7 +944,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.1</version>
+                <version>1.1.10.4</version>
             </dependency>
             <!-- Byte Code Manipulation Libraries -->
             <dependency>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5083

**A Brief Overview**
Upgrade snappy-java to 1.1.10.4 version