### PR TITLE
protection for npe in case of using java 8 - lambdas etc will have null classname

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyClassTransformer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/jpa/copy/DirectCopyClassTransformer.java
@@ -65,6 +65,9 @@ public class DirectCopyClassTransformer implements BroadleafClassTransformer {
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, 
             ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        if (className == null) {
+            return null;
+        }
         String convertedClassName = className.replace('/', '.');
         
         if (xformTemplates.containsKey(convertedClassName)) {


### PR DESCRIPTION
protection for npe in case of using java 8 - lambdas etc will have null classname