### PR TITLE
Fixed an issue where the discount value was displayed incorrectly for Amount Off 

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
@@ -262,7 +262,9 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
                         .replaceAll(Pattern.quote(moneySuffix), "")
                         .replaceAll("\\%", "")
                         .replaceAll("\\" + groupingSeparator, "");
-                setValue = this.stripTrailingZeros(setValue, decimalSeparator);
+                if (!setValue.isEmpty()) {
+                    setValue = this.stripTrailingZeros(setValue, decimalSeparator);
+                }
                 discountValue.setValue(setValue);
             }
 

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
@@ -262,12 +262,20 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
                         .replaceAll(Pattern.quote(moneySuffix), "")
                         .replaceAll("\\%", "")
                         .replaceAll("\\" + groupingSeparator, "");
+                setValue = this.stripTrailingZeros(setValue, decimalSeparator);
                 discountValue.setValue(setValue);
             }
 
             addIsActiveStatus(helper, entity);
         }
         return resultSet;
+    }
+
+    protected String stripTrailingZeros(String value, String decimalSeparator) {
+        String replaceDecimalSeparator = value.replace(decimalSeparator, ".");
+        BigDecimal number = new BigDecimal(replaceDecimalSeparator);
+        String stripTrailingZeros = number.stripTrailingZeros().toPlainString();
+        return stripTrailingZeros.replace(".", decimalSeparator);
     }
 
     protected void addIsActiveFiltering(CriteriaTransferObject cto) {

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/OfferCustomPersistenceHandler.java
@@ -256,10 +256,12 @@ public class OfferCustomPersistenceHandler extends ClassCustomPersistenceHandler
                 String moneyPrefix = ((DecimalFormat) nf).getPositivePrefix();
                 String moneySuffix = ((DecimalFormat) nf).getPositiveSuffix();
                 String setValue = discountValue.getValue();
-                setValue = setValue.replaceAll("\\%", "")
-                        .replaceAll("\\" + decimalSeparator, "")
+                String groupingSeparator = String.valueOf(((DecimalFormat) nf).getDecimalFormatSymbols().getGroupingSeparator());
+                setValue = setValue
                         .replaceAll(Pattern.quote(moneyPrefix), "")
-                        .replaceAll(Pattern.quote(moneySuffix), "");
+                        .replaceAll(Pattern.quote(moneySuffix), "")
+                        .replaceAll("\\%", "")
+                        .replaceAll("\\" + groupingSeparator, "");
                 discountValue.setValue(setValue);
             }
 


### PR DESCRIPTION
**A Brief Overview**
In OfferCustomPersistenceHandler.fetch() uses a groupingSeparator to clear setValue

**Link to QA issue**
[QA-5156](https://github.com/BroadleafCommerce/QA/issues/5156)