### PR TITLE
Fix to better check if sequence needs to be updated for hibernate 6

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/persistence/SequenceGeneratorCorruptionDetection.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/SequenceGeneratorCorruptionDetection.java
@@ -208,7 +208,7 @@ public class SequenceGeneratorCorruptionDetection implements ApplicationListener
                 if (CollectionUtils.isNotEmpty(results) && results.get(0) != null) {
                     LOG.debug(String.format("Checking for sequence corruption on entity %s", segmentValue));
                     Long maxEntityId = BLCNumberUtils.toLong(results.get(0));
-                    if (maxEntityId >= maxSequenceId) {
+                    if (maxEntityId+incrementSize+1 >= maxSequenceId) {
                         String invalidSequenceDetectedMsg = String.format("The sequence value for %s in %s was found as %d (or an entry did not exist) but the actual max sequence in"
                             + " %s's table was found as %d", segmentValue, tableName, maxSequenceId, mappedClass.getName(), maxEntityId);
                         if (automaticallyCorrectInconsistencies) {

--- a/common/src/test/resources/common-test-properties/common.properties
+++ b/common/src/test/resources/common-test-properties/common.properties
@@ -18,3 +18,5 @@
 # This is used only for the PropertySourceOverrideTest
 test.property.source=commonvalue
 shared.override.test=commonvalue
+
+auto.correct.sequence.generator.inconsistencies=true

--- a/integration/src/test/resources/config/bc/overrideprops/common.properties
+++ b/integration/src/test/resources/config/bc/overrideprops/common.properties
@@ -17,3 +17,5 @@
 
 # Test file to be overridden by SystemPropertiesTest
 property.file.override.test=propertyfile
+
+auto.correct.sequence.generator.inconsistencies=true


### PR DESCRIPTION
- Fix to better check if sequence needs to be updated for hibernate 6
In hibernate 6 sequence generators updated formulas, so seq corruption detector should not only increment correctly, but a condition to check if sequence needs to be update should be enhanced

Fixes: BroadleafCommerce/QA#5157