### PR TITLE
Added new filter that ignores all other filters

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/web/filter/GeneralIgnoreFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/filter/GeneralIgnoreFilter.java
@@ -1,0 +1,24 @@
+package org.broadleafcommerce.common.web.filter;
+
+import org.broadleafcommerce.common.util.BLCRequestUtils;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+
+public class GeneralIgnoreFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        BLCRequestUtils.setIsFilteringIgnoredForUri(new ServletWebRequest((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse), Boolean.TRUE);
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}

--- a/common/src/main/java/org/broadleafcommerce/common/web/filter/SecurityBasedIgnoreFilter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/filter/SecurityBasedIgnoreFilter.java
@@ -19,8 +19,6 @@ package org.broadleafcommerce.common.web.filter;
 
 import org.broadleafcommerce.common.util.BLCRequestUtils;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;


### PR DESCRIPTION
**A Brief Overview**
Added a new filter for resolving warnings while loading resource files

**Additional context**
https://github.com/BroadleafCommerce/QA/issues/5242

Example of how to use in SiteSecurityConfig.class

Need to replace:

```
 @Bean
    public WebSecurityCustomizer webSecurityCustomizer() {
        return (web) -> web.ignoring().requestMatchers(
                antMatcher("/css/**"),
                antMatcher("/fonts/**"),
                antMatcher("/img/**"),
                antMatcher("/js/**"),
                antMatcher("/widget/js/**"),
                antMatcher("/**/" + assetServerUrlPrefixInternal + "/**"),
                antMatcher("/favicon.ico"));
    }
```
 with a new configuration
```
    @Bean
    @Order(0)
    SecurityFilterChain resources(HttpSecurity http) throws Exception {
        http
            .securityMatchers(matcherConfigurer -> matcherConfigurer.requestMatchers(
                antMatcher("/css/**"),
                antMatcher("/fonts/**"),
                antMatcher("/img/**"),
                antMatcher("/js/**"),
                antMatcher("/**/" + assetServerUrlPrefixInternal + "/**"),
                antMatcher("/favicon.ico"),
                antMatcher("/widget/js/**")))
            .logout().disable()
            .csrf().disable()
            .headers().disable()
            .requestCache().disable()
            .securityContext().disable()
            .sessionManagement().disable()
            .anonymous().disable()
            .exceptionHandling().disable()
            .servletApi().disable()
            .formLogin().disable()
            .httpBasic().disable()
            .addFilterBefore(new GeneralIgnoreFilter(), UsernamePasswordAuthenticationFilter.class);

        return http.build();
    }
```

