### PR TITLE
Revert of deletion of defaultParentCategory as it is too tightly bound in different parts

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Product.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/Product.java
@@ -370,6 +370,29 @@ public interface Product extends Serializable, MultiTenantCloneable<Product>, In
     public void setCategory(Category category);
 
     /**
+     * Returns the default {@link Category} this product is associated with. This method will delegate to
+     * {@link #getCategory()} by default, unless the "use.legacy.default.category.mode" property is set to
+     * true in the implementation's property file. If set to true, this method will use legacy behavior,
+     * which is to return the deprecated defaultCategory field.
+     *
+     * @deprecated use {@link #getCategory()} instead
+     */
+    @Deprecated
+    public Category getDefaultCategory();
+
+    /**
+     * Sets the default {@link Category} to associate this product with. This method will delegate to
+     * {@link #setCategory(Category)} by default, unless the "use.legacy.default.category.mode" property is set to
+     * true in the implementation's property file. If set to true, this method will use legacy behavior,
+     * which is to set the deprecated defaultCategory field.
+     *
+     * @deprecated use {@link #setCategory(Category)} instead
+     * @param defaultCategory - the default {@link Category} to associate this product with
+     */
+    @Deprecated
+    public void setDefaultCategory(Category defaultCategory);
+
+    /**
      * Returns the model number of the product
      * @return the model number
      */

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -1144,13 +1144,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (StringUtils.isEmpty(this.inventoryType)) {
             if (hasDefaultSku() && lookupDefaultSku().getInventoryType() != null) {
                 return lookupDefaultSku().getInventoryType();
-            } else {
-                if (getProduct() != null) {
-                    Category category = getProduct().getCategory();
-                    if (category != null) {
-                        return category.getInventoryType();
-                    }
-                }
+            } else if (getProduct() != null && getProduct().getDefaultCategory() != null) {
+                return getProduct().getDefaultCategory().getInventoryType();
             }
             return null;
         }
@@ -1177,13 +1172,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (StringUtils.isEmpty(this.fulfillmentType)) {
             if (hasDefaultSku() && lookupDefaultSku().getFulfillmentType() != null) {
                 return lookupDefaultSku().getFulfillmentType();
-            } else {
-                if (getProduct() != null) {
-                    Category category = getProduct().getCategory();
-                    if (category != null) {
-                        return category.getFulfillmentType();
-                    }
-                }
+            } else if (getProduct() != null && getProduct().getDefaultCategory() != null) {
+                return getProduct().getDefaultCategory().getFulfillmentType();
             }
             return null;
         }
@@ -1291,13 +1281,8 @@ public class SkuImpl implements Sku, SkuAdminPresentation {
         if (StringUtils.isEmpty(this.taxCode)) {
             if (hasDefaultSku() && !StringUtils.isEmpty(lookupDefaultSku().getTaxCode())) {
                 return lookupDefaultSku().getTaxCode();
-            } else {
-                if (getProduct() != null) {
-                    Category category = getProduct().getCategory();
-                    if (category != null) {
-                        return category.getTaxCode();
-                    }
-                }
+            }  else if (getProduct() != null && getProduct().getDefaultCategory() != null) {
+                return getProduct().getDefaultCategory().getTaxCode();
             }
         }
         return this.taxCode;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/RelatedProductsServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/RelatedProductsServiceImpl.java
@@ -77,7 +77,7 @@ public class RelatedProductsServiceImpl implements RelatedProductsService {
         List<FeaturedProduct> returnFeaturedProducts = null;
         
         if (product != null) {
-            category = product.getCategory();
+            category = product.getDefaultCategory();
         }
         
         if (category != null) {

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
@@ -411,7 +411,7 @@ public class OrderItemServiceImpl implements OrderItemService {
             }
 
             if (bundleCategory == null && bundleProduct != null) {
-                bundleCategory = bundleProduct.getCategory();
+                bundleCategory = bundleProduct.getDefaultCategory();
             }
 
             DiscreteOrderItemRequest bundleItemRequest = new DiscreteOrderItemRequest();
@@ -520,7 +520,7 @@ public class OrderItemServiceImpl implements OrderItemService {
         }
 
         if (category == null && product != null) {
-            category = product.getCategory();
+            category = product.getDefaultCategory();
         }
 
         OrderItem item;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/strategy/FulfillmentGroupItemStrategyImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/strategy/FulfillmentGroupItemStrategyImpl.java
@@ -193,8 +193,8 @@ public class FulfillmentGroupItemStrategyImpl implements FulfillmentGroupItemStr
         if (sku.getFulfillmentType() != null) {
             return sku.getFulfillmentType();
         }
-        if (sku.getDefaultProduct() != null && sku.getDefaultProduct().getCategory() != null) {
-            return sku.getDefaultProduct().getCategory().getFulfillmentType();
+        if (sku.getDefaultProduct() != null && sku.getDefaultProduct().getDefaultCategory() != null) {
+            return sku.getDefaultProduct().getDefaultCategory().getFulfillmentType();
         }
         return null;
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/AutoBundleActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/workflow/AutoBundleActivity.java
@@ -181,7 +181,7 @@ public class AutoBundleActivity extends BaseActivity<ProcessContext<Order>> {
 
         BundleOrderItem bundleOrderItem = (BundleOrderItem) orderItemDao.create(OrderItemType.BUNDLE);
         bundleOrderItem.setQuantity(numApplications);
-        bundleOrderItem.setCategory(productBundle.getCategory());
+        bundleOrderItem.setCategory(productBundle.getDefaultCategory());
         bundleOrderItem.setSku(productBundle.getDefaultSku());
         bundleOrderItem.setName(productBundle.getName());
         bundleOrderItem.setProductBundle(productBundle);


### PR DESCRIPTION
- Revert of deletion of defaultParentCategory as it is too tightly bound in different parts
Fixes: BroadleafCommerce/QA#4923