### PR TITLE
Adding ability to change locale for currency

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/currency/util/BroadleafCurrencyUtils.java
+++ b/common/src/main/java/org/broadleafcommerce/common/currency/util/BroadleafCurrencyUtils.java
@@ -19,13 +19,14 @@ package org.broadleafcommerce.common.currency.util;
 
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.money.Money;
+import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Currency;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -137,74 +138,20 @@ public class BroadleafCurrencyUtils {
      * @return either a new NumberFormat instance, or one taken from the cache
      */
     public static NumberFormat getNumberFormatFromCache(Locale locale, Currency currency) {
-        return getNumberFormatFromCache(locale, currency, CurrencyLocation.DEFAULT.name());
+        return getNumberFormatFromCache(locale, currency, new HashMap<>());
     }
 
-    public static NumberFormat getNumberFormatFromCache(Locale locale, Currency currency, String location) {
+    public static NumberFormat getNumberFormatFromCache(Locale locale, Currency currency, Map<String, String> localeToChange) {
         String key = locale.toString() + currency.getCurrencyCode();
         if (!FORMAT_CACHE.containsKey(key)) {
+            if (localeToChange.containsKey(locale.toString())) {
+                locale = StringUtils.parseLocaleString(localeToChange.get(locale.toString()));
+            }
             NumberFormat format = NumberFormat.getCurrencyInstance(locale);
             format.setCurrency(currency);
-            specifyCurrencyLocation((DecimalFormat)format, location);
             FORMAT_CACHE.put(key, format);
         }
         return FORMAT_CACHE.get(key);
-    }
-
-    protected static void specifyCurrencyLocation(DecimalFormat format, String location) {
-        CurrencyLocation currencyLocation = currencyLocation(location);
-        switch (currencyLocation) {
-            case PREFIX:
-                prefixCurrencyLocation(format);
-                break;
-            case SUFFIX:
-                suffixCurrencyLocation(format);
-                break;
-            default:
-                break;
-        }
-    }
-
-    protected static CurrencyLocation currencyLocation(String location) {
-        CurrencyLocation currencyLocation;
-        try {
-            currencyLocation = CurrencyLocation.valueOf(location);
-        } catch (IllegalArgumentException e) {
-            currencyLocation = CurrencyLocation.DEFAULT;
-        }
-        return currencyLocation;
-    }
-
-    protected static void suffixCurrencyLocation(DecimalFormat format) {
-        String positivePrefix = format.getPositivePrefix();
-        if (!positivePrefix.isEmpty()) {
-            format.setPositivePrefix(format.getPositiveSuffix());
-            format.setPositiveSuffix(positivePrefix);
-        }
-        String negativePrefix = format.getNegativePrefix();
-        if (!negativePrefix.isEmpty()) {
-            format.setNegativePrefix(format.getNegativeSuffix());
-            format.setNegativeSuffix(negativePrefix);
-        }
-    }
-
-    protected static void prefixCurrencyLocation(DecimalFormat format) {
-        String positiveSuffix = format.getPositiveSuffix();
-        if (!positiveSuffix.isEmpty()) {
-            format.setPositiveSuffix(format.getPositivePrefix());
-            format.setPositivePrefix(positiveSuffix);
-        }
-        String negativeSuffix = format.getNegativeSuffix();
-        if (!negativeSuffix.isEmpty()) {
-            format.setNegativeSuffix(format.getNegativePrefix());
-            format.setNegativePrefix(negativeSuffix);
-        }
-    }
-
-    public enum CurrencyLocation {
-        DEFAULT,
-        PREFIX,
-        SUFFIX
     }
 
 }

--- a/common/src/main/java/org/broadleafcommerce/common/util/BLCMoneyFormatUtils.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/BLCMoneyFormatUtils.java
@@ -21,6 +21,9 @@ import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;
 
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * Convenience class to format prices for front-end display.
  * 
@@ -48,14 +51,14 @@ public class BLCMoneyFormatUtils {
         }
     }
 
-    public static String formatPrice(Money price, String location) {
+    public static String formatPrice(Money price, Map<String,String> localeToChange) {
         if (price == null) {
             return "Not Available";
         }
 
-        BroadleafRequestContext brc = BroadleafRequestContext.getBroadleafRequestContext();
-        if (brc.getJavaLocale() != null) {
-            return BroadleafCurrencyUtils.getNumberFormatFromCache(brc.getJavaLocale(), price.getCurrency(), location)
+        Locale javaLocale = BroadleafRequestContext.getBroadleafRequestContext().getJavaLocale();
+        if (javaLocale != null) {
+            return BroadleafCurrencyUtils.getNumberFormatFromCache(javaLocale, price.getCurrency(),localeToChange)
                     .format(price.getAmount());
         } else {
             // Setup your BLC_CURRENCY and BLC_LOCALE to display a diff default.

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/PriceTextDisplayProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/PriceTextDisplayProcessor.java
@@ -25,6 +25,7 @@ import org.broadleafcommerce.presentation.model.BroadleafTemplateContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -49,8 +50,8 @@ public class PriceTextDisplayProcessor extends AbstractBroadleafTagTextModifierP
         return 1500;
     }
 
-    @Value("${currency.location:DEFAULT}")
-    protected String currencyLocation;
+    @Value("#{${currency.locale.change}}")
+    protected Map<String, String> localeToChange = new HashMap<>();
 
     @Override
     public String getTagText(String tagName, Map<String, String> tagAttributes, String attributeName, String attributeValue, BroadleafTemplateContext context) {
@@ -63,7 +64,7 @@ public class PriceTextDisplayProcessor extends AbstractBroadleafTagTextModifierP
             price = new Money(((Number)result).doubleValue());
         }
 
-        return BLCMoneyFormatUtils.formatPrice(price, currencyLocation);
+        return BLCMoneyFormatUtils.formatPrice(price, localeToChange);
     }
 
 }


### PR DESCRIPTION
**A Brief Overview**
Added localeToChange to replace locale for the currency

property example: 
currency.locale.change={it_IT:'fr_FR'}

[QA-5268](https://github.com/BroadleafCommerce/QA/issues/5283)
