### PR TITLE
Removed Cancel button from the admin change password modal

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/login/changePasswordPopup.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/login/changePasswordPopup.html
@@ -25,7 +25,6 @@
 
         <div class="actions">
             <button class="button primary change-password-confirm" th:text="#{PasswordChange_submitButton}"></button>
-            <a href="#" class="button secondary action-popup-cancel" th:text="#{Cancel}"></a>
         </div>
     
         <img th:src="@{/img/admin/ajax-loader.gif}" class="ajax-loader" />


### PR DESCRIPTION
**A Brief Overview**
Removed redundant action button

**Link**
https://github.com/BroadleafCommerce/QA/issues/5240
![Screenshot 2024-04-15 at 13 50 56](https://github.com/BroadleafCommerce/BroadleafCommerce/assets/6154569/6859b52c-196d-47d8-bfe4-2944ab5206cd)


