### PR TITLE
Fixes the errors with the sandbox class transformer

### DIFF
--- a/common/src/main/resources/bl-common-applicationContext.xml
+++ b/common/src/main/resources/bl-common-applicationContext.xml
@@ -73,6 +73,7 @@
                             <value>net\.bytebuddy.*</value>
                             <value>org\.owasp.*</value>
                             <value>org\.htmlunit.*</value>
+                            <value>io\.netty.*</value>
                         </array>
                     </property>
                 </bean>


### PR DESCRIPTION
**A Brief Overview**
This error appears when we are using Redis in sandbox class transformer.
Added io.netty to the list of patterns in blDirectCopyIgnorePatterns

**Additional context**
[QA-5269](https://github.com/BroadleafCommerce/QA/issues/5269)
