### PR TITLE
 Fix to fetch additional skus correctly for promote operation after propagation

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -27,6 +27,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.admin.server.service.SkuMetadataCacheService;
 import org.broadleafcommerce.common.exception.ServiceException;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
+import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.presentation.client.LookupType;
 import org.broadleafcommerce.common.presentation.client.OperationType;
 import org.broadleafcommerce.common.presentation.client.PersistencePerspectiveItemType;
@@ -907,7 +909,18 @@ public class SkuCustomPersistenceHandler extends CustomPersistenceHandlerAdapter
             }
 
             boolean validated = true;
-            for (Sku sku : product.getAdditionalSkus()) {
+            ExtensionResultHolder<List<Sku>> holder = new ExtensionResultHolder<>();
+            ExtensionResultStatusType result = extensionManager.getProxy().getAdditionalSkusCollection(product, holder);
+            List<Sku> additionalSkus;
+            if(result.equals(ExtensionResultStatusType.HANDLED)){
+                additionalSkus = holder.getResult();
+                if(CollectionUtils.isEmpty(additionalSkus)){
+                    additionalSkus = product.getAdditionalSkus();
+                }
+            }else {
+                additionalSkus = product.getAdditionalSkus();
+            }
+            for (Sku sku : additionalSkus) {
                 if (currentSku == null || !sku.getId().equals(currentSku.getId())) {
                     List<Long> testList = new ArrayList<>();
                     for (ProductOptionValue optionValue : sku.getProductOptionValues()) {

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandlerExtensionHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandlerExtensionHandler.java
@@ -18,8 +18,12 @@
 package org.broadleafcommerce.admin.server.service.handler;
 
 import org.broadleafcommerce.common.extension.ExtensionHandler;
+import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
+import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.core.catalog.domain.Sku;
+
+import java.util.List;
 
 /**
  * Allows special behavior to be defined when a sku is updated via the admin.
@@ -35,6 +39,8 @@ public interface SkuCustomPersistenceHandlerExtensionHandler extends ExtensionHa
      * @return
      */
     ExtensionResultStatusType skuUpdated(Sku updated);
+
+    ExtensionResultStatusType getAdditionalSkusCollection(Product product, ExtensionResultHolder<List<Sku>> erh);
 
     public static final int DEFAULT_PRIORITY = Integer.MAX_VALUE;
 }


### PR DESCRIPTION
- Fix to fetch additional skus correctly for promote operation after propagation. Seems it is hibernate 6.2 issue but for some reason query didn't fetch results correctly, only product refresh gives effect, but if is heavy operation, fetching collection directly should do the trick and be equivalent to invoking lazy getter

Fixes: BroadleafCommerce/QA#5153