### PR TITLE
Do not set readOnly flag if a transaction is NEW

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/util/TransactionUtils.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/TransactionUtils.java
@@ -59,8 +59,6 @@ public class TransactionUtils {
         // Only apply readOnly to new transactions
         if (isNewTransaction(propagationBehavior)) {
             def.setReadOnly(isReadOnly);
-        } else {
-            def.setReadOnly(false);
         }
         def.setPropagationBehavior(propagationBehavior);
         def.setIsolationLevel(isolationLevel);
@@ -76,8 +74,6 @@ public class TransactionUtils {
         // Only apply readOnly to new transactions
         if (isNewTransaction(propagationBehavior)) {
             def.setReadOnly(isReadOnly);
-        } else {
-            def.setReadOnly(false);
         }
         def.setPropagationBehavior(propagationBehavior);
         def.setIsolationLevel(isolationLevel);


### PR DESCRIPTION
Previously we set this to `FALSE` but we instead not set anything on this flag if it is not `NEW`.