### PR TITLE
Update mvel2 dependency to 2.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,7 +1086,7 @@
             <dependency>
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
-                <version>2.4.15.Final</version>
+                <version>2.5.2.Final</version>
             </dependency>
 
             <!--Regular Expression Libraries -->


### PR DESCRIPTION
Homepage would not load due to error:

```
: Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Filter execution threw an exception] with root cause

java.lang.ClassNotFoundException: java.lang.Compiler
```

The root issue was due to `mvel2` being built when `java.lang.Compiler` still existed. When it tries to dynamically evaluate an expression, it falls back to using that class, which was completely removed from the JDK in Java 9.

