### PR TITLE
Support rounding mode property for the offer calculations

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/money/Money.java
+++ b/common/src/main/java/org/broadleafcommerce/common/money/Money.java
@@ -82,6 +82,10 @@ public class Money implements Serializable, Cloneable, Comparable<Money>, Extern
         this(amount, Currency.getInstance(getCurrencyCode(blCurrency)), scale);
     }
 
+    public Money(BigDecimal amount, BroadleafCurrency blCurrency, int scale, RoundingMode roundingMode) {
+        this(amount.setScale(scale, roundingMode), blCurrency);
+    }
+
     public Money() {
         this(BankersRounding.zeroAmount(), defaultCurrency());
     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
@@ -179,7 +179,7 @@ public class PromotableOfferUtilityImpl implements PromotableOfferUtility {
                 // override scale from rounding settings if set
                 scale = rounding.getRoundingScale();
             }
-            adjustmentValue = new Money(offerValue, currency, scale);
+            adjustmentValue = new Money(offerValue, currency, scale, rounding.getRoundingMode());
             if (rounding.getRoundingScale() != null) {
                 adjustmentValue = Money.trimUnnecessaryScaleToCurrency(adjustmentValue);
             }


### PR DESCRIPTION
**A Brief Overview**
Added a new constructor to the Money with Rounding mode and use it in the `PromotableOfferUtilityImpl`

**Issue**
https://github.com/BroadleafCommerce/QA/issues/5294