### PR TITLE
Set default CLOB type to TEXT for Postgres

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
+++ b/common/src/main/java/org/broadleafcommerce/common/dialect/BroadleafPostgreSQLDialect.java
@@ -30,6 +30,11 @@ import java.sql.Types;
  */
 public class BroadleafPostgreSQLDialect extends PostgreSQL95Dialect {
 
+    public BroadleafPostgreSQLDialect() {
+        super();
+        registerColumnType(Types.CLOB, "text");
+    }
+
     @Override
     public SqlTypeDescriptor getSqlTypeDescriptorOverride(int sqlCode) {
         if (sqlCode == Types.CLOB) {


### PR DESCRIPTION
**A Brief Overview**
Set default CLOB type to TEXT for Postgres