### PR TITLE
Fixed an issue where Generate skus button can result in duplicated skus

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
@@ -55,6 +55,7 @@ maxSkuGenerated=Sku generation is not possible because it will create more than 
 noSkusGenerated=No Skus were generated. Each product option value permutation already has a Sku associated with it.
 noProductOptionsConfigured=This product has no Product Options configured to generate Skus from.
 numberSkusGenerated=Sku(s) generated from the configured product options.
+inconsistentPermutations=<br> There are previously generated permutations <br> that do not match current set of the product options.<br> Please fix them manually or delete before clicking 'Generate Skus' button.
 
 Duplication_Failure=Entity Failed Duplication
 Validation_Failure=Entity failed validation for Duplication. Refresh the page and try again. If there are saved changes, deploy or revert them and try again.


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5230


**A Brief Overview**

**The solution is:**
In the case when we have previously generated Skus that don't match the current set of product options we don't generate new Skus and show the error message.

**Possible action to fix:**
1. Open each wrong Skus and fix it manually according to the current product options configuration
2. Delete all wrong Skus

**The message is:**
There are previously generated permutations
that don't match current set of the product options.
Please fix them manually or delete before clicking Generate Skus button.
