### PR TITLE
Set "use strict" mode for JavaScript to false in the Closure Compiler

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/resource/service/GoogleClosureJavascriptMinificationServiceImpl.java
@@ -69,6 +69,9 @@ public class GoogleClosureJavascriptMinificationServiceImpl implements Javascrip
     @Value("${minify.closure.compiler.warningLevel:QUIET}")
     protected String warningLevel;
 
+    @Value("${minify.closure.compiler.strictMode:false}")
+    protected Boolean strictMode;
+
     protected CompilerOptions.LanguageMode languageIn;
     protected CompilerOptions.LanguageMode languageOut;
 
@@ -137,6 +140,8 @@ public class GoogleClosureJavascriptMinificationServiceImpl implements Javascrip
         WarningLevel.valueOf(this.warningLevel).setOptionsForWarningLevel(options);
         options.setClosurePass(true);
         options.skipAllCompilerPasses();
+        options.setEmitUseStrict(strictMode);
+        options.setStrictModeInput(strictMode);
         return options;
     }
 

--- a/common/src/main/resources/config/bc/common.properties
+++ b/common/src/main/resources/config/bc/common.properties
@@ -95,6 +95,9 @@ minify.closure.compiler.languageOut=NO_TRANSPILE
 # Possible values: QUIET, DEFAULT, VERBOSE
 minify.closure.compiler.warningLevel=QUIET
 
+# Sets "use strict" mode for JavaScript
+minify.closure.compiler.strictMode=false
+
 site.baseurl=http://localhost:8080
 admin.baseurl=http://localhost:8081
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5275

**A Brief Overview**
Set "use strict" mode for JavaScript to false in the Closure Compiler