### PR TITLE
Prevent generating too many skus

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogService.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogService.java
@@ -17,6 +17,8 @@
  */
 package org.broadleafcommerce.admin.server.service;
 
+import java.util.Map;
+
 /**
  * 
  * @author Phillip Verheyden
@@ -33,6 +35,8 @@ public interface AdminCatalogService {
      * @return the number of generated Skus from the ProductOption permutations
      */
     public Integer generateSkusFromProduct(Long productId);
+
+     Map<String, Object> generateSkus(Long productId);
 
     /**
      * This will create a new product along with a new Sku for the defaultSku, along with new

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogService.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogService.java
@@ -25,18 +25,26 @@ import java.util.Map;
  *
  */
 public interface AdminCatalogService {
-    
+
     /**
      * Clear out any Skus that are already attached to the Product
      * if there were any there and generate a new set of Skus based
      * on the permutations of ProductOptions attached to this Product
-     * 
+     *
      * @param productId - the Product to generate Skus from
      * @return the number of generated Skus from the ProductOption permutations
+     * @deprecated use {@link #generateSkus(Long)}
      */
+    @Deprecated
     public Integer generateSkusFromProduct(Long productId);
 
-     Map<String, Object> generateSkus(Long productId);
+    /**
+     * Create new Skus based on a product's ProductOptions by permutation and add them to existing ones.
+     *
+     * @param productId - Product ID to create SKUs
+     * @return the map as ResponseBody
+     */
+    Map<String, Object> generateSkus(Long productId);
 
     /**
      * This will create a new product along with a new Sku for the defaultSku, along with new

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -24,18 +24,21 @@ import org.broadleafcommerce.admin.server.service.extension.AdminCatalogServiceE
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.util.BLCCollectionUtils;
-import org.broadleafcommerce.common.util.TypedTransformer;
+import org.broadleafcommerce.common.util.BLCMessageUtils;
 import org.broadleafcommerce.core.catalog.dao.SkuDao;
 import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.core.catalog.domain.ProductOption;
 import org.broadleafcommerce.core.catalog.domain.ProductOptionValue;
 import org.broadleafcommerce.core.catalog.domain.Sku;
 import org.broadleafcommerce.core.catalog.service.CatalogService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
@@ -50,6 +53,15 @@ import javax.persistence.PersistenceContext;
 public class AdminCatalogServiceImpl implements AdminCatalogService {
 
     private static final Log LOG = LogFactory.getLog(AdminCatalogServiceImpl.class);
+
+    public static String NO_SKUS_GENERATED_KEY = "noSkusGenerated";
+    public static String MAX_SKU_GENERATION_KEY = "maxSkuGenerated";
+    public static String NO_PRODUCT_OPTIONS_GENERATED_KEY = "noProductOptionsConfigured";
+    public static String FAILED_SKU_GENERATION_KEY = "errorNeedAllowedValue";
+    public static String NUMBER_SKUS_GENERATED_KEY = "numberSkusGenerated";
+
+    @Value("${product.sku.generation.max:2}")
+    protected int skuMaxGeneration;
 
     @Resource(name = "blCatalogService")
     protected CatalogService catalogService;
@@ -82,7 +94,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
         LOG.info(allPermutations);
 
         //determine the permutations that I already have Skus for
-        List<List<ProductOptionValue>> previouslyGeneratedPermutations = new ArrayList<List<ProductOptionValue>>();
+        List<List<ProductOptionValue>> previouslyGeneratedPermutations = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(product.getAdditionalSkus())) {
             for (Sku additionalSku : product.getAdditionalSkus()) {
                 if (CollectionUtils.isNotEmpty(additionalSku.getProductOptionValues())) {
@@ -91,7 +103,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             }
         }
 
-        List<List<ProductOptionValue>> permutationsToGenerate = new ArrayList<List<ProductOptionValue>>();
+        List<List<ProductOptionValue>> permutationsToGenerate = new ArrayList<>();
         for (List<ProductOptionValue> permutation : allPermutations) {
             boolean previouslyGenerated = false;
             for (List<ProductOptionValue> generatedPermutation : previouslyGeneratedPermutations) {
@@ -110,7 +122,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
 
         int numPermutationsCreated = 0;
         if (extensionManager != null && CollectionUtils.isNotEmpty(permutationsToGenerate)) {
-            ExtensionResultHolder<Integer> result = new ExtensionResultHolder<Integer>();
+            ExtensionResultHolder<Integer> result = new ExtensionResultHolder<>();
             ExtensionResultStatusType resultStatusType = extensionManager.getProxy().persistSkuPermutation(product, permutationsToGenerate, result);
             if (ExtensionResultStatusType.HANDLED == resultStatusType) {
                 numPermutationsCreated = result.getResult();
@@ -118,27 +130,99 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
         }
 
         LOG.info("Total number of permutations generated: " + numPermutationsCreated);
-
         return numPermutationsCreated;
+    }
+
+    @Override
+    public Map<String, Object> generateSkus(Long productId) {
+        Map<String, Object> result = new HashMap<>();
+
+        Product product = catalogService.findProductById(productId);
+
+        if (CollectionUtils.isEmpty(product.getProductOptionXrefs())) {
+            result.put("message", BLCMessageUtils.getMessage(NO_PRODUCT_OPTIONS_GENERATED_KEY));
+            return result;
+        }
+
+        if (checkSkuMaxGeneration(product.getProductOptions())) {
+            result.put("message", String.format(BLCMessageUtils.getMessage(MAX_SKU_GENERATION_KEY), skuMaxGeneration));
+            return result;
+        }
+
+        List<List<ProductOptionValue>> allPermutations = generatePermutations(0, new ArrayList<>(), product.getProductOptions());
+
+        if (allPermutations == null) {
+            // one of the Product Options used in Sku generation has no Allowed Values
+            result.put("message", BLCMessageUtils.getMessage(FAILED_SKU_GENERATION_KEY));
+            result.put("error", "no-allowed-value-error");
+            return result;
+        }
+
+        LOG.info("Total number of permutations: " + allPermutations.size());
+        LOG.info(allPermutations);
+
+        //determine the permutations that I already have Skus for
+        List<List<ProductOptionValue>> previouslyGeneratedPermutations = new ArrayList<>();
+        if (CollectionUtils.isNotEmpty(product.getAdditionalSkus())) {
+            for (Sku additionalSku : product.getAdditionalSkus()) {
+                if (CollectionUtils.isNotEmpty(additionalSku.getProductOptionValues())) {
+                    previouslyGeneratedPermutations.add(additionalSku.getProductOptionValues());
+                }
+            }
+        }
+
+        List<List<ProductOptionValue>> permutationsToGenerate = new ArrayList<>();
+        for (List<ProductOptionValue> permutation : allPermutations) {
+            boolean previouslyGenerated = false;
+            for (List<ProductOptionValue> generatedPermutation : previouslyGeneratedPermutations) {
+                if (isSamePermutation(permutation, generatedPermutation)) {
+                    previouslyGenerated = true;
+                    break;
+                }
+            }
+
+            if (!previouslyGenerated) {
+                permutationsToGenerate.add(permutation);
+            }
+        }
+
+        LOG.info("Total number of permutations to generate: " + permutationsToGenerate.size());
+
+        int numPermutationsCreated = 0;
+        if (extensionManager != null && CollectionUtils.isNotEmpty(permutationsToGenerate)) {
+            ExtensionResultHolder<Integer> resultHolder = new ExtensionResultHolder<>();
+            ExtensionResultStatusType resultStatusType = extensionManager.getProxy().persistSkuPermutation(product, permutationsToGenerate, resultHolder);
+            if (ExtensionResultStatusType.HANDLED == resultStatusType) {
+                numPermutationsCreated = resultHolder.getResult();
+            }
+        }
+
+        if (numPermutationsCreated == 0) {
+            result.put("message", BLCMessageUtils.getMessage(NO_SKUS_GENERATED_KEY));
+        }
+        LOG.info("Total number of permutations generated: " + numPermutationsCreated);
+
+        result.put("message", numPermutationsCreated + " " + BLCMessageUtils.getMessage(NUMBER_SKUS_GENERATED_KEY));
+        result.put("skusGenerated", numPermutationsCreated);
+        return result;
+    }
+
+    protected boolean checkSkuMaxGeneration(List<ProductOption> productOptions) {
+        boolean beyondAvailable = false;
+        long count = productOptions.stream()
+                .map(ProductOption::getAllowedValues)
+                .mapToInt(List::size)
+                .reduce(1, Math::multiplyExact);;
+        if (count > skuMaxGeneration) {
+            beyondAvailable = true;
+        }
+        return beyondAvailable;
     }
 
     protected boolean isSamePermutation(List<ProductOptionValue> perm1, List<ProductOptionValue> perm2) {
         if (perm1.size() == perm2.size()) {
-
-            Collection<Long> perm1Ids = BLCCollectionUtils.collect(perm1, new TypedTransformer<Long>() {
-                @Override
-                public Long transform(Object input) {
-                    return ((ProductOptionValue) input).getId();
-                }
-            });
-
-            Collection<Long> perm2Ids = BLCCollectionUtils.collect(perm2, new TypedTransformer<Long>() {
-                @Override
-                public Long transform(Object input) {
-                    return ((ProductOptionValue) input).getId();
-                }
-            });
-
+            Collection<Long> perm1Ids = BLCCollectionUtils.collect(perm1, input -> ((ProductOptionValue) input).getId());
+            Collection<Long> perm2Ids = BLCCollectionUtils.collect(perm2, input -> ((ProductOptionValue) input).getId());
             return perm1Ids.containsAll(perm2Ids);
         }
         return false;
@@ -151,8 +235,12 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
      * @param options
      * @return a list containing all of the possible combinations of ProductOptionValues based on grouping by the ProductOptionValue
      */
-    public List<List<ProductOptionValue>> generatePermutations(int currentTypeIndex, List<ProductOptionValue> currentPermutation, List<ProductOption> options) {
-        List<List<ProductOptionValue>> result = new ArrayList<List<ProductOptionValue>>();
+    public List<List<ProductOptionValue>> generatePermutations(
+            int currentTypeIndex,
+            List<ProductOptionValue> currentPermutation,
+            List<ProductOption> options
+    ) {
+        List<List<ProductOptionValue>> result = new ArrayList<>();
         if (currentTypeIndex == options.size()) {
             if (!currentPermutation.isEmpty()) {
                 result.add(currentPermutation);
@@ -173,8 +261,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             return null;
         }
         for (ProductOptionValue option : allowedValues) {
-            List<ProductOptionValue> permutation = new ArrayList<ProductOptionValue>();
-            permutation.addAll(currentPermutation);
+            List<ProductOptionValue> permutation = new ArrayList<>(currentPermutation);
             permutation.add(option);
             result.addAll(generatePermutations(currentTypeIndex + 1, permutation, options));
         }
@@ -214,8 +301,6 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             additionalSku.setProduct(derivedProduct);
             catalogService.saveSku(additionalSku);
         }
-        
-        
         return true;
     }
     

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -91,7 +91,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
         }
 
         LOG.info("Total number of permutations: " + allPermutations.size());
-        LOG.info(allPermutations);
+        LOG.debug(allPermutations);
 
         //determine the permutations that I already have Skus for
         List<List<ProductOptionValue>> previouslyGeneratedPermutations = new ArrayList<>();
@@ -144,7 +144,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
             return result;
         }
 
-        if (checkSkuMaxGeneration(product.getProductOptions())) {
+        if (this.checkSkuMaxGeneration(product.getProductOptions())) {
             result.put("message", String.format(BLCMessageUtils.getMessage(MAX_SKU_GENERATION_KEY), skuMaxGeneration));
             return result;
         }
@@ -159,7 +159,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
         }
 
         LOG.info("Total number of permutations: " + allPermutations.size());
-        LOG.info(allPermutations);
+        LOG.debug(allPermutations);
 
         //determine the permutations that I already have Skus for
         List<List<ProductOptionValue>> previouslyGeneratedPermutations = new ArrayList<>();
@@ -209,7 +209,8 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
 
     protected boolean checkSkuMaxGeneration(List<ProductOption> productOptions) {
         boolean beyondAvailable = false;
-        long count = productOptions.stream()
+        int count = productOptions.stream()
+                .filter(ProductOption::getUseInSkuGeneration)
                 .map(ProductOption::getAllowedValues)
                 .mapToInt(List::size)
                 .reduce(1, Math::multiplyExact);;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -60,7 +60,7 @@ public class AdminCatalogServiceImpl implements AdminCatalogService {
     public static String FAILED_SKU_GENERATION_KEY = "errorNeedAllowedValue";
     public static String NUMBER_SKUS_GENERATED_KEY = "numberSkusGenerated";
 
-    @Value("${product.sku.generation.max:2}")
+    @Value("${product.sku.generation.max:400}")
     protected int skuMaxGeneration;
 
     @Resource(name = "blCatalogService")

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/action/AdminCatalogActionsController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/action/AdminCatalogActionsController.java
@@ -19,7 +19,6 @@ package org.broadleafcommerce.admin.web.controller.action;
 
 import org.broadleafcommerce.admin.server.service.AdminCatalogService;
 import org.broadleafcommerce.admin.web.controller.entity.AdminProductController;
-import org.broadleafcommerce.common.util.BLCMessageUtils;
 import org.broadleafcommerce.core.catalog.domain.Product;
 import org.broadleafcommerce.openadmin.web.controller.AdminAbstractController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Resource;
@@ -48,48 +46,29 @@ import javax.servlet.http.HttpServletResponse;
  */
 @Controller("blAdminCatalogActionsController")
 public class AdminCatalogActionsController extends AdminAbstractController {
-    
+
     @Resource(name = "blAdminCatalogService")
     protected AdminCatalogService adminCatalogService;
-    
     @Autowired
     protected MessageSource messageSource;
-
-    public static String NO_SKUS_GENERATED_KEY = "noSkusGenerated";
-    public static String NO_PRODUCT_OPTIONS_GENERATED_KEY = "noProductOptionsConfigured";
-    public static String FAILED_SKU_GENERATION_KEY = "errorNeedAllowedValue";
-    public static String NUMBER_SKUS_GENERATED_KEY = "numberSkusGenerated";
 
     /**
      * Invokes a separate service to generate a list of Skus for a particular {@link Product} and that {@link Product}'s
      * Product Options
      */
     @RequestMapping(value = "product/{productId}/{skusFieldName}/generate-skus",
-                    method = RequestMethod.GET,
-                    produces = "application/json")
+            method = RequestMethod.GET,
+            produces = "application/json")
     public @ResponseBody Map<String, Object> generateSkus(HttpServletRequest request, HttpServletResponse response, Model model,
-            @PathVariable(value = "productId") Long productId,
-            @PathVariable(value = "skusFieldName") String skusFieldName) {
-        HashMap<String, Object> result = new HashMap<>();
-        Integer skusGenerated = adminCatalogService.generateSkusFromProduct(productId);
-        
-        //TODO: Modify the message "Failed to generate Skus...." to include which Product Option is the offender
-        if (skusGenerated == 0) {
-            result.put("message", BLCMessageUtils.getMessage(NO_SKUS_GENERATED_KEY));
-        } else if (skusGenerated == -1) {
-            result.put("message", BLCMessageUtils.getMessage(NO_PRODUCT_OPTIONS_GENERATED_KEY));
-        } else if (skusGenerated == -2) {
-            result.put("message", BLCMessageUtils.getMessage(FAILED_SKU_GENERATION_KEY));
-            result.put("error", "no-allowed-value-error");
-        } else {
-            result.put("message", skusGenerated + " " + BLCMessageUtils.getMessage(NUMBER_SKUS_GENERATED_KEY));
-        }
-        
+                                                          @PathVariable(value = "productId") Long productId,
+                                                          @PathVariable(value = "skusFieldName") String skusFieldName) {
+        Map<String, Object> responseBody = adminCatalogService.generateSkus(productId);
+
         String url = request.getRequestURL().toString();
         url = url.substring(0, url.indexOf("/generate-skus"));
-        
-        result.put("skusGenerated", skusGenerated);
-        result.put("listGridUrl", url);
-        return result;
+
+        responseBody.put("listGridUrl", url);
+        return responseBody;
     }
+
 }

--- a/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
@@ -51,6 +51,7 @@ valueIllegalForPropertyType=This value is not allowed for the given property typ
 
 # For AdminCatalogActionsController
 errorNeedAllowedValue=Failed to generate Skus. One of the Product Options has no Allowed Values.
+maxSkuGenerated=Sku generation is not possible because it will create more than them maximum allowed of %d. Please check that all the Product Options that have been added to this product are set up correctly with the "Use in Sku Generation" flag.
 noSkusGenerated=No Skus were generated. Each product option value permutation already has a Sku associated with it.
 noProductOptionsConfigured=This product has no Product Options configured to generate Skus from.
 numberSkusGenerated=Sku(s) generated from the configured product options.

--- a/admin/broadleaf-open-admin-platform/src/main/resources/config/bc/admin/common.properties
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/config/bc/admin/common.properties
@@ -64,3 +64,6 @@ admin.password.regex.validation=[^\\s]{6,}
 #this could cause unwanted validation errors. Like during import for something that is not client-facing(shown on site)
 #and invalid/incomplete html can be accepted
 ignore.entities.for.cleaning.list=
+
+# Maximum number of skus that will be generated
+product.sku.generation.max=400


### PR DESCRIPTION
**A Brief Overview**
A new logic of generation Skus has been created based on AdminCatalogServiceImpl.generateSkusFromProduct().
Added check for potential number of Skus generated.

**Link to QA issue**
[QA-5164](https://github.com/BroadleafCommerce/QA/issues/5164)

