### PR TITLE
Fix of error in uploading new assets

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/service/StaticAssetServiceImpl.java
@@ -199,12 +199,12 @@ public class StaticAssetServiceImpl implements StaticAssetService {
             final Tika tika = new Tika();
             final MimeTypes allTypes = MimeTypes.getDefaultMimeTypes();
             final String detectedType;
-            detectedType = tika.detect(file.getBytes());
+            detectedType = tika.detect(file.getOriginalFilename());
             if (detectedType != null && !detectedType.isEmpty()) {
                 final MimeType mimeType = allTypes.forName(detectedType);
                 tikaExtension = mimeType.getExtension().replace(".", "").toLowerCase();
             }
-        } catch (IOException | MimeTypeException ignored) {
+        } catch (MimeTypeException ignored) {
         }
         return (tikaExtension != null && !tikaExtension.isEmpty()) ? tikaExtension : FilenameUtils.getExtension(file.getOriginalFilename());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1567,7 +1567,7 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>2.7.0</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
**A Brief Overview**
StaticAssetServiceImpl.getFileExtension() used the tika.detect(byte[] data) signature, which generated an error. It has been replaced by another method tika.detect(String name);
Updated version of tika-core;

**Link to QA issue**
[QA-5084](https://github.com/BroadleafCommerce/QA/issues/5084)
