### PR TITLE
 Fix to disable possible fields in redactor during submit

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/blc-admin.js
@@ -1142,7 +1142,10 @@ var BLCAdmin = (function($) {
          */
         serializeArray : function serializeArray($form) {
             var $disabledFields = $form.find(':disabled').attr('disabled', false);
+            var redactorEnabledFields= $form.find(".redactor-editor").find('input:not(:disabled)');
+            $form.find(".redactor-editor").find('input').attr('disabled', true);
             var serializedForm = $form.serializeArray();
+            redactorEnabledFields.attr("disabled", false);
             $disabledFields.attr('disabled', true);
 
             return serializedForm.filter(notIdFilterFunction);


### PR DESCRIPTION
- Fix to disable possible fields in redactor, so they will not be sent server and possible clash with blc fields like csrfToken etc

Fixes: BroadleafCommerce/QA#5098