### PR TITLE
7.1 Upgrade hibernate and other libs to latest patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
         <broadleaf-presentation.version>2.1.0-SNAPSHOT</broadleaf-presentation.version>
         <hsqldb.database.starter.version>3.1.0-SNAPSHOT</hsqldb.database.starter.version>
         <ehcache3.version>3.10.8</ehcache3.version>
-        <spring.version>6.2.6</spring.version>
-        <spring.security.version>6.4.5</spring.security.version>
-        <spring.boot.version>3.4.5</spring.boot.version>
+        <spring.version>6.2.7</spring.version>
+        <spring.security.version>6.5.0</spring.security.version>
+        <spring.boot.version>3.4.6</spring.boot.version>
         <jackson.version>2.19.0</jackson.version>
         <lombok.version>1.18.36</lombok.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
@@ -60,7 +60,7 @@
         <gpg.plugin.version>3.2.7</gpg.plugin.version>
         <closure.compiler.version>v20240317</closure.compiler.version>
         <hsqldb.version>2.7.4</hsqldb.version>
-        <hibernate.version>6.6.14.Final</hibernate.version>
+        <hibernate.version>6.6.16.Final</hibernate.version>
         <jakarta.version>6.1.0</jakarta.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gpg.plugin.version>3.2.7</gpg.plugin.version>
         <closure.compiler.version>v20240317</closure.compiler.version>
         <hsqldb.version>2.7.4</hsqldb.version>
-        <hibernate.version>6.6.10.Final</hibernate.version>
+        <hibernate.version>6.6.14.Final</hibernate.version>
         <jakarta.version>6.1.0</jakarta.version>
         <jakarta-xml.version>4.0.2</jakarta-xml.version>
         <jakarta-annotation.version>3.0.0</jakarta-annotation.version>


### PR DESCRIPTION
**A Brief Overview**
New version of hibernate is available with the fix that was reported by Alex. So upgrade it to latest patch. Also upgrade few other libs.

**Additional context**
[QA LInk](https://github.com/BroadleafCommerce/QA/issues/5382)
