### PR TITLE
Fixed an issue where Entity header disappears after reload the product page

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -30,6 +30,17 @@
             if ($stickyContainer.length) {
                 originalStickyBarOffset = $stickyContainer.offset().top;
                 originalStickyBarHeight = $stickyContainer.height();
+                if (originalStickyBarOffset < 0) {
+                    originalStickyBarOffset = 0;
+                    var $sandboxBar = $('.sandbox-bar');
+                    if ($sandboxBar !== undefined) {
+                        originalStickyBarOffset = originalStickyBarOffset + $sandboxBar.height();
+                    }
+                    var $siteBar = $('.site-bar');
+                    if ($siteBar !== undefined) {
+                        originalStickyBarOffset = originalStickyBarOffset + $siteBar.height();
+                    }
+                }
             }
 
             if ($('form.entity-form').length && !$('.oms').length) {


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5228

**A Brief Overview**
The solution for such edge cases is to recalculate the initial position based on the height of (.sandbox-bar + .site-bar) elements
