### PR TITLE
Fixed invalid queries producement if the sandBoxHelper.mergeCloneIds returns multiple rows

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/dao/ProductDaoImpl.java
@@ -185,7 +185,7 @@ public class ProductDaoImpl implements ProductDao {
 
     protected List<Product> readActiveProductsByCategoryInternal(Long categoryId, Date currentDate) {
         TypedQuery<Product> query = em.createNamedQuery("BC_READ_ACTIVE_PRODUCTS_BY_CATEGORY", Product.class);
-        query.setParameter("categoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
+        query.setParameter("categoryInList", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
         query.setParameter("currentDate", currentDate);
         query.setHint(QueryHints.HINT_CACHEABLE, true);
         query.setHint(QueryHints.HINT_CACHE_REGION, "query.Catalog");
@@ -444,7 +444,7 @@ public class ProductDaoImpl implements ProductDao {
 
     public List<Product> readActiveProductsByCategoryInternal(Long categoryId, Date currentDate, int limit, int offset) {
         TypedQuery<Product> query = em.createNamedQuery("BC_READ_ACTIVE_PRODUCTS_BY_CATEGORY", Product.class);
-        query.setParameter("categoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
+        query.setParameter("categoryInList", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
         query.setParameter("currentDate", currentDate);
         query.setFirstResult(offset);
         query.setMaxResults(limit);
@@ -457,7 +457,7 @@ public class ProductDaoImpl implements ProductDao {
     @Override
     public List<Product> readProductsByCategory(Long categoryId) {
         TypedQuery<Product> query = em.createNamedQuery("BC_READ_PRODUCTS_BY_CATEGORY", Product.class);
-        query.setParameter("categoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
+        query.setParameter("categoryInList", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
         query.setHint(QueryHints.HINT_CACHEABLE, true);
         query.setHint(QueryHints.HINT_CACHE_REGION, "query.Catalog");
 
@@ -467,7 +467,7 @@ public class ProductDaoImpl implements ProductDao {
     @Override
     public List<Product> readProductsByCategory(Long categoryId, int limit, int offset) {
         TypedQuery<Product> query = em.createNamedQuery("BC_READ_PRODUCTS_BY_CATEGORY", Product.class);
-        query.setParameter("categoryId", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
+        query.setParameter("categoryInList", sandBoxHelper.mergeCloneIds(CategoryImpl.class, categoryId));
         query.setFirstResult(offset);
         query.setMaxResults(limit);
         query.setHint(QueryHints.HINT_CACHEABLE, true);

--- a/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Product.orm.xml
+++ b/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Product.orm.xml
@@ -42,7 +42,7 @@
 
     <named-query name="BC_READ_ACTIVE_PRODUCTS_BY_CATEGORY" >
         <query>SELECT categoryProduct.product FROM org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl categoryProduct
-        WHERE categoryProduct.category.id IN (:categoryIsList)
+        WHERE categoryProduct.category.id IN (:categoryInList)
         AND categoryProduct.product.defaultSku.activeStartDate &lt;= :currentDate
         AND (categoryProduct.product.defaultSku.activeEndDate &gt; :currentDate OR categoryProduct.product.defaultSku.activeEndDate IS NULL)
                 AND (categoryProduct.product.archiveStatus.archived IS NULL OR categoryProduct.product.archiveStatus.archived = 'N')
@@ -52,7 +52,7 @@
     
     <named-query name="BC_READ_PRODUCTS_BY_CATEGORY" >
         <query>SELECT categoryProduct.product FROM org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl categoryProduct
-        WHERE categoryProduct.category.id IN (:categoryIsList)
+        WHERE categoryProduct.category.id IN (:categoryInList)
         ORDER BY COALESCE (categoryProduct.displayOrder,999999)
         </query>
     </named-query>

--- a/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Product.orm.xml
+++ b/core/broadleaf-framework/src/main/resources/config/bc/jpa/domain/Product.orm.xml
@@ -42,7 +42,7 @@
 
     <named-query name="BC_READ_ACTIVE_PRODUCTS_BY_CATEGORY" >
         <query>SELECT categoryProduct.product FROM org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl categoryProduct
-        WHERE categoryProduct.category.id = :categoryId
+        WHERE categoryProduct.category.id IN (:categoryIsList)
         AND categoryProduct.product.defaultSku.activeStartDate &lt;= :currentDate
         AND (categoryProduct.product.defaultSku.activeEndDate &gt; :currentDate OR categoryProduct.product.defaultSku.activeEndDate IS NULL)
                 AND (categoryProduct.product.archiveStatus.archived IS NULL OR categoryProduct.product.archiveStatus.archived = 'N')
@@ -52,7 +52,7 @@
     
     <named-query name="BC_READ_PRODUCTS_BY_CATEGORY" >
         <query>SELECT categoryProduct.product FROM org.broadleafcommerce.core.catalog.domain.CategoryProductXrefImpl categoryProduct
-        WHERE categoryProduct.category.id = :categoryId
+        WHERE categoryProduct.category.id IN (:categoryIsList)
         ORDER BY COALESCE (categoryProduct.displayOrder,999999)
         </query>
     </named-query>


### PR DESCRIPTION
Fixes: https://github.com/BroadleafCommerce/QA/issues/5110

Changed queries to categoryProduct.category.id IN (:categoryId) also renamed variable to categoryIsList from categoryId.

