### PR TITLE
Fixes the Spring Web Security vulnerability

### DIFF
--- a/core/broadleaf-framework/pom.xml
+++ b/core/broadleaf-framework/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.4</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -95,12 +95,16 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper-jute</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.4</version>
             <scope>compile</scope>
         </dependency>
         <!-- Solr still needs this dependency, we'll just use the later version -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,18 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ehcache3.version>3.10.8</ehcache3.version>
-        <spring.version>6.0.13</spring.version>
-        <spring.security.version>6.1.5</spring.security.version>
-        <spring.boot.version>3.1.5</spring.boot.version>
-        <jackson.version>2.15.3</jackson.version>
+        <spring.version>6.0.18</spring.version>
+        <spring.security.version>6.1.8</spring.security.version>
+        <spring.boot.version>3.1.10</spring.boot.version>
+        <jackson.version>2.16.2</jackson.version>
         <lombok.version>1.18.30</lombok.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <geb.version>7.0</geb.version>
-        <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
-        <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
+        <spock.core.version>2.4-M4-groovy-4.0</spock.core.version>
+        <spock.spring.version>2.4-M4-groovy-4.0</spock.spring.version>
         <selenium.version>4.14.1</selenium.version>
         <project.uri>${project.baseUri}</project.uri>
-        <groovy.version>4.0.15</groovy.version>
+        <groovy.version>4.0.20</groovy.version>
         <gpg.plugin.version>3.1.0</gpg.plugin.version>
         <broadleaf-presentation.version>2.0.0-GA</broadleaf-presentation.version>
         <hsqldb.database.starter.version>3.0.0-GA</hsqldb.database.starter.version>
@@ -65,7 +65,7 @@
         <jakarta-xml.version>4.0.0</jakarta-xml.version>
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <logback.version>1.4.11</logback.version>
+        <logback.version>1.4.14</logback.version>
         <!-- because of spring when does instrumentation it uses reflection to jdk classes, for tests we need this -->
         <surefire.argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</surefire.argLine>
         <failsafe.argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</failsafe.argLine>
@@ -390,7 +390,7 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
-                      <version>8.4.0</version>
+                      <version>8.4.3</version>
                       <executions>
                           <execution>
                               <goals>
@@ -627,7 +627,7 @@
             <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
-                <version>1.7</version>
+                <version>1.8.0</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>commons-logging</artifactId>
@@ -709,7 +709,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.15.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -719,17 +719,23 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.15</version>
+                <version>1.16.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.14.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.10.0</version>
+                <version>1.11.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Logging -->
@@ -860,13 +866,13 @@
             <dependency>
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
-                <version>5.10.0</version>
+                <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>5.1.0</version>
+                <version>5.2.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1004,11 +1010,23 @@
             <dependency>
                 <groupId>org.apache.solr</groupId>
                 <artifactId>solr-solrj</artifactId>
-                <version>9.3.0</version>
+                <version>9.5.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1041,7 +1059,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.8</version>
+                <version>1.14.12</version>
             </dependency>
 
             <!--Scheduling Libraries -->
@@ -1063,7 +1081,7 @@
             <dependency>
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
-                <version>2.4.3.Final</version>
+                <version>2.4.15.Final</version>
             </dependency>
 
             <!--Regular Expression Libraries -->
@@ -1440,6 +1458,10 @@
                     <exclusion>
                         <groupId>org.owasp.antisamy</groupId>
                         <artifactId>antisamy</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <groovy.version>4.0.20</groovy.version>
         <gpg.plugin.version>3.1.0</gpg.plugin.version>
         <broadleaf-presentation.version>2.0.0-GA</broadleaf-presentation.version>
-        <hsqldb.database.starter.version>3.0.0-GA</hsqldb.database.starter.version>
+        <hsqldb.database.starter.version>3.0.1-SNAPSHOT</hsqldb.database.starter.version>
         <hsqldb.version>2.7.2</hsqldb.version>
         <closure.compiler.version>v20180506</closure.compiler.version>
         <hibernate.version>6.2.13.Final</hibernate.version>


### PR DESCRIPTION
**A Brief Overview**
Updated versions of spring, spock, jackson, groovy, logback, commons-*, dependency-check-maven, junit-vintage-engine, easymock, solr-solrj, byte-buddy, mvel2, zookeeper, zookeeper-jute

**Link to QA issue**
[QA-5212](https://github.com/BroadleafCommerce/QA/issues/5212)