### PR TITLE
Refactor out Comparator anonymous inner class

### DIFF
--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -63,7 +63,6 @@ import java.io.Serial;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -982,15 +981,11 @@ public class ProductImpl implements Product, ProductAdminPresentation, Status, A
     @Override
     public List<ProductOptionXref> getProductOptionXrefs() {
         List<ProductOptionXref> sorted = new ArrayList<>(productOptions);
-        Collections.sort(sorted, new Comparator<ProductOptionXref>() {
-
-            @Override
-            public int compare(ProductOptionXref o1, ProductOptionXref o2) {
-                return ObjectUtils.compare(o1.getProductOption().getDisplayOrder(),
-                        o2.getProductOption().getDisplayOrder(), true);
-            }
-
-        });
+        sorted.sort((o1, o2) -> ObjectUtils.compare(
+                o1.getProductOption().getDisplayOrder(),
+                o2.getProductOption().getDisplayOrder(),
+                true)
+        );
         return sorted;
     }
 


### PR DESCRIPTION
BroadleafCommerce/QA#5412 : Runtime error due to use of `Comparator` anonymous inner class in `ProductImpl`

- Refactor out Comparator anonymous inner class and instead use lambda function to compare objects


