### PR TITLE
Remove commons-collections from the framework in favor of commons-collections4

### DIFF
--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferQualifyingCriteriaValidator.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.persistence.validation;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.FieldMetadata;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferTargetItemCriteriaValidator.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/persistence/validation/OfferTargetItemCriteriaValidator.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.persistence.validation;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.broadleafcommerce.core.offer.service.type.OfferType;
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/AdminCatalogServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.admin.server.service.extension.AdminCatalogServiceExtensionManager;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/CategoryCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/CategoryCustomPersistenceHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/CustomerPaymentCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/CustomerPaymentCustomPersistenceHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.payment.PaymentAdditionalFieldType;
 import org.broadleafcommerce.common.presentation.client.OperationType;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/IndexFieldCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/IndexFieldCustomPersistenceHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.persistence.Status;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/ProductCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/ProductCustomPersistenceHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuCustomPersistenceHandler.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Transformer;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuRestrictionFactoryImpl.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/handler/SkuRestrictionFactoryImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FieldPath;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.FieldPathBuilder;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/CategoryParentCategoryFieldPersistenceProvider.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/CategoryParentCategoryFieldPersistenceProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.persistence.module.provider;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.admin.server.service.persistence.module.provider.extension.CategoryParentCategoryFieldPersistenceProviderExtensionManager;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/ProductParentCategoryFieldPersistenceProvider.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/ProductParentCategoryFieldPersistenceProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.persistence.module.provider;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.admin.server.service.persistence.module.provider.extension.ProductParentCategoryFieldPersistenceProviderExtensionManager;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/SkuPricingPersistenceProvider.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/module/provider/SkuPricingPersistenceProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.persistence.module.provider;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/validation/TargetItemRulesValidator.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/server/service/persistence/validation/TargetItemRulesValidator.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.server.service.persistence.validation;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.service.type.OfferType;
 import org.broadleafcommerce.openadmin.dto.BasicFieldMetadata;

--- a/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminOrderController.java
+++ b/admin/broadleaf-admin-module/src/main/java/org/broadleafcommerce/admin/web/controller/entity/AdminOrderController.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.admin.web.controller.entity;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.openadmin.web.controller.entity.AdminBasicEntityController;
 import org.broadleafcommerce.openadmin.web.form.component.ListGrid;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/DynamicFieldPersistenceHandlerHelper.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/DynamicFieldPersistenceHandlerHelper.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.cms.admin.server.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.cms.field.domain.FieldDefinition;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;
 import org.broadleafcommerce.cms.structure.domain.StructuredContentType;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/PageTemplateCustomPersistenceHandler.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/PageTemplateCustomPersistenceHandler.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.cms.admin.server.handler;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.cms.field.domain.FieldDefinition;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/StructuredContentTypeCustomPersistenceHandler.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/admin/server/handler/StructuredContentTypeCustomPersistenceHandler.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.cms.admin.server.handler;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.cms.field.domain.FieldDefinition;
 import org.broadleafcommerce.cms.field.domain.FieldGroup;

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/dao/StaticAssetDaoImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/file/dao/StaticAssetDaoImpl.java
@@ -148,7 +148,7 @@ public class StaticAssetDaoImpl implements StaticAssetDao {
                 );
             }
             criteria.where(restrictions.toArray(new Predicate[restrictions.size()]));
-            if (!org.apache.commons.collections.CollectionUtils.isEmpty(sorts)) {
+            if (!org.apache.commons.collections4.CollectionUtils.isEmpty(sorts)) {
                 criteria.orderBy(sorts);
             }
 

--- a/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/PageServiceImpl.java
+++ b/admin/broadleaf-contentmanagement-module/src/main/java/org/broadleafcommerce/cms/page/service/PageServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.cms.page.service;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.cms.file.service.StaticAssetService;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/Entity.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/Entity.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.openadmin.dto;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.broadleafcommerce.common.util.BLCMapUtils;
 import org.broadleafcommerce.common.util.TypedClosure;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/dto/FilterAndSortCriteria.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.dto;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.util.BLCCollectionUtils;
 import org.broadleafcommerce.common.util.TypedPredicate;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.criteria.RestrictionType;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/DefaultFieldMetadataProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/dao/provider/metadata/DefaultFieldMetadataProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.dao.provider.metadata;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/handler/AdminUserCustomPersistenceHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/handler/AdminUserCustomPersistenceHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.security.handler;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.exception.ServiceException;
 import org.broadleafcommerce.common.persistence.Status;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/RowLevelSecurityServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/RowLevelSecurityServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.security.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.openadmin.dto.ClassMetadata;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.dto.PersistencePackage;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.openadmin.server.security.service.navigation;
 
 import org.apache.commons.beanutils.BeanComparator;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/service/navigation/AdminNavigationServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.security.service.navigation;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminExporterRemoteService.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/AdminExporterRemoteService.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.openadmin.dto.AdminExporterDTO;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/PersistenceManagerImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/PersistenceManagerImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/AdornedTargetListPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/AdornedTargetListPersistenceModule.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/BasicPersistenceModule.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/FieldManager.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/MapStructurePersistenceModule.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/CriteriaTranslatorImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/CriteriaTranslatorImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.criteria;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.exception.NoPossibleResultsException;
 import org.broadleafcommerce.openadmin.dto.ClassTree;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/FilterMapping.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/criteria/FilterMapping.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.criteria;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.openadmin.dto.SortDirection;
 
 import java.util.ArrayList;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/extension/DefaultBasicPersistenceModuleExtensionHandler.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/extension/DefaultBasicPersistenceModuleExtensionHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.extension;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/BasicFieldPersistenceProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.exception.ExceptionHelper;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/module/provider/RuleFieldPersistenceProvider.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.module.provider;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/service/persistence/validation/EntityValidatorServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.server.service.persistence.validation;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.presentation.ValidationConfiguration;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/AdminAbstractController.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.web.controller;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/controller/entity/AdminBasicEntityController.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.openadmin.web.controller.entity;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestProcessor.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/filter/BroadleafAdminRequestProcessor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.web.filter;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGrid.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.web.form.component;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.broadleafcommerce.common.presentation.client.AddMethodType;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridActionGroup.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/component/ListGridActionGroup.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.openadmin.web.form.component;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.util.TypedPredicate;
 
 import java.util.ArrayList;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityFormValidator.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/form/entity/EntityFormValidator.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.openadmin.web.form.entity;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.openadmin.dto.Entity;
 import org.broadleafcommerce.openadmin.server.service.AdminEntityService;

--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/web/service/FormBuilderServiceImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.openadmin.web.service;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -455,8 +455,9 @@
             <artifactId>commons-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-beanutils2</artifactId>
+            <version>2.0.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/common/src/main/java/org/broadleafcommerce/common/cache/HydratedSetup.java
+++ b/common/src/main/java/org/broadleafcommerce/common/cache/HydratedSetup.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.cache;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/common/src/main/java/org/broadleafcommerce/common/email/service/message/MessageCreator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/email/service/message/MessageCreator.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.email.service.message;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.broadleafcommerce.common.email.domain.EmailTarget;
 import org.broadleafcommerce.common.email.service.info.EmailInfo;

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeAnnotationAwareBeanDefinitionRegistryPostProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/MergeAnnotationAwareBeanDefinitionRegistryPostProcessor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.broadleafcommerce.common.exception.ExceptionHelper;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/AttributePreserveInsert.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/AttributePreserveInsert.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge.handlers;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/InsertChildrenOf.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/InsertChildrenOf.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge.handlers;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/InsertItems.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/InsertItems.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge.handlers;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Node;

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/NodeReplaceInsert.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/NodeReplaceInsert.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge.handlers;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.util.NodeUtil;

--- a/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/NodeValueMerge.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extensibility/context/merge/handlers/NodeValueMerge.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extensibility.context.merge.handlers;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.w3c.dom.Node;
 
 import java.util.Iterator;

--- a/common/src/main/java/org/broadleafcommerce/common/extension/ExtensionManager.java
+++ b/common/src/main/java/org/broadleafcommerce/common/extension/ExtensionManager.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.extension;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;

--- a/common/src/main/java/org/broadleafcommerce/common/filter/Filter.java
+++ b/common/src/main/java/org/broadleafcommerce/common/filter/Filter.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.filter;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/common/src/main/java/org/broadleafcommerce/common/filter/FilterDefinition.java
+++ b/common/src/main/java/org/broadleafcommerce/common/filter/FilterDefinition.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.filter;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.i18n.dao;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ResultType;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/dao/TranslationDaoImpl.java
@@ -18,7 +18,7 @@
 package org.broadleafcommerce.common.i18n.dao;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ResultType;
 import org.broadleafcommerce.common.extension.StandardCacheItem;

--- a/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/i18n/service/ThresholdCacheTranslationOverrideStrategy.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.i18n.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.cache.CacheStatType;
 import org.broadleafcommerce.common.cache.StatisticsService;
 import org.broadleafcommerce.common.extension.ItemStatus;

--- a/common/src/main/java/org/broadleafcommerce/common/page/dto/PageDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/page/dto/PageDTO.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.page.dto;
 
-import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils2.BeanUtils;
 import org.broadleafcommerce.common.structure.dto.ItemCriteriaDTO;
 
 import java.io.Serial;

--- a/common/src/main/java/org/broadleafcommerce/common/persistence/SequenceGeneratorCorruptionDetection.java
+++ b/common/src/main/java/org/broadleafcommerce/common/persistence/SequenceGeneratorCorruptionDetection.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.persistence;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/common/src/main/java/org/broadleafcommerce/common/site/dao/SiteDaoImpl.java
+++ b/common/src/main/java/org/broadleafcommerce/common/site/dao/SiteDaoImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.site.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
 import org.broadleafcommerce.common.site.domain.Catalog;
 import org.broadleafcommerce.common.site.domain.CatalogImpl;

--- a/common/src/main/java/org/broadleafcommerce/common/structure/dto/StructuredContentDTO.java
+++ b/common/src/main/java/org/broadleafcommerce/common/structure/dto/StructuredContentDTO.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.structure.dto;
 
-import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.beanutils2.BeanUtils;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/common/src/main/java/org/broadleafcommerce/common/util/BLCCollectionUtils.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/BLCCollectionUtils.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.common.util;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Transformer;
 import org.springframework.util.ClassUtils;
 
 import java.lang.reflect.Array;

--- a/common/src/main/java/org/broadleafcommerce/common/util/BroadleafMergeResourceBundleMessageSource.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/BroadleafMergeResourceBundleMessageSource.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.util;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;

--- a/common/src/main/java/org/broadleafcommerce/common/util/PomEvaluator.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/PomEvaluator.java
@@ -90,7 +90,7 @@ public class PomEvaluator {
 
         // Apache
         knownLibraries.put("commons-validator", APACHE_FOUNDATION);
-        knownLibraries.put("commons-collections", APACHE_FOUNDATION);
+        knownLibraries.put("commons-collections4", APACHE_FOUNDATION);
         knownLibraries.put("commons-beanutils", APACHE_FOUNDATION);
         knownLibraries.put("commons-cli", APACHE_FOUNDATION);
         knownLibraries.put("commons-fileupload", APACHE_FOUNDATION);

--- a/common/src/main/java/org/broadleafcommerce/common/util/TypedPredicate.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/TypedPredicate.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.util;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
 
 import java.lang.reflect.ParameterizedType;
 

--- a/common/src/main/java/org/broadleafcommerce/common/util/TypedTransformer.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/TypedTransformer.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.util;
 
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.Transformer;
 
 /**
  * A class that provides for a typed transformer.

--- a/common/src/main/java/org/broadleafcommerce/common/util/dao/TQRestriction.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/dao/TQRestriction.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.util.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/common/src/main/java/org/broadleafcommerce/common/util/dao/TypedQueryBuilder.java
+++ b/common/src/main/java/org/broadleafcommerce/common/util/dao/TypedQueryBuilder.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.util.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/common/src/main/java/org/broadleafcommerce/common/web/expression/BRCVariableExpression.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/expression/BRCVariableExpression.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.web.expression;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.broadleafcommerce.common.crossapp.service.CrossAppAuthService;
 import org.broadleafcommerce.common.sandbox.domain.SandBox;
 import org.broadleafcommerce.common.site.domain.Catalog;

--- a/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/TransparentRedirectCreditCardFormProcessor.java
+++ b/common/src/main/java/org/broadleafcommerce/common/web/payment/processor/TransparentRedirectCreditCardFormProcessor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.common.web.payment.processor;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.broadleafcommerce.common.payment.dto.PaymentRequestDTO;
 import org.broadleafcommerce.common.vendor.service.exception.PaymentException;
 import org.broadleafcommerce.presentation.condition.ConditionalOnTemplating;

--- a/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
@@ -18,7 +18,7 @@
 
 package org.broadleafcommerce.common.sitemap.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.config.domain.ModuleConfiguration;
 import org.broadleafcommerce.common.config.service.ModuleConfigurationService;
 import org.broadleafcommerce.common.config.service.type.ModuleConfigurationType;

--- a/common/src/test/java/org/broadleafcommerce/test/common/rule/MvelTestUtils.java
+++ b/common/src/test/java/org/broadleafcommerce/test/common/rule/MvelTestUtils.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.test.common.rule;
 
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.rule.SelectizeCollectionUtils;

--- a/core/broadleaf-framework-web/pom.xml
+++ b/core/broadleaf-framework-web/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>broadleaf-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/controller/cart/BroadleafCartController.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.controller.cart;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.util.BLCMessageUtils;
 import org.broadleafcommerce.core.catalog.domain.Product;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/expression/PromotionMessageVariableExpression.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/expression/PromotionMessageVariableExpression.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.expression;
 
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.core.catalog.domain.Product;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleAnalytics4Processor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleAnalytics4Processor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.processor;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleUniversalAnalyticsProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/GoogleUniversalAnalyticsProcessor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.processor;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/processor/UncacheableDataProcessor.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.processor;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.BroadleafEnumerationType;
 import org.broadleafcommerce.common.admin.domain.TypedEntity;

--- a/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/search/SearchFilterUtil.java
+++ b/core/broadleaf-framework-web/src/main/java/org/broadleafcommerce/core/web/search/SearchFilterUtil.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.web.search;
 
-import org.apache.commons.beanutils.BeanToPropertyValueTransformer;
+import org.apache.commons.beanutils2.BeanToPropertyValueTransformer;
 import org.apache.commons.lang3.ArrayUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.core.catalog.domain.Product;
@@ -55,7 +55,7 @@ public class SearchFilterUtil {
             if (parameters.containsKey(parameter)) { // we're doing a multi-select
                 for (Iterator<Product> itr = products.iterator(); itr.hasNext(); ) {
                     Product product = itr.next();
-                    if (!ArrayUtils.contains(parameters.get(parameter), reader.transform(product).toString())) {
+                    if (!ArrayUtils.contains(parameters.get(parameter), reader.apply(product).toString())) {
                         itr.remove();
                     }
                 }
@@ -66,7 +66,7 @@ public class SearchFilterUtil {
                 Money maximumMoney = new Money(maxMoney.replaceAll("[^0-9.]", ""));
                 for (Iterator<Product> itr = products.iterator(); itr.hasNext(); ) {
                     Product product = itr.next();
-                    Money objectValue = (Money) reader.transform(product);
+                    Money objectValue = (Money) reader.apply(product);
                     if (objectValue.lessThan(minimumMoney) || objectValue.greaterThan(maximumMoney)) {
                         itr.remove();
                     }

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.Transformer;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/CategoryImpl.java
@@ -18,10 +18,10 @@
 package org.broadleafcommerce.core.catalog.domain;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/ProductImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/domain/SkuImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.core.catalog.domain;
 
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/CatalogServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.catalog.service;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;
 import org.broadleafcommerce.common.extension.ExtensionResultStatusType;
 import org.broadleafcommerce.common.web.BroadleafRequestContext;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/SkuSiteMapGenerator.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/catalog/service/SkuSiteMapGenerator.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.catalog.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.broadleafcommerce.common.file.service.BroadleafFileUtils;
 import org.broadleafcommerce.common.sitemap.domain.SiteMapGeneratorConfiguration;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ConfirmPaymentsRollbackHandler.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/checkout/service/workflow/ConfirmPaymentsRollbackHandler.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.checkout.service.workflow;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.payment.PaymentTransactionType;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/domain/OfferImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.domain;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/OfferServiceImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.core.offer.service;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Transformer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.persistence.EntityDuplicateModifier;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOfferUtilityImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.discount.domain;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.discount.domain;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/discount/domain/PromotableOrderItemPriceDetailImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.discount.domain;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.money.Money;
 import org.broadleafcommerce.core.offer.domain.Offer;
 import org.broadleafcommerce.core.offer.domain.OfferItemCriteria;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.processor;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 import org.apache.commons.collections4.comparators.NullComparator;
 import org.apache.commons.collections4.comparators.ReverseComparator;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/FulfillmentGroupOfferProcessorImpl.java
@@ -18,8 +18,8 @@
 package org.broadleafcommerce.core.offer.service.processor;
 
 import org.apache.commons.beanutils.BeanComparator;
-import org.apache.commons.collections.comparators.NullComparator;
-import org.apache.commons.collections.comparators.ReverseComparator;
+import org.apache.commons.collections4.comparators.NullComparator;
+import org.apache.commons.collections4.comparators.ReverseComparator;
 import org.broadleafcommerce.common.currency.domain.BroadleafCurrency;
 import org.broadleafcommerce.common.currency.util.BroadleafCurrencyUtils;
 import org.broadleafcommerce.common.money.BankersRounding;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/ItemOfferProcessorImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/offer/service/processor/ItemOfferProcessorImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.offer.service.processor;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.money.Money;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderDaoImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderItemDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/dao/OrderItemDaoImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
 import org.broadleafcommerce.core.order.domain.GiftWrapOrderItem;
 import org.broadleafcommerce.core.order.domain.Order;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/domain/OrderItemImpl.java
@@ -37,7 +37,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.admin.domain.AdminMainEntity;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderItemServiceImpl.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.core.order.service;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.broadleafcommerce.core.catalog.domain.Category;
 import org.broadleafcommerce.core.catalog.domain.Product;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/OrderServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.extension.ExtensionResultHolder;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/call/AddToCartItems.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/call/AddToCartItems.java
@@ -17,17 +17,16 @@
  */
 package org.broadleafcommerce.core.order.service.call;
 
-import org.apache.commons.collections.FactoryUtils;
-import org.apache.commons.collections.list.LazyList;
+import org.apache.commons.collections4.FactoryUtils;
+import org.apache.commons.collections4.list.LazyList;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class AddToCartItems {
 
-    @SuppressWarnings("unchecked")
     //TOOD: this should probably be refactored to be called "rows" like in other model objects
-    private List<OrderItemRequestDTO> addToCartItems = LazyList.decorate(
+    private List<OrderItemRequestDTO> addToCartItems = LazyList.lazyList(
             new ArrayList<OrderItemRequestDTO>(),
             FactoryUtils.instantiateFactory(OrderItemRequestDTO.class)
     );

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/AddWorkflowPriceOrderIfNecessaryActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/AddWorkflowPriceOrderIfNecessaryActivity.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.service.workflow;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.core.order.dao.FulfillmentGroupItemDao;
 import org.broadleafcommerce.core.order.domain.BundleOrderItem;
 import org.broadleafcommerce.core.order.domain.DiscreteOrderItem;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/remove/RemoveOrderItemActivity.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/remove/RemoveOrderItemActivity.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.service.workflow.remove;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.core.order.domain.OrderItem;
 import org.broadleafcommerce.core.order.service.OrderItemService;
 import org.broadleafcommerce.core.order.service.OrderService;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/order/service/workflow/service/OrderItemRequestValidationServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.order.service.workflow.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/TaxServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/pricing/service/TaxServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.pricing.service;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.config.domain.ModuleConfiguration;
 import org.broadleafcommerce.common.config.service.ModuleConfigurationService;
 import org.broadleafcommerce.common.config.service.type.ModuleConfigurationType;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/dto/service/PromotionMessageDTOServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/promotionMessage/dto/service/PromotionMessageDTOServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.promotionMessage.dto.service;
 
-import org.apache.commons.collections.map.MultiValueMap;
+import org.apache.commons.collections4.map.MultiValueMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.presentation.RuleIdentifier;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/rating/service/RatingServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.rating.service;
 
-import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.beanutils2.BeanComparator;
 import org.broadleafcommerce.common.time.SystemTime;
 import org.broadleafcommerce.core.rating.dao.RatingSummaryDao;
 import org.broadleafcommerce.core.rating.dao.ReviewDetailDao;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/dao/IndexFieldDaoImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/dao/IndexFieldDaoImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.search.dao;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.broadleafcommerce.common.persistence.EntityConfiguration;
 import org.broadleafcommerce.core.search.domain.Field;
 import org.broadleafcommerce.core.search.domain.FieldEntity;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/MvelToSearchCriteriaConversionServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/MvelToSearchCriteriaConversionServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.search.service.solr;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -18,8 +18,8 @@
 package org.broadleafcommerce.core.search.service.solr;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrHelperServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.search.service.solr;
 
-import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.beanutils2.PropertyUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/SolrSearchServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.search.service.solr;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/search/service/solr/index/SolrIndexServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.search.service.solr.index;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/service/ResourcePurgeServiceImpl.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/util/service/ResourcePurgeServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.util.service;
 
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.exception.ServiceException;

--- a/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/workflow/BaseProcessor.java
+++ b/core/broadleaf-framework/src/main/java/org/broadleafcommerce/core/workflow/BaseProcessor.java
@@ -17,8 +17,8 @@
  */
 package org.broadleafcommerce.core.workflow;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Transformer;
 import org.broadleafcommerce.common.logging.LifeCycleEvent;
 import org.broadleafcommerce.common.logging.SupportLogManager;
 import org.broadleafcommerce.common.logging.SupportLogger;

--- a/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/offer/service/processor/OrderOfferProcessorSpec.groovy
+++ b/core/broadleaf-framework/src/test/groovy/org/broadleafcommerce/core/spec/offer/service/processor/OrderOfferProcessorSpec.groovy
@@ -17,7 +17,7 @@
  */
 package org.broadleafcommerce.core.spec.offer.service.processor
 
-import org.apache.commons.collections.map.MultiValueMap
+import org.apache.commons.collections4.map.MultiValueMap
 import org.broadleafcommerce.core.catalog.domain.*
 import org.broadleafcommerce.core.offer.service.processor.OrderOfferProcessor
 import org.broadleafcommerce.core.offer.service.processor.OrderOfferProcessorImpl

--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,10 @@
                         <groupId>commons-logging</groupId>
                     </exclusion>
                     <exclusion>
+                        <artifactId>commons-collections</artifactId>
+                        <groupId>commons-collections</groupId>
+                    </exclusion>
+                    <exclusion>
                         <artifactId>xml-apis</artifactId>
                         <groupId>xml-apis</groupId>
                     </exclusion>
@@ -678,6 +682,10 @@
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-collections</artifactId>
+                        <groupId>commons-collections</groupId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -661,11 +661,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>3.2.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>4.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -662,6 +662,10 @@
                         <artifactId>xml-apis</artifactId>
                         <groupId>xml-apis</groupId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>commons-beanutils</groupId>
+                        <artifactId>commons-beanutils</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
Commons-collections has security vulnerabilities which will not be fixed. So updating all imports to use `collections4` however there is some work around required for Commons BeanUtils library. The class `BeanToPropertyValueTransformer`  is hard-coded to depend on commons-collections. 