### PR TITLE
Add Mockito package to DirectCopyIgnorePattern

### DIFF
--- a/common/src/main/resources/bl-common-applicationContext.xml
+++ b/common/src/main/resources/bl-common-applicationContext.xml
@@ -74,6 +74,7 @@
                             <value>org\.owasp.*</value>
                             <value>org\.htmlunit.*</value>
                             <value>io\.netty.*</value>
+                            <value>org\.mockito.*</value>
                         </array>
                     </property>
                 </bean>


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5346

**A Brief Overview**
Add Mockito package to DirectCopyIgnorePattern to avoid the errors below in tests:

```
11:24:47.676 [main] o.s.o.j.p.ClassFileTransformerAdapter - Error weaving class [org/mockito/internal/creation/bytebuddy/MockMethodAdvice] with transformer of class [com.broadleafcommerce.enterprise.workflow.transform.SandBoxClassTransformer]
 jakarta.persistence.spi.TransformerException: Unable to convert   org.mockito.internal.creation.bytebuddy.MockMethodAdvice to sandbox: org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher
```