### PR TITLE
Fix for hibernate 6 issue with stackoverflow, during adding to cart or navigating with having something in the cart

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/persistence/PostLoaderDao.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/PostLoaderDao.java
@@ -50,4 +50,7 @@ public interface PostLoaderDao {
      */
     <T> T findSandboxEntity(Class<T> clazz, Object id);
 
+    void evict(Class<?> clazz, Object id);
+
+    void evict(Object entity);
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -168,7 +168,7 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
 
     @Override
     public Boolean isTaxable() {
-        return (sku == null || sku.isTaxable() == null || sku.isTaxable());
+        return (sku == null || getSku().isTaxable() == null || getSku().isTaxable());
     }
 
     @Override
@@ -253,7 +253,7 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
     public String getName() {
         String name = super.getName();
         if (name == null) {
-            return sku.getName();
+            return getSku().getName();
         }
         return name;
     }
@@ -472,14 +472,14 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
         final int prime = super.hashCode();
         int result = 1;
         result = prime * result + ((bundleOrderItem == null) ? 0 : bundleOrderItem.hashCode());
-        result = prime * result + ((sku == null) ? 0 : sku.hashCode());
+        result = prime * result + ((sku == null) ? 0 : getSku().hashCode());
         return result;
     }
 
     @Override
     public boolean isDiscountingAllowed() {
         if (discountsAllowed == null) {
-            return sku.isDiscountable();
+            return getSku().isDiscountable();
         } else {
             return discountsAllowed.booleanValue();
         }
@@ -546,6 +546,6 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
 
     @Override
     public boolean isSkuActive() {
-        return sku.isActive();
+        return getSku().isActive();
     }
 }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/DiscreteOrderItemImpl.java
@@ -35,6 +35,7 @@ import org.broadleafcommerce.core.catalog.domain.SkuBundleItem;
 import org.broadleafcommerce.core.catalog.domain.SkuBundleItemImpl;
 import org.broadleafcommerce.core.catalog.domain.SkuImpl;
 import org.broadleafcommerce.core.catalog.service.dynamic.DynamicSkuPrices;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -129,6 +130,15 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
             PostLoaderDao postLoaderDao = DefaultPostLoaderDao.getPostLoaderDao();
 
             if (postLoaderDao != null && sku.getId() != null) {
+                //TODO this if exists because of https://discourse.hibernate.org/t/hibernate-6-onetoone-stackoverflow/8178/2
+                // https://hibernate.atlassian.net/browse/HHH-17140 once it is fixed it can be removed
+                //long story short if you fetch orderItem before fetching product/sku and neither is in 2nd level cache
+                //hibernate will fail with stackoverflow as it is not able to understand which proxy(sku or product
+                // they're both lazy) should be initialized first and so it finds a reference
+                // sku->defaultProduct->defaultSku and fails
+                if(sku instanceof HibernateProxy && !Hibernate.isInitialized(sku)) {
+                    postLoaderDao.evict(sku);
+                }
                 Long id = sku.getId();
                 deproxiedSku = postLoaderDao.find(SkuImpl.class, id);
             } else if (sku instanceof HibernateProxy) {
@@ -168,6 +178,15 @@ public class DiscreteOrderItemImpl extends OrderItemImpl implements DiscreteOrde
 
             if (product != null && postLoaderDao != null && product.getId() != null) {
                 Long id = product.getId();
+                //TODO this if exists because of https://discourse.hibernate.org/t/hibernate-6-onetoone-stackoverflow/8178/2
+                // https://hibernate.atlassian.net/browse/HHH-17140 once it is fixed it can be removed
+                //long story short if you fetch orderItem before fetching product/sku and neither is in 2nd level cache
+                //hibernate will fail with stackoverflow as it is not able to understand which proxy(sku or product
+                // they're both lazy) should be initialized first and so it finds a reference
+                // sku->defaultProduct->defaultSku and fails
+                if(product instanceof HibernateProxy && !Hibernate.isInitialized(product)) {
+                    postLoaderDao.evict(product);
+                }
                 deproxiedProduct = postLoaderDao.find(ProductImpl.class, id);
             } else if (product instanceof HibernateProxy) {
                 deproxiedProduct = HibernateUtils.deproxy(product);


### PR DESCRIPTION
- Fix for hibernate 6 issue with stackoverflow, during adding to cart or navigating with having something in the cart

Fixes: BroadleafCommerce/QA#5111

This is a known issue we found with hibernate 6...
OrderItem has a 2 lazy references sku & product, if such happens that you fetch orderItem before you've fetched referenced sku or product and then try to access product or sku, or fetch them it will fail with stackoverflow

https://discourse.hibernate.org/t/hibernate-6-onetoone-stackoverflow/8178/2
https://hibernate.atlassian.net/browse/HHH-17140

In hibernate 6.3.1 it is also not fixed