### PR TITLE
Fixes the issue where incorrect product status check before adding to cart

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/add/ValidateAddRequestActivity.java
@@ -149,8 +149,12 @@ public class ValidateAddRequestActivity extends BaseActivity<ProcessContext<Cart
     }
 
     protected void validateIfProductIsProdRecord(Product product) {
-        if (product != null && sandBoxHelper.getOriginalId(product) != null) {
-            throw new IllegalArgumentException("Only production record could be added to the cart");
+        if (product != null) {
+            Long originalId = sandBoxHelper.getOriginalId(product);
+            if (originalId != null
+                    && !originalId.equals(sandBoxHelper.getProductionOriginalId(product.getClass(), product.getId()).getOriginalId())) {
+                throw new IllegalArgumentException("Only production record could be added to the cart");
+            }
         }
     }
 


### PR DESCRIPTION
**A Brief Overview**
 fixed validateIfProductIsProdRecord()

issue was introduced by:
BroadleafCommerce/QA#5081
 
**Link to QA issue**
[https://github.com/BroadleafCommerce/QA/issues/5308](https://github.com/BroadleafCommerce/QA/issues/5308)
