### PR TITLE
Fix Flaky tests

### DIFF
--- a/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
@@ -37,6 +37,9 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.matchers.CompareMatcher;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -135,7 +138,7 @@ public class SiteMapGeneratorTest {
     protected void compareFiles(File file1, String pathToFile2) throws IOException {
         String actualOutput = convertFileToString(file1);
         String expectedOutput = convertFileToString(new File(pathToFile2));
-        Assert.assertTrue(actualOutput.equals(expectedOutput));
+        Assert.assertThat(actualOutput, CompareMatcher.isSimilarTo(expectedOutput).withNodeMatcher( new DefaultNodeMatcher(ElementSelectors.byName)));
     }
 
     protected String convertFileToString(File file) throws IOException {
@@ -147,7 +150,6 @@ public class SiteMapGeneratorTest {
             if (line.contains("</lastmod>")) {
                 continue;
             }
-            line = line.replaceAll("\\s+", "");
             sb.append(line);
         }
         br.close();

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,11 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>2.2.1</version>
+        </dependency>
     </dependencies>
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
**Fix flaky tests**

**A Brief Overview**
This PR is to fix several flaky tests which call `compareFiles()` in file `common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java`, such as tests `org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest#testSiteMapsWithSiteContext`, `org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest#testCustomUrlSiteMapGenerator`, etc.

**Reproduce test failures**
- Run the following command to reproduce test failures, we will take one test for example:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl common -Dtest=org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest#testSiteMapsWithSiteContext
```
- We get the following test failures:
```
[ERROR]   CustomUrlSiteMapGeneratorTest.testSiteMapsWithSiteContext:86->SiteMapGeneratorTest.compareFiles:138
```
**Root cause**
In method `convertFileToString`, when reading lines of `xml` file content and then converting them to string, the orders of elements can be different. 
For example, for exactly the same node, in one file the order is`<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">`, while in the other the order is `<sitemapindex xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`. The two `xml` files actually have the same nodes but with different orders, and in this case, the assertion will assume they are different and fail.

**Fix**
In ` compareFiles`, the fix is to use `xmlunit` to compare the content of two `xml` files only ignoring the orders of elements.
In `convertFileToString`, remove line `line = line.replaceAll("\\s+", "");` to keep correct `xml` formats (keep the spaces, otherwise it will be an invalid `xml` node format), so that it can be applied to xml assertion.
Also, add necessary dependencies in `pom.xml`.
