### PR TITLE
Strip image sources from content outside the target tab to prevent broken requests

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/js/admin/components/entityForm.js
@@ -432,6 +432,12 @@ $(document).ready(function() {
      		    // using tabKey instead of href. Href is not dependable because of hidden tabs
                 var tabKey = $tab.find('span').data('tabkey');
 
+                $(data).find('img').each(function () {
+                    if (!$(this).closest('#' + tabKey + 'Contents').length) {
+                        $(this).removeAttr('src');
+                    }
+                });
+
                 $('#' + tabKey + 'Contents .listgrid-container', $(data)).find('.listgrid-header-wrapper table').each(function() {
      				var tableId = $(this).attr('id').replace('-header', '');
                     var $tableWrapper = data.find('table#' + tableId).parents('.listgrid-header-wrapper');

--- a/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
+++ b/admin/broadleaf-open-admin-platform/src/main/resources/open_admin_style/templates/components/listGrid.html
@@ -153,7 +153,7 @@
                                 <a class="external-link" th:href="@{${headerField.foreignKeySectionPath + '/' + field.value}}" th:utext="${field.displayValue}"></a>
                             </th:block>
 
-                            <span th:if="${field.fieldType == 'IMAGE'}">
+                            <span th:if="${field.fieldType == 'IMAGE' and field.value != null and !#strings.isEmpty(field.value)}">
                                 <th:block th:if="${field.gridFieldComponentRenderer == null or #strings.equals(field.gridFieldComponentRenderer, 'UNKNOWN')}">
                                     <img class="thumbnail" th:style="${'width: 100%;'}"
                                          blc:src="@{${field.value + record.getField('thumbnailKey').value}}"


### PR DESCRIPTION
https://github.com/BroadleafCommerce/QA/issues/5463

**A Brief Overview**
Strip image sources from content outside the target tab to prevent broken requests