### PR TITLE
Fix #3124: block protocol-relative open-redirect bypass in LocalRedirectStrategy

### DIFF
--- a/common/src/main/java/org/broadleafcommerce/common/security/LocalRedirectStrategy.java
+++ b/common/src/main/java/org/broadleafcommerce/common/security/LocalRedirectStrategy.java
@@ -50,6 +50,16 @@ public class LocalRedirectStrategy implements RedirectStrategy {
      */
     @Override
     public void sendRedirect(HttpServletRequest request, HttpServletResponse response, String url) throws IOException {
+        if (isProtocolRelativeUrl(url)) {
+            // A protocol-relative reference (e.g. "//evil.com" or "/\evil.com") begins with a slash,
+            // so the legacy startsWith("/") check treated it as a safe local path. Browsers, however,
+            // resolve it as an absolute reference to an external host, which allows the application's
+            // redirect protection to be bypassed (open redirect). There is no legitimate local redirect
+            // of this form, so reject it outright.
+            String errorMessage = "Invalid redirect url specified.  Protocol-relative urls are not allowed";
+            LOG.warn(errorMessage + ":  " + url);
+            throw new MalformedURLException(errorMessage + ":  " + url);
+        }
         if (!url.startsWith("/")) {
             if (StringUtils.equals(request.getParameter("successUrl"), url)
                     || StringUtils.equals(request.getParameter("failureUrl"), url)) {
@@ -92,6 +102,27 @@ public class LocalRedirectStrategy implements RedirectStrategy {
         }
 
         return url;
+    }
+
+    /**
+     * Determine whether the supplied url is a protocol-relative (a.k.a. network-path) reference.
+     *
+     * <p>Such urls begin with two slashes ({@code //host}) or use a backslash variant
+     * ({@code /\host}, {@code \/host}, {@code \\host}) that browsers normalize to {@code //host}.
+     * They start with a slash and therefore pass a naive {@code startsWith("/")} "is local" check,
+     * but the browser resolves them as absolute references to an external host. They must never be
+     * treated as safe local redirects.</p>
+     *
+     * @param url the candidate redirect url
+     * @return true if the url is a protocol-relative reference
+     */
+    protected boolean isProtocolRelativeUrl(String url) {
+        if (url == null || url.length() < 2) {
+            return false;
+        }
+        char first = url.charAt(0);
+        char second = url.charAt(1);
+        return (first == '/' || first == '\\') && (second == '/' || second == '\\');
     }
 
     /**

--- a/common/src/test/java/org/broadleafcommerce/common/security/LocalRedirectStrategyTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/security/LocalRedirectStrategyTest.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * BroadleafCommerce Common Libraries
+ * %%
+ * Copyright (C) 2009 - 2026 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ *
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.common.security;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.net.MalformedURLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression tests for {@link LocalRedirectStrategy}.
+ *
+ * <p>Guards against the open-redirect bypass reported in issue #3124: a protocol-relative target
+ * such as {@code //evil.com} begins with a slash and so slipped past the legacy
+ * {@code startsWith("/")} "is local" check, yet browsers resolve it to an external host.</p>
+ */
+public class LocalRedirectStrategyTest {
+
+    private static final String SERVER_NAME = "localhost";
+    private static final int SERVER_PORT = 80;
+
+    private MockHttpServletRequest request(String paramName, String url) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServerName(SERVER_NAME);
+        request.setServerPort(SERVER_PORT);
+        request.setContextPath("");
+        if (paramName != null) {
+            request.setParameter(paramName, url);
+        }
+        return request;
+    }
+
+    private MalformedURLException expectBlocked(String url) {
+        LocalRedirectStrategy strategy = new LocalRedirectStrategy();
+        MockHttpServletRequest request = request("successUrl", url);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        try {
+            strategy.sendRedirect(request, response, url);
+            fail("Expected redirect to be blocked but it was allowed: " + url
+                    + " -> " + response.getRedirectedUrl());
+            return null; // unreachable
+        } catch (MalformedURLException ex) {
+            return ex;
+        } catch (Exception ex) {
+            fail("Expected MalformedURLException for " + url + " but got " + ex);
+            return null; // unreachable
+        }
+    }
+
+    // --- The reported bypass and its variants must be blocked ---------------------------------
+
+    @Test
+    public void protocolRelativeUrlIsBlocked() {
+        expectBlocked("//evil.com");
+    }
+
+    @Test
+    public void backslashProtocolRelativeVariantsAreBlocked() {
+        expectBlocked("/\\evil.com");
+        expectBlocked("\\/evil.com");
+        expectBlocked("\\\\evil.com");
+    }
+
+    @Test
+    public void absoluteExternalUrlIsBlocked() {
+        // Pre-existing protection: a fully-qualified external url must still be rejected.
+        expectBlocked("http://evil.com");
+    }
+
+    // --- Legitimate local redirects must still work -------------------------------------------
+
+    @Test
+    public void localRelativePathIsAllowed() throws Exception {
+        LocalRedirectStrategy strategy = new LocalRedirectStrategy();
+        MockHttpServletRequest request = request(null, null);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        strategy.sendRedirect(request, response, "/admin/login");
+
+        assertEquals("/admin/login", response.getRedirectedUrl());
+    }
+
+    @Test
+    public void sameHostAbsoluteUrlIsAllowed() throws Exception {
+        LocalRedirectStrategy strategy = new LocalRedirectStrategy();
+        String target = "http://" + SERVER_NAME + "/admin/home";
+        MockHttpServletRequest request = request("successUrl", target);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        strategy.sendRedirect(request, response, target);
+
+        assertEquals(target, response.getRedirectedUrl());
+    }
+
+    // --- Helper classification -----------------------------------------------------------------
+
+    @Test
+    public void isProtocolRelativeUrlClassifiesCorrectly() {
+        LocalRedirectStrategy strategy = new LocalRedirectStrategy();
+        assertTrue(strategy.isProtocolRelativeUrl("//evil.com"));
+        assertTrue(strategy.isProtocolRelativeUrl("/\\evil.com"));
+        assertTrue(strategy.isProtocolRelativeUrl("\\/evil.com"));
+        assertTrue(strategy.isProtocolRelativeUrl("\\\\evil.com"));
+
+        assertFalse(strategy.isProtocolRelativeUrl("/admin/login"));
+        assertFalse(strategy.isProtocolRelativeUrl("/"));
+        assertFalse(strategy.isProtocolRelativeUrl("http://localhost/x"));
+        assertFalse(strategy.isProtocolRelativeUrl(""));
+        assertFalse(strategy.isProtocolRelativeUrl(null));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3124 — an open-redirect bypass in `LocalRedirectStrategy`.

`sendRedirect` treats any url beginning with `/` as a safe, application-local path and skips `validateRedirectUrl`. A **protocol-relative** reference such as `//evil.com` begins with a slash, so it slips past that check, yet browsers resolve it as an absolute reference to an external host — bypassing the redirect protection (the exact scenario reported in #3124).

## Fix

Reject protocol-relative / network-path references **before** the "is local" check, since there is no legitimate local redirect of this form. The guard also covers the backslash variants browsers normalize to `//` (`/\host`, `\/host`, `\\host`).

```java
if (isProtocolRelativeUrl(url)) {
    throw new MalformedURLException("Invalid redirect url specified.  Protocol-relative urls are not allowed:  " + url);
}
```

Behavior preserved:
- Fully-qualified absolute urls still flow through `validateRedirectUrl` (host / port / context-path checks) — e.g. `http://evil.com` remains blocked.
- Genuine relative paths like `/admin/login` and same-host absolute urls are unaffected.

## Tests

Adds `LocalRedirectStrategyTest` (uses `MockHttpServletRequest`/`MockHttpServletResponse`) covering:
- the reported `//evil.com` bypass and the `/\`, `\/`, `\\` variants → blocked;
- pre-existing external-absolute-url block (`http://evil.com`) → still blocked;
- legitimate `/admin/login` relative and same-host absolute redirects → allowed;
- `isProtocolRelativeUrl` classification.

All 6 tests pass.

## Note

I'm aware of the existing open PR #3126 addressing the same issue. This change is independent and intentionally minimal/surgical (single guard + helper), and additionally covers the backslash-obfuscated variants. Happy to defer or align with whichever approach the maintainers prefer.
