### PR TITLE
Add validation to avoid Orphaned Offer Code records

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/UtilityMessages.properties
@@ -61,3 +61,4 @@ Duplication_Failure=Entity Failed Duplication
 Validation_Failure=Entity failed validation for Duplication. Refresh the page and try again. If there are saved changes, deploy or revert them and try again.
 
 OfferCode_Duplication_Validation_Failure=Offer code with the same value already exist
+OfferCode_Not_Saved_Offer_Validation_Failure=Please save parent Offer before add Offer Code


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5260

**A Brief Overview**
The solution:
Not to allow saving the offer code if the parent Offer is not saved.