### PR TITLE
Adding validation before adding an SKU manually

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
@@ -235,6 +235,8 @@ productOptionValue_displayOrder=Display Order
 productOptionValue_attributeValue=Attribute Value
 productOptionValue_adjustment=Price Adjustment
 skuNullProductOption=Please select an option from the list.
+notAvailableProductOption=There is no suitable productOption available for SKU creation
+emptyProductOptions=To create an SKU, the product must have the options
 
 Seo_Group=SEO Properties
 cloneErrorMessage=There was an error when cloning product ${productName}


### PR DESCRIPTION
**A Brief Overview**
Added validation before adding an SKU manually:
- check for empty ProductOptions
- check for available ProductOption

**QA**
[QA-5312](https://github.com/BroadleafCommerce/QA/issues/5312)
