### PR TITLE
Fixed an issue where Too many skus to generate error message does not appear for moved product options

### DIFF
--- a/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/product.js
+++ b/admin/broadleaf-admin-module/src/main/resources/admin_style/js/admin/catalog/product.js
@@ -61,13 +61,17 @@ $(document).ready(function() {
             type : "GET"
         }, function(data) {
             var alertType = data.error ? 'error-alert' : data.skusGenerated > 0 ? 'save-alert' : 'error-alert';
-            
-            BLCAdmin.listGrid.showAlert($container, data.message, {
-                alertType: alertType,
-                clearOtherAlerts: true,
-                autoClose: 5000
-            });
-            
+
+            if (alertType === 'error-alert') {
+                BLCAdmin.showMessageAsModal('Failed to generate Skus', data.message);
+            } else {
+                BLCAdmin.listGrid.showAlert($container, data.message, {
+                    alertType: alertType,
+                    clearOtherAlerts: true,
+                    autoClose: 5000
+                });
+            }
+
             if (data.skusGenerated > 0) {
                 BLCAdmin.product.refreshSkusGrid($container, data.listGridUrl);
             }

--- a/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
+++ b/admin/broadleaf-admin-module/src/main/resources/messages/MerchandisingMessages.properties
@@ -113,6 +113,7 @@ productOption_general=General
 productOption_details=Details
 productOption_validation=Validation
 productOption_group=Options
+productOption_description=Description
 newProductOptionValue=New Value
 
 allowedValuesRequired_ValidationFailure=If this Product Option is to be used in sku generation, then it must have at least one Option Value.

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductOptionImpl.java
@@ -155,7 +155,7 @@ public class ProductOptionImpl implements ProductOption, AdminMainEntity, Produc
     @Lob
     @JdbcType(LongVarcharJdbcType.class)
     @Column(name = "LONG_DESCRIPTION", length = Length.LONG32 - 1)
-    @AdminPresentation(friendlyName = "Checkbox_Description",
+    @AdminPresentation(friendlyName = "productOption_description",
             group = GroupName.General,
             largeEntry = true,
             fieldType = SupportedFieldType.HTML_BASIC,


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5347

**A Brief Overview**
The solution is to show the "Sku generation error" as a modal message
