### PR TITLE
Make root query class and return type not to depend on each other in QueryBuilder

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/dao/TypedQueryBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/dao/TypedQueryBuilder.java
@@ -56,7 +56,7 @@ public class TypedQueryBuilder<T> {
         this(rootClass, rootAlias, rootClass);
     }
 
-    public TypedQueryBuilder(Class<? extends T> rootClass, String rootAlias, Class<T> returnClass) {
+    public TypedQueryBuilder(Class rootClass, String rootAlias, Class<T> returnClass) {
         this.rootClass = rootClass;
         this.rootAlias = rootAlias;
         this.returnClass = returnClass;
@@ -119,7 +119,7 @@ public class TypedQueryBuilder<T> {
      * 
      * If you are using this as a COUNT query, you should look at the corresponding {@link #toCountQuery(EntityManager)}
      * 
-     * @param whether or not the resulting query string should be used as a count query or not
+     * @param count - whether or not the resulting query string should be used as a count query or not
      * @return the QL string
      */
     public String toQueryString(boolean count) {


### PR DESCRIPTION
- Make root query class and return type not to depend on each other, as we do runtime weaving and static compilation can fail while in runtime everything is fine

Fixes: BroadleafCommerce/QA#5150