### PR TITLE
Fixed typo in the ADDRESS_COUNTRY_INDEX

### DIFF
--- a/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
+++ b/core/broadleaf-profile/src/main/java/org/broadleafcommerce/profile/core/domain/AddressImpl.java
@@ -60,7 +60,7 @@ import jakarta.persistence.Table;
         @Index(name = "ADDRESS_PHONE_PRI_IDX", columnList = "PHONE_PRIMARY_ID"),
         @Index(name = "ADDRESS_PHONE_SEC_IDX", columnList = "PHONE_SECONDARY_ID"),
         @Index(name = "ADDRESS_PHONE_FAX_IDX", columnList = "PHONE_FAX_ID"),
-        @Index(name = "ADDRESS_COUNTRY_INDEX", columnList = "COUNTY")
+        @Index(name = "ADDRESS_COUNTY_INDEX", columnList = "COUNTY")
 })
 @AdminPresentationMergeOverrides({
         @AdminPresentationMergeOverride(name = "phonePrimary", mergeEntries =


### PR DESCRIPTION
**A Brief Overview**
Renamed index in the entity

**Additional context**
https://github.com/BroadleafCommerce/QA/issues/5293
