### PR TITLE
Fix for the listgrid data alignment when adding a new row to an empty listgrid

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/listGrid.js
@@ -105,6 +105,9 @@
             BLCAdmin.listGrid.paginate.initializeHeaderWidths($listGridContainer.find('table.list-grid-table'));
             $listGridContainer.find('.listgrid-body-wrapper').mCustomScrollbar('update')
 
+            if ($tbody.length) {
+                BLCAdmin.listGrid.paginate.updateGridSize($tbody);
+            }
             $listGridContainer.trigger('blc-listgrid-replaced', $listGridContainer);
         },
 


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5444

**A Brief Overview**
Fix for the listgrid data alignment when adding a new row to an empty listgrid