### PR TITLE
Fix redundant join in admin user count query

### DIFF
--- a/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
+++ b/admin/broadleaf-open-admin-platform/src/main/java/org/broadleafcommerce/openadmin/server/security/domain/AdminUserImpl.java
@@ -169,7 +169,7 @@ public class AdminUserImpl implements AdminUser, AdminMainEntity, AdminUserAdmin
     protected Set<AdminPermission> allPermissions = new HashSet<>();
     @Transient
     protected String unencodedPassword;
-    @ManyToOne(targetEntity = SandBoxImpl.class, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+    @ManyToOne(targetEntity = SandBoxImpl.class, cascade = {CascadeType.MERGE, CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(name = "BLC_ADMIN_USER_SANDBOX", joinColumns = @JoinColumn(name = "ADMIN_USER_ID",
             referencedColumnName = "ADMIN_USER_ID"),
             inverseJoinColumns = @JoinColumn(name = "SANDBOX_ID",


### PR DESCRIPTION
**Description**
Updated the `sandbox` association in `AdminUserImpl` to use lazy fetching.

Previously, the `@ManyToOne` association used the default eager fetch strategy, which caused Hibernate to include an unnecessary join with `BLC_ADMIN_USER_SANDBOX` when generating count queries for admin users.

Setting `fetch = FetchType.LAZY` prevents the association from being fetched when it is not needed, removing the redundant join.

#### Fixes #2323 

## Verification

Verified the change using the existing integration test setup with SQL logging temporarily enabled.

The generated admin user count query no longer joins `BLC_ADMIN_USER_SANDBOX`:

```sql
select
    count(adminuseri0_.ADMIN_USER_ID) as col_0_0_
from
    BLC_ADMIN_USER adminuseri0_
where
    1=1
```

<img width="1555" height="662" alt="image" src="https://github.com/user-attachments/assets/2ac87a96-b904-4ff6-b692-e4b520828b4b" />

<img width="1576" height="940" alt="image" src="https://github.com/user-attachments/assets/09cdbf22-e8e6-497b-aa57-1fa8cc6993f2" />

@wtune 
@StanislavFedorov 