### PR TITLE
Update dependency to use jakarta interceptor for successfully building java docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,8 +476,8 @@
                             <additionalDependencies>
                                 <additionalDependency>
                                     <groupId>jakarta.interceptor</groupId>
-                                    <artifactId>javax.interceptor-api</artifactId>
-                                    <version>2.1.0</version>
+                                    <artifactId>jakarta.interceptor-api</artifactId>
+                                    <version>2.2.0</version>
                                 </additionalDependency>
                             </additionalDependencies>
                         </configuration>


### PR DESCRIPTION
**A Brief Overview**
For 7.0, we migrated from javax to jakarta so update the dependency for building javadocs. This helps get past this error:

```
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/jakarta/interceptor/javax.interceptor-api/2.1.0/javax.interceptor-api-2.1.0.jar
[ERROR] MavenReportException: Error while generating Javadoc: artifact resolver problem - Could not find artifact jakarta.interceptor:javax.interceptor-api:jar:2.1.0 in replacement-public-releases (https://nexus2.broadleafcommerce.org/nexus/content/groups/community-releases/)
org.apache.maven.reporting.MavenReportException: artifact resolver problem - Could not find artifact jakarta.interceptor:javax.interceptor-api:jar:2.1.0 in replacement-public-releases 
```

https://github.com/BroadleafCommerce/QA/issues/5388