### PR TITLE
Fixed an issue where Filters interpret HTML code

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/filterbuilder.js
@@ -1133,8 +1133,6 @@ $(document).ready(function() {
      * Invoked from the "Apply" button on an individual row
      */
     $('body').on('click', 'button.filter-apply-button', function () {
-        // apply the filters
-        BLCAdmin.filterBuilders.applyFilters();
 
         // mark this rule as read-only
         var el = $(this).parent().parent().parent();
@@ -1173,6 +1171,8 @@ $(document).ready(function() {
             hideError($errorContainer);
         }
 
+        // apply the filters
+        BLCAdmin.filterBuilders.applyFilters();
 
         el.find('.read-only').remove();
         el.find('.filter-text').remove();


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5198

**A Brief Overview**
Filters where text input is allowed, for example in Catalogs - filter "Catalog name", interpret HTML code.
The fix moves the "add filter" method call after validation.