### PR TITLE
Upgrade Spring libraries to the latest 6.2.x release

### DIFF
--- a/admin/broadleaf-admin-module/pom.xml
+++ b/admin/broadleaf-admin-module/pom.xml
@@ -59,6 +59,7 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
         </plugins>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,6 +54,7 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
         </plugins>
@@ -212,6 +213,16 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -220,6 +231,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -246,6 +263,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/common/src/main/java/org/broadleafcommerce/common/web/resource/BroadleafResourceHttpRequestHandler.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/resource/BroadleafResourceHttpRequestHandler.java
@@ -84,7 +84,7 @@ public class BroadleafResourceHttpRequestHandler extends ResourceHttpRequestHand
     ) throws IOException {
         super.setHeaders(response, resource, mediaType);
         //Add public to cache control for universal CDN recognition
-        if (isUseCacheControlHeader() && cacheSeconds > 0) {
+        if (getCacheControl() != null && cacheSeconds > 0) {
             String header = response.getHeader(HEADER_CACHE_CONTROL);
             if (!header.contains("public")) {
                 header += ",public";

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/config/FrameworkWebConfig.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/config/FrameworkWebConfig.java
@@ -26,7 +26,6 @@ import org.broadleafcommerce.core.web.cookie.CookieRuleRequestProcessor;
 import org.broadleafcommerce.core.web.seo.BasicSeoPropertyGeneratorImpl;
 import org.broadleafcommerce.core.web.seo.SeoPropertyGenerator;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ListFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -75,7 +74,7 @@ public class FrameworkWebConfig {
     }
 
     @Bean
-    @Autowired
+//    @Autowired
     @ConditionalOnProperty("cookie.content.targeting.enabled")
     @ConditionalOnNotAdmin
     public CookieRuleRequestProcessor blCookieRuleRequestProcessor(
@@ -87,7 +86,6 @@ public class FrameworkWebConfig {
     }
 
     @Bean
-    @Autowired
     @ConditionalOnProperty("cookie.content.targeting.enabled")
     @ConditionalOnNotAdmin
     public CookieRuleFilter blCookieRuleFilter(

--- a/core/broadleaf-profile-web/pom.xml
+++ b/core/broadleaf-profile-web/pom.xml
@@ -68,6 +68,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-acl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -228,6 +228,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/integration/src/test/java/org/broadleafcommerce/test/config/AdminSpringBootTestConfiguration.java
+++ b/integration/src/test/java/org/broadleafcommerce/test/config/AdminSpringBootTestConfiguration.java
@@ -115,7 +115,6 @@ public class AdminSpringBootTestConfiguration {
     }
 
     @Bean
-    @Autowired
     public MessageCreator blMessageCreator(@Qualifier("blMailSender") JavaMailSender mailSender) {
         return new NullMessageCreator(mailSender);
     }

--- a/integration/src/test/resources/bl-applicationContext-test.xml
+++ b/integration/src/test/resources/bl-applicationContext-test.xml
@@ -114,7 +114,9 @@
         <property name="activities" ref="blCheckoutWorkflowActivities"/>
         <property name="defaultErrorHandler" ref="blDefaultErrorHandler"/>
     </bean>
-    
+
+    <bean id="blSilentErrorHandler" class="org.broadleafcommerce.core.workflow.SilentErrorHandler" />
+
     <bean id="testRollbackWorkflow" class="org.broadleafcommerce.core.workflow.SequenceProcessor">
         <property name="processContextFactory">
             <bean class="org.broadleafcommerce.common.workflow.DummyProcessContextFactory"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <ehcache3.version>3.10.8</ehcache3.version>
         <spring.version>6.2.10</spring.version>
         <spring.security.version>6.5.3</spring.security.version>
+        <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
         <spring.boot.version>3.5.5</spring.boot.version>
         <jackson.version>2.19.0</jackson.version>
         <lombok.version>1.18.38</lombok.version>
@@ -1314,6 +1315,11 @@
                         <artifactId>spring-aop</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.ldap</groupId>
+                <artifactId>spring-ldap-core</artifactId>
+                <version>${spring-ldap-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <spring.version>6.2.11</spring.version>
         <spring.security.version>6.5.3</spring.security.version>
         <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
-        <spring.boot.version>3.5.5</spring.boot.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
         <jackson.version>2.19.0</jackson.version>
         <lombok.version>1.18.38</lombok.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ehcache3.version>3.10.8</ehcache3.version>
-        <spring.version>6.0.23</spring.version>
-        <spring.security.version>6.1.9</spring.security.version>
-        <spring.boot.version>3.1.12</spring.boot.version>
+        <spring.version>6.2.10</spring.version>
+        <spring.security.version>6.5.3</spring.security.version>
+        <spring.boot.version>3.5.5</spring.boot.version>
         <jackson.version>2.19.0</jackson.version>
         <lombok.version>1.18.38</lombok.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ehcache3.version>3.10.8</ehcache3.version>
-        <spring.version>6.2.10</spring.version>
+        <spring.version>6.2.11</spring.version>
         <spring.security.version>6.5.3</spring.security.version>
         <spring-ldap-core.version>3.3.3</spring-ldap-core.version>
         <spring.boot.version>3.5.5</spring.boot.version>
@@ -87,6 +87,7 @@
                         <source>17</source>
                         <target>17</target>
                         <release>17</release>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
BroadleafCommerce/QA#5419 

Upgraded Spring libraries:
- Spring `6.0.23` -> `6.2.10`
- Spring Boot `3.1.12` -> `3.5.5`
- Spring Security `6.1.9` -> `6.5.3`

Replaced the removed method `isUseCacheControlHeader()` with `getCacheControl() != null` .
 - The method had been deprecated in `6.0.x` and was now removed in `6.2.x`