### PR TITLE
Fixing checkForMatches logic to find the regEx rows only and not to iterate through all URLHandlers

### DIFF
--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/service/URLHandlerServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/url/service/URLHandlerServiceImpl.java
@@ -147,7 +147,7 @@ public class URLHandlerServiceImpl implements URLHandlerService {
     protected URLHandler checkForMatches(String requestURI) {
         URLHandler currentHandler = null;
         try {
-            List<URLHandler> urlHandlers = findAllURLHandlers();
+            List<URLHandler> urlHandlers = findAllRegexURLHandlers();
             for (URLHandler urlHandler : urlHandlers) {
                 currentHandler = urlHandler;
                 String incomingUrl = wrapStringsWithAnchors(currentHandler.getIncomingURL());

--- a/admin/broadleaf-contentmanagement-module/src/test/java/org/broadleafcommerce/cms/url/service/URLHandlerServiceTest.java
+++ b/admin/broadleaf-contentmanagement-module/src/test/java/org/broadleafcommerce/cms/url/service/URLHandlerServiceTest.java
@@ -39,21 +39,28 @@ public class URLHandlerServiceTest extends TestCase {
     
     URLHandlerServiceImpl handlerService = new URLHandlerServiceImpl();
 
-    public List<URLHandler> buildUrlHandlerList() {
+    public List<URLHandler> buildAllUrlHandlerList() {
         List<URLHandler> handlerList = new ArrayList<URLHandler>();
-
-        handlerList.add(createHandler("/simple_url", "/NewSimpleUrl"));
-        handlerList.add(createHandler("^/simple_regex$", "/NewSimpleRegex"));
-        handlerList.add(createHandler("/blogs/(.*)/(.*)$", "/newblogs/$2/$1"));
-        handlerList.add(createHandler("(.*)/shirts-tops(.*)", "$1/shirts$2"));
+        handlerList.add(createHandler("/simple_url", "/NewSimpleUrl", false));
+        handlerList.addAll(buildRegExUrlHandlerList());
         return handlerList;
     }
 
-    protected URLHandler createHandler(String incomingUrl, String newUrl) {
+    public List<URLHandler> buildRegExUrlHandlerList() {
+        List<URLHandler> handlerList = new ArrayList<URLHandler>();
+
+        handlerList.add(createHandler("^/simple_regex$", "/NewSimpleRegex", true));
+        handlerList.add(createHandler("/blogs/(.*)/(.*)$", "/newblogs/$2/$1", true));
+        handlerList.add(createHandler("(.*)/shirts-tops(.*)", "$1/shirts$2", true));
+        return handlerList;
+    }
+
+    protected URLHandler createHandler(String incomingUrl, String newUrl, Boolean isRegEx) {
         URLHandler handler = new URLHandlerImpl();
         handler.setIncomingURL(incomingUrl);
         handler.setNewURL(newUrl);
         handler.setUrlRedirectType(URLRedirectType.REDIRECT_PERM);
+        handler.setRegexHandler(isRegEx);
         return handler;
     }
 
@@ -62,14 +69,16 @@ public class URLHandlerServiceTest extends TestCase {
 
         URLHandlerDao handlerDao = EasyMock.createMock(URLHandlerDao.class);
         handlerService.urlHandlerDao = handlerDao;
-        EasyMock.expect(handlerDao.findAllURLHandlers()).andReturn(buildUrlHandlerList());
+        EasyMock.expect(handlerDao.findAllURLHandlers()).andReturn(buildAllUrlHandlerList());
+        EasyMock.expect(handlerDao.findAllRegexURLHandlers()).andReturn(buildRegExUrlHandlerList());
         EasyMock.replay(handlerDao);
     }
 
+    //checkForMatches is the RegEx test.  A non-regex URLHandler should not be found
     @Test
-    public void testFoundSimpleUrl() {
+    public void testNotFoundSimpleUrlWithCheckForMatches() {
         URLHandler h = handlerService.checkForMatches("/simple_url");
-        assertTrue(h.getNewURL().equals("/NewSimpleUrl"));
+        assertTrue(h == null);
     }
 
     @Test


### PR DESCRIPTION
 Fixes https://github.com/BroadleafCommerce/QA/issues/5191

### Release Notes ###
If clients are not using the RegEx boolean flag, this change could impact them.  That flag should be used when the URLHandler needs to be checked for a matching Regular Expression.

